### PR TITLE
feat: enable gracefull shutdown, fix error in tests

### DIFF
--- a/Helpers.fs
+++ b/Helpers.fs
@@ -88,7 +88,11 @@ let createProcess exe args dir =
     // See https://github.com/SAFE-Stack/SAFE-template/issues/551.
     CreateProcess.fromRawCommand exe args
     |> CreateProcess.withWorkingDirectory dir
-    |> CreateProcess.ensureExitCode
+    |> CreateProcess.addOnExited (fun data exitCode ->
+        // Treat SIGINT (130) and SIGTERM (143) as graceful shutdown
+        if exitCode <> 0 && exitCode <> 130 && exitCode <> 143 then
+            failwithf "Process exit code '%d' <> 0. Command Line: %s %s" exitCode exe (args |> String.concat " ")
+        data)
 
 
 let dotnet args dir = createProcess "dotnet" args dir

--- a/tests/Informedica.NKF.Tests/Tests.fs
+++ b/tests/Informedica.NKF.Tests/Tests.fs
@@ -188,6 +188,7 @@ module Tests =
                     let cleaned = (Export.cleanGenericName drug).Generic
                     cleaned
                     |> Expect.equal "should be lowercased" "colistimethaatnatrium"
+                }
                 test "cleanGenericName strips ' (combinatiepreparaat)' suffix" {
                     let drug = createDrug "" "" "co-trimoxazol (combinatiepreparaat)" ""
                     (Export.cleanGenericName drug).Generic


### PR DESCRIPTION
This pull request introduces an improvement to process handling in `Helpers.fs` and a minor test fix in `Tests.fs`. The most significant change is to the way process exit codes are handled, allowing certain signals to be treated as graceful shutdowns rather than errors.

### Process handling improvements

* Updated `createProcess` in `Helpers.fs` to treat SIGINT (130) and SIGTERM (143) exit codes as graceful shutdowns instead of errors, and only fail for other non-zero exit codes. This prevents unnecessary failures when processes are terminated intentionally.

### Test code fix

* Fixed a missing closing brace in a test case in `tests/Informedica.NKF.Tests/Tests.fs` to ensure proper test structure.