### PR TITLE
docs: fix broken links

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -276,7 +276,7 @@ Our roadmap is guided by:
 ## Detailed Planning
 
 For detailed workshop planning and task breakdown, see:
-- [GenPRES Production Plan 2026 v3](docs/roadmap/genpres-production-plan-2026-v3.md)
+- [GenPRES Architecture and Timeline](docs/roadmap/genpres-architecture-and-timeline.md)
 - [W1: Project Structure & Governance](docs/roadmap/w1-project-structure-and-governance.md)
 
 ## Get Involved

--- a/docs/roadmap/w1-project-structure-and-governance.md
+++ b/docs/roadmap/w1-project-structure-and-governance.md
@@ -205,7 +205,7 @@ See the sections below for detailed analysis of missing items and implementation
 ##### Other Documentation
 
 - ✅ **docs/roadmap/** - Strategic planning and workshops
-  - ✅ **genpres-production-plan-2026-v3.md** - Production roadmap with 12 workshops
+  - ✅ **genpres-architecture-and-timeline.md** - Architecture and timeline with 12 workshops
   - ✅ **w1-project-structure-and-governance.md** - This document
 - ✅ **docs/scenarios/** - Clinical scenario examples (6 files)
   - Newborn.md, Infant.md, Child.md, Teenager.md, Adult.md, Toddler.md
@@ -1087,7 +1087,7 @@ scripts/:
 Many missing root-level files should link to detailed MDR documentation:
 
 - `ARCHITECTURE.md` → `docs/mdr/design-history/architecture.md`
-- `ROADMAP.md` → `docs/roadmap/genpres-production-plan-2026-v3.md`
+- `ROADMAP.md` → `docs/roadmap/genpres-architecture-and-timeline.md`
 - `CHANGELOG.md` (user-facing) ≠ `docs/mdr/design-history/change-log.md` (developer)
 - ADRs should reference design history files for detailed technical decisions
 


### PR DESCRIPTION
This pull request updates references throughout the documentation to point to the new `genpres-architecture-and-timeline.md` file instead of the previous `genpres-production-plan-2026-v3.md`. This ensures that all roadmap and planning links are consistent and up-to-date.

Documentation reference updates:

* Updated the main roadmap link in `ROADMAP.md` to reference `genpres-architecture-and-timeline.md` instead of the older production plan.
* Changed references in `w1-project-structure-and-governance.md` to point to the new architecture and timeline document for both the strategic planning section and the roadmap link. [[1]](diffhunk://#diff-ff61b49f8b5b9bf42b33f8cc585f88cbebd604d1b42e5f7b36bf48a91ac3ff84L208-R208) [[2]](diffhunk://#diff-ff61b49f8b5b9bf42b33f8cc585f88cbebd604d1b42e5f7b36bf48a91ac3ff84L1090-R1090)
