### PR TITLE
fix: prevent equation runtime crash, fix autocomplete input rendering…

### DIFF
--- a/.github/instructions/fsharp-coding.instructions.md
+++ b/.github/instructions/fsharp-coding.instructions.md
@@ -149,7 +149,7 @@ type Patient = {
 
 ### Scoping and use of `private`
 
-Do not make types or functions private, unless explicitly mentionned in a comment or being told to.
+Do not make types or functions private, unless explicitly mentioned in a comment or being told to.
 
 ### Type and Module Shadowing Pattern
 - Create specific modules for each domain type that shadow the type name

--- a/src/Informedica.GenORDER.Lib/EquationMapping.fs
+++ b/src/Informedica.GenORDER.Lib/EquationMapping.fs
@@ -45,7 +45,7 @@ module EquationMapping =
             data
             |> Array.skip 1
             // only pick those equations that are marked with an 'x'
-            |> Array.filter (fun xs -> xs[indx] = "x")
+            |> Array.filter (fun xs -> xs.Length > indx && xs[indx] = "x" && xs.Length > 1)
             |> Array.map (Array.item 1)
             |> Array.toList
 

--- a/src/Informedica.GenPRES.Client/Components/Autocomplete.fs
+++ b/src/Informedica.GenPRES.Client/Components/Autocomplete.fs
@@ -1,9 +1,6 @@
 namespace Components
 
 
-// Note: cannot set label on textfield in render function using the props.label
-// therefore hardcoded versions of autocomplete. Need to fix this.
-// Note: runs when building in development mode, but fails in production mode!
 module Autocomplete =
 
 
@@ -34,11 +31,12 @@ module Autocomplete =
                 |> props.updateSelected
 
         let renderInput pars =
-            // Mutate the MUI-provided params to include the label before spreading,
-            // avoiding Fable 5 interpolation issue: https://github.com/fable-compiler/Fable/issues/3999
-            pars?label <- props.label
+            // Copy the MUI-provided params before mutating to avoid React reuse issues,
+            // then add the label, avoiding Fable 5 interpolation issue: https://github.com/fable-compiler/Fable/issues/3999
+            let parsCopy = emitJsExpr pars "Object.assign({}, $0)"
+            parsCopy?label <- props.label
             JSX.jsx """
-                <TextField {...pars} />
+                <TextField {...parsCopy} />
             """
             
         JSX.jsx

--- a/src/Informedica.GenPRES.Server/ServerApi.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.fs
@@ -1085,7 +1085,7 @@ module NutritionPlan =
 
 
     let updateNutritionOrderContext logger provider (plan: NutritionPlan, label: string, ctx: OrderContext) : Result<NutritionPlan, string[]> =
-        match OrderContext.evaluate logger provider Api.UpdateOrderScenario ctx with
+        match OrderContext.evaluate logger provider Api.UpdateOrderContext ctx with
         | Ok resolved ->
             plan |> updateContext label resolved |> Ok
         | Error errs -> Error errs


### PR DESCRIPTION
This pull request includes several targeted fixes and improvements across the codebase, focusing on bug fixes, code clarity, and minor documentation corrections. The most significant changes address a filtering bug in equation mapping, improve the robustness of the autocomplete component, and fix a function call in the server API.

Bug fixes and robustness improvements:

* Fixed a bug in `EquationMapping.fs` where the filter could throw an exception if the array was too short; now checks array length before accessing elements.
* In `Autocomplete.fs`, improved the `renderInput` function to avoid React reuse issues by copying the parameter object before mutation, addressing a Fable 5 interpolation issue.
* In `ServerApi.fs`, corrected a function call from `Api.UpdateOrderScenario` to the correct `Api.UpdateOrderContext` in `updateNutritionOrderContext`.

Code and documentation cleanup:

* Removed obsolete comments in `Autocomplete.fs` regarding label setting and build issues.
* Fixed a minor typo in the F# coding instructions documentation.
