### PR TITLE
fix(ui): fix interpolated string error for generic filter, always sho…

### DIFF
--- a/src/Informedica.GenPRES.Client/Views/Formulary.fs
+++ b/src/Informedica.GenPRES.Client/Views/Formulary.fs
@@ -199,7 +199,7 @@ module Formulary =
                 |]
             )
 
-        let select = ViewHelpers.simpleSelect false
+        let select = ViewHelpers.filterSelect false
         let autoComplete = ViewHelpers.autoComplete false
 
 

--- a/src/Informedica.GenPRES.Client/Views/Nutrition.fs
+++ b/src/Informedica.GenPRES.Client/Views/Nutrition.fs
@@ -501,7 +501,7 @@ module Nutrition =
         let isOrderLoading = props.isRecalculating
         let isLoading = state.Order.IsNone && not props.isRecalculating
         let select = ViewHelpers.orderSelect true isOrderLoading
-        let filterSelect = ViewHelpers.simpleSelect isOrderLoading isOrderLoading
+        let filterSelect = ViewHelpers.filterSelect isOrderLoading isOrderLoading
         let autoComplete = ViewHelpers.autoComplete isOrderLoading isOrderLoading
         let loadingIndicator = ViewHelpers.inlineProgress isOrderLoading
 
@@ -671,14 +671,15 @@ module Nutrition =
             let sel = ctx.Filter.Generic
             let items = ctx.Filter.Generics
             let lbl = "Samenstelling"
+            let onChange = genericChange
 
             if isMobile then
                 items
                 |> Array.map (fun s -> s, s)
-                |> filterSelect lbl sel genericChange
+                |> filterSelect lbl sel onChange
             else
                 items
-                |> autoComplete lbl sel genericChange
+                |> autoComplete lbl sel onChange
 
         let frequencyDoseRow =
             if isEnteral then

--- a/src/Informedica.GenPRES.Client/Views/Parenteralia.fs
+++ b/src/Informedica.GenPRES.Client/Views/Parenteralia.fs
@@ -131,7 +131,7 @@ module Parenteralia =
                 |]
             )
 
-        let select = ViewHelpers.simpleSelect false
+        let select = ViewHelpers.filterSelect false
         let autoComplete = ViewHelpers.autoComplete false
 
         let progress = ViewHelpers.progressOrEmpty props.parenteralia

--- a/src/Informedica.GenPRES.Client/Views/Prescribe.fs
+++ b/src/Informedica.GenPRES.Client/Views/Prescribe.fs
@@ -118,7 +118,7 @@ module Prescribe =
         let isSourceLoading source =
             isAnythingLoading && loadingSource = Some source
 
-        let select = ViewHelpers.simpleSelect isAnythingLoading
+        let select = ViewHelpers.filterSelect isAnythingLoading
 
         let multiSelect isLoading lbl selected dispatch xs =
             Components.MultipleSelect.View({|

--- a/src/Informedica.GenPRES.Client/Views/ViewHelpers.fs
+++ b/src/Informedica.GenPRES.Client/Views/ViewHelpers.fs
@@ -9,14 +9,15 @@ module ViewHelpers =
     open Shared.Models.Order
 
 
-    let simpleSelect disabled isLoading lbl selected dispatch xs =
+    let filterSelect disabled isLoading lbl selected dispatch xs =
+        let isEmpty = xs |> Array.isEmpty
         Components.SimpleSelect.View({|
-            updateSelected = dispatch
+            updateSelected = if isEmpty then ignore else dispatch
             label = lbl
             selected = selected
             values = xs
             isLoading = isLoading
-            disabled = disabled
+            disabled = disabled || isEmpty
             hasClear = true
             navigate = None
             warning = None
@@ -48,15 +49,16 @@ module ViewHelpers =
         if not alwaysShow && xs |> Array.isEmpty && navigate |> Option.isNone then
             null
         else
+            let isEmpty = xs |> Array.isEmpty && navigate |> Option.isNone
             Components.SimpleSelect.View({|
-                updateSelected = updateSelected
+                updateSelected = if isEmpty then ignore else updateSelected
                 label = lbl
                 selected =
                     if xs |> Array.length = 1 then xs[0] |> fst |> Some
                     else selected
                 values = xs
                 isLoading = isLoading
-                disabled = disabled
+                disabled = disabled || isEmpty
                 hasClear = hasClear
                 warning = warning
                 navigate = navigate
@@ -127,13 +129,14 @@ module ViewHelpers =
 
 
     let autoComplete disabled isLoading lbl selected dispatch xs =
+        let isEmpty = xs |> Array.isEmpty
         Components.Autocomplete.View({|
-            updateSelected = dispatch
+            updateSelected = if isEmpty then ignore else dispatch
             label = lbl
             selected = selected
             values = xs
             isLoading = isLoading
-            disabled = disabled
+            disabled = disabled || isEmpty
         |})
 
 


### PR DESCRIPTION
This pull request makes a small change to the `Nutrition` module in `Nutrition.fs` by simplifying the logic for rendering the generic filter. The redundant check for empty generics has been removed, resulting in a cleaner and more straightforward rendering flow.