### PR TITLE
perf: improved parallel chunksize

### DIFF
--- a/src/Informedica.GenOrder.Lib/Api.fs
+++ b/src/Informedica.GenOrder.Lib/Api.fs
@@ -413,10 +413,12 @@ module OrderContext =
                     |> Array.map (fun ord -> ord, pr)
                 )
 
-            // Evaluate all orders in parallel using Array.Parallel for better performance
-            ords
-            |> Array.Parallel.map (fun (ord, pr) -> evaluateOrder logger pr ord)
-            |> Array.filter Result.isOk
+            if ords |> Array.isEmpty then [||]
+            else
+                // Evaluate all orders in parallel using Array.Parallel for better performance
+                ords
+                |> Array.Parallel.map (fun (ord, pr) -> evaluateOrder logger pr ord)
+                |> Array.filter Result.isOk
 
 
         let processEvaluationResults prs =

--- a/src/Informedica.GenSolver.Lib/Solver.fs
+++ b/src/Informedica.GenSolver.Lib/Solver.fs
@@ -161,10 +161,8 @@ module Solver =
                         | que, unsolv -> que, unsolv |> List.append acc
 
                     let rpl, rst =
-                        // TODO: need to calculate the optimal chunksize 
-                        // depending on the hardware
                         let chunkSize =
-                            let c = (que |> List.length) / 12
+                            let c = (que |> List.length) / Parallel.totalWorders
                             if c > 0 then c else 1
 
                         que

--- a/src/Informedica.GenSolver.Lib/Utils.fs
+++ b/src/Informedica.GenSolver.Lib/Utils.fs
@@ -4,6 +4,17 @@ namespace Informedica.GenSolver.Lib
 [<AutoOpen>]
 module Utils =
 
+    open System
+    open MathNet.Numerics
+
+
+    module Parallel =
+
+
+        let maxDepth = int (Math.Log(float Environment.ProcessorCount))
+
+
+        let totalWorders = int (2.0 ** (float maxDepth))
 
 
     module Constants =


### PR DESCRIPTION
This pull request introduces improvements to parallel processing across the codebase, focusing on optimizing chunk sizes for parallel tasks based on hardware capabilities and ensuring robust handling of empty order arrays. The most important changes are grouped below:

**Parallelism and Performance Optimization**

* Added the `Parallel` module in `Utils.fs`, which calculates `maxDepth` based on the number of processor cores and defines `totalWorders` as the number of parallel workers to use. This enables dynamic scaling of parallel tasks according to hardware resources.
* Updated the chunk size calculation in the `Solver` module to use `Parallel.totalWorders` instead of a fixed value, allowing chunk sizes to adapt to the available hardware for improved parallel efficiency.

**Robustness Improvements**

* In `OrderContext`, added a guard to return an empty array immediately if there are no orders, preventing unnecessary parallel evaluation and potential errors when input is empty.