### PR TITLE
chore: exclude scripts from fantomas formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,7 @@ max_line_length=120
 # Known Fantomas limitations (not configurable):
 # - if/then/else: cannot keep simple `then` on same line with complex `else` on next line
 # - pipeline: cannot force `|>` to start-of-line positioning
-[*.{fs,fsx}]
+[*.{fs}]
 fsharp_multiline_bracket_style = aligned
 fsharp_align_function_signature_to_indentation = true
 fsharp_keep_max_number_of_blank_lines = 2


### PR DESCRIPTION
Formatting scripts by fantomas leads to too many problems and is not really needed anyway.
