### PR TITLE
fix: updated DoseRule parallel processing using a grouped prior to ch…

### DIFF
--- a/src/Informedica.GenForm.Lib/DoseRule.fs
+++ b/src/Informedica.GenForm.Lib/DoseRule.fs
@@ -960,18 +960,33 @@ module DoseRule =
                 // process ok results
                 let rules =
                     fun () ->
+                        (*
+                        rules
+                        |> Array.map (fun (d, r) ->
+                            r |> Result.get, d
+                        )
+                        |> Array.groupBy fst
+                        |> Array.map (fun (dr, rs) ->
+                            dr |> addDoseLimits (rs |> Array.map snd)
+                        )
+                        *)
+
                         let chunkBySize = Parallel.totalWorders
 
-                        rules
+                        let grouped =
+                            rules
+                            |> Array.map (fun (d, r) ->
+                                r |> Result.get, d
+                            )
+                            |> Array.groupBy fst
+
+
+                        grouped
                         |> Array.chunkBySize chunkBySize
                         |> Array.map (fun rs ->
                             async {
                                 return
                                     rs
-                                    |> Array.map (fun (d, r) ->
-                                        r |> Result.get, d
-                                    )
-                                    |> Array.groupBy fst
                                     |> Array.map (fun (dr, rs) ->
                                         dr |> addDoseLimits (rs |> Array.map snd)
                                     )


### PR DESCRIPTION
This pull request refactors the way dose rules are processed in the `DoseRule` module, specifically improving the grouping and chunking fixing inappropriate dose rule splits when multiple components/substances. The main change is the introduction of a pre-grouping step before chunking, which streamlines the subsequent processing.