### PR TITLE
build(deps): bump picomatch from 4.0.3 to 4.0.4 in /src/Informedica.G…

### DIFF
--- a/src/Informedica.GenPRES.Client/package-lock.json
+++ b/src/Informedica.GenPRES.Client/package-lock.json
@@ -4345,9 +4345,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {


### PR DESCRIPTION
This pull request updates a single dependency in the `package-lock.json` file to ensure the project uses the latest patch version.

- Dependency update:
  * Upgraded the `picomatch` package from version 4.0.3 to 4.0.4, which may include bug fixes or minor improvements.
