### PR TITLE
chore: explained order context payload and renamed filter medications…

### DIFF
--- a/docs/domain/genorder-operational-rules-to-orders.md
+++ b/docs/domain/genorder-operational-rules-to-orders.md
@@ -128,6 +128,30 @@ GenORDER uses a generic, domain-independent Order model that can represent medic
 
 Each Orderable consists of one or more Components. Each Component consists of one or more Items (Appendix C.2. Order Model Table).
 
+#### 6.1.1 Schedule representation across layers {#6.1.1-schedule-representation-across-layers}
+
+In **GenORDER** (server/domain), `Schedule` is modeled as a discriminated union (DU) because it is a closed set of mutually exclusive cases:
+
+- `Once`
+- `OnceTimed of Time`
+- `Continuous of Time`
+- `Discontinuous of Frequency`
+- `Timed of Frequency * Time`
+
+Across the **client/server boundary**, the client is transpiled to JavaScript (Fable), and the shared transport types are designed to be simple DTOs.
+For that reason, `GenPRES.Shared` represents `Schedule` as a record with boolean flags (`IsOnce`, `IsOnceTimed`, `IsContinuous`, `IsDiscontinuous`, `IsTimed`) plus the payload fields (`Frequency`, `Time`).
+
+This is a deliberate cross-language transport strategy:
+
+- Exactly one of the `Is*` flags should be `true` for a valid schedule.
+- The boolean flags represent the DU case; `Frequency` and/or `Time` carry the case payload when applicable.
+- `Once` has no payload.
+- `OnceTimed` and `Continuous` use `Time`.
+- `Discontinuous` uses `Frequency`.
+- `Timed` uses both `Frequency` and `Time`.
+
+Conceptually, both representations describe the same domain concept; the DTO exists to support safe and predictable serialization between .NET and JavaScript.
+
 ## 7. Quantitative Dose Semantics {#7.-quantitative-dose-semantics}
 
 GenORDER distinguishes the following quantitative dose concepts:

--- a/src/Informedica.GenPRES.Client/Views/Prescribe.fs
+++ b/src/Informedica.GenPRES.Client/Views/Prescribe.fs
@@ -65,7 +65,7 @@ module Prescribe =
                     { pr with
                         Filter =
                             { pr.Filter with
-                                Medications = [||]
+                                Generics = [||]
                                 Generic = None
                                 DoseTypes = [||]
                                 DoseType = None
@@ -476,7 +476,7 @@ module Prescribe =
                     <Stack direction={stackDirection} spacing={3} >
                         {
                             match props.orderContext with
-                            | Resolved pr -> false, pr.Filter.Generic, pr.Filter.Medications
+                            | Resolved pr -> false, pr.Filter.Generic, pr.Filter.Generics
                             | _ -> true, None, [||]
                             |> fun (isLoading, sel, items) ->
                                 let lbl = Terms.``Prescribe Medications`` |> getTerm "Medicatie"

--- a/src/Informedica.GenPRES.Server/ServerApi.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.fs
@@ -481,7 +481,7 @@ module Mappers =
                 Filter =
                     { ctx.Filter with
                         Indications = newCtx.Filter.Indications
-                        Medications = newCtx.Filter.Generics
+                        Generics = newCtx.Filter.Generics
                         Routes = newCtx.Filter.Routes
                         Forms = newCtx.Filter.Forms
                         DoseTypes = newCtx.Filter.DoseTypes |> Array.map mapFromOrderDoseTypeToSharedDoseType

--- a/src/Informedica.GenPRES.Shared/Models.fs
+++ b/src/Informedica.GenPRES.Shared/Models.fs
@@ -1586,7 +1586,7 @@ module Models =
         let filter =
             {
                 Indications = [||]
-                Medications = [||]
+                Generics = [||]
                 Routes = [||]
                 Forms = [||]
                 DoseTypes = [||]

--- a/src/Informedica.GenPRES.Shared/Types.fs
+++ b/src/Informedica.GenPRES.Shared/Types.fs
@@ -387,7 +387,7 @@ module Types =
     type Filter =
         {
             Indications: string []
-            Medications: string []
+            Generics: string []
             Routes: string []
             Forms: string []
             DoseTypes: DoseType []


### PR DESCRIPTION
This pull request primarily updates documentation to clarify discrepancies between the conceptual domain model and the implemented API payloads, and renames the `Medications` field to `Generics` throughout the codebase for consistency. The documentation now better reflects the actual API structures and cross-layer representations, while the code changes align naming conventions across client, server, and shared models.

**Documentation improvements and clarification:**

* Added a new section in `core-domain.md` explaining the difference between the conceptual `Order Context` and its concrete API/DTO shape, including details on the structure and transport fields.
* Expanded the discrepancies analysis to clearly document previously undocumented fields (`Form` in component/product models) and to describe the cross-layer schedule representation, including a new section on how `Schedule` is represented differently in the domain (discriminated union) and in transport DTOs (record with flags). [[1]](diffhunk://#diff-6392823aa65e9a686e1c8ead92c940cc95f7021796d8ae4ef7d5ff9211412e86L30-R64) [[2]](diffhunk://#diff-b173581bf59c51ffeab6e9158cfa9565ca05b9a59f5f6f2e1336353da0e086d9R131-R154)
* Updated recommendations and critical discrepancy tracking in `discrepancies-analysis.md` to reflect current state and to recommend documentation alignment rather than code changes. [[1]](diffhunk://#diff-6392823aa65e9a686e1c8ead92c940cc95f7021796d8ae4ef7d5ff9211412e86L171-R154) [[2]](diffhunk://#diff-6392823aa65e9a686e1c8ead92c940cc95f7021796d8ae4ef7d5ff9211412e86L191-L192) [[3]](diffhunk://#diff-6392823aa65e9a686e1c8ead92c940cc95f7021796d8ae4ef7d5ff9211412e86L203-R183)

**Codebase naming consistency:**

* Renamed the `Medications` field to `Generics` in the `Filter` type and all related code and mapping logic across shared types, server API, client views, and shared models for consistency and clarity. [[1]](diffhunk://#diff-8fdd799ab0791e295561f41dacc6bae28e5c74fbf00d2ea3b6659b8b46d70bf5L390-R390) [[2]](diffhunk://#diff-4054b27a7cad789febda8d2a7c57ce4d1496c3e174d62d667a78fcddc7de298eL1589-R1589) [[3]](diffhunk://#diff-276271c0c8ead222a200f72c2f2cda6cdd7bec13c3a794a5841adddd6bc755d7L484-R484) [[4]](diffhunk://#diff-33e8e62dbc22e2f0bee8a46facb93db3a8a519012c535792ee2888b63f4d448cL68-R68) [[5]](diffhunk://#diff-33e8e62dbc22e2f0bee8a46facb93db3a8a519012c535792ee2888b63f4d448cL479-R479)

**References:** [[1]](diffhunk://#diff-82a915d10232ea1380d822e00da07a09dc5b8218e75fb15733ca8f8507fb186cR112-R150) [[2]](diffhunk://#diff-6392823aa65e9a686e1c8ead92c940cc95f7021796d8ae4ef7d5ff9211412e86L30-R64) [[3]](diffhunk://#diff-b173581bf59c51ffeab6e9158cfa9565ca05b9a59f5f6f2e1336353da0e086d9R131-R154) [[4]](diffhunk://#diff-8fdd799ab0791e295561f41dacc6bae28e5c74fbf00d2ea3b6659b8b46d70bf5L390-R390) [[5]](diffhunk://#diff-4054b27a7cad789febda8d2a7c57ce4d1496c3e174d62d667a78fcddc7de298eL1589-R1589) [[6]](diffhunk://#diff-276271c0c8ead222a200f72c2f2cda6cdd7bec13c3a794a5841adddd6bc755d7L484-R484) [[7]](diffhunk://#diff-33e8e62dbc22e2f0bee8a46facb93db3a8a519012c535792ee2888b63f4d448cL68-R68) [[8]](diffhunk://#diff-33e8e62dbc22e2f0bee8a46facb93db3a8a519012c535792ee2888b63f4d448cL479-R479) [[9]](diffhunk://#diff-6392823aa65e9a686e1c8ead92c940cc95f7021796d8ae4ef7d5ff9211412e86L171-R154) [[10]](diffhunk://#diff-6392823aa65e9a686e1c8ead92c940cc95f7021796d8ae4ef7d5ff9211412e86L191-L192) [[11]](diffhunk://#diff-6392823aa65e9a686e1c8ead92c940cc95f7021796d8ae4ef7d5ff9211412e86L203-R183)