### PR TITLE
Fix errors in test scaffolding script

### DIFF
--- a/scripts/GenOrderTestScaffolding.fsx
+++ b/scripts/GenOrderTestScaffolding.fsx
@@ -12,6 +12,7 @@
 
 open System
 open System.IO
+open System.Text.RegularExpressions
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -58,9 +59,9 @@ let ciContent =
         printfn "WARNING: CI tests file not found at path: %s. Proceeding with empty content." ciTestsPath
         ""
 
-let testNameRegex = Regex(@"test(Task)?\s*\"([^\"]+)\"", RegexOptions.Compiled)
+let testNameRegex = Regex(@"test(Task)?\s*""([^""]+)""", RegexOptions.Compiled)
 
-let hasTest name =
+let hasTest (name: string) =
     // Heuristic: function name appears within an Expecto test/testTask name (the string in test "...").
     testNameRegex.Matches(ciContent)
     |> Seq.cast<Match>


### PR DESCRIPTION
This pull request makes a minor update to the `GenOrderTestScaffolding.fsx` script, focusing on improving test name parsing. The most important change is a fix to the regular expression used to match test names, ensuring more reliable extraction of test names from the CI tests file.

Test name parsing improvements:
* Updated the regular expression in `testNameRegex` to correctly handle double-quoted test names, improving the reliability of test name extraction.
* Added `System.Text.RegularExpressions` to the imports to support regular expression operations.