### PR TITLE
docs: increase threshold for involved PR process

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/implementation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/implementation.md
@@ -1,7 +1,7 @@
 ## Author checklist
 
 > [!NOTE]
-> An issue and agreed implementation plan are necessary unless either fewer than 10 lines have been changed or only documentation has been changed.
+> An issue and agreed implementation plan are necessary unless either fewer than 25 lines have been changed or only documentation has been changed.
 
 I confirm that these changes:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ The process is meant to support productive develpoment, not be a hindrance to it
 - Reviewers may request that complex changes are split into smaller PRs, even if the original PR's diff is less than 200
 lines.
 - Certain changes can go straight to implementation PR, without needing an issue and implementation plan:
-  - Code changes less than 10 lines.
+  - Code changes less than 25 lines.
   - Documentation-only changes.
 - Reviewers will ask authors to rework or resubmit PRs that don't meet the above guidelines.
 


### PR DESCRIPTION
I think 10 lines is too low a threshold for the more bureaucratic process. I propose 25 lines instead. 