### PR TITLE
feat(genform): add component dose limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Client (UI)**: Add templating fields for emergency list — facilitates switching to prescribe mode for an emergency medication; adds template fields (`TemplateGeneric`, `TemplateRoute`, `TemplateDoseType`, `TemplateIndication`) to shared models and wires through server API and client app (PR #243)
+- **GenFORM**: Resolve `min adj to max` constraints for patient — `PrescriptionRule.fs` now handles the adjustment of minimum doses relative to maximum constraints; 131 new test cases added to `Informedica.GenFORM.Tests` (PR #243)
+- **Docs**: Add ADR for template-based prescribing — new design decision document describing the emergency medication prescribing template approach (PR #245)
+- **Build/CI**: Add comprehensive Copilot instructions and prompt files — `.github/copilot-instructions.md` updated with full project guidance; four reusable prompt files added for `add-dose-rule`, `fix-failing-test`, `new-fsx-script`, and `review-pr` workflows (PR #247)
 - **Client (UI)**: Localise hardcoded UI strings — replaces hardcoded Dutch strings across client views with localised terms; adds new `Terms` DU cases for shared, patient, nutrition, and interaction labels; language selector now shows short language code instead of flag emoji (PR #239)
 - **Scripts (GenSOLVER)**: Add `LRUSolverIntegration.fsx` — W2 final step; session-level `SessionSolver` that integrates the LRU cache into the constraint solver with canonical name-remapping, 6 correctness tests, and a 50-patient capacity benchmark (PR #238)
 - **Client (UI)**: Improve overall layout — responsive table rendering, sidebar initialisation, conditional totals bar, and layout design documentation update (PR #235)
@@ -28,13 +32,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Docs**: Restructure `docs/mdr/design-history/` as numbered ADRs with consistent naming — all design-history documents renamed with `0001`–`0013` prefixes for discoverability and traceability (PR #245)
+- **Docs (MCP)**: Update MCP server architecture document — fix file structure listing and pin `ModelContextProtocol` to version `1.2.0` (PR #241)
 - **Client**: Refactor environment variable access to use `AppEnv` module — adds `asEnv` Fable-compatible helper (`unbox<'T>`), eliminating scattered inline environment reads; fixes `appendScenarioToTreatmentPlan` naming to remove shadowing of outer `updateTreatmentPlan`; prevents concurrent duplicate `UpdateOrderPlan` requests by checking `InProgress`/`Recalculating` state (PR #223)
 - **Docs**: Update `0007-clean-safe-architecture.md` to reflect implemented safe-and-clean architecture state and add code-verified implementation notes (PR #227)
 
 ### Fixed
 
+- **GenFORM / Build**: Fix build failure caused by incompatible message error types (PR #243)
 - **Client (UI)**: Remove hardcoded year ("2023") from application title bar (PR #238)
 - **Client (UI)**: Fix layout overflow — replace `React.Fragment` with `Box` for correct overflow containment in universal layout; conditional totals bar rendering and duplicate padding corrections (PR #229, PR #235)
+- **Client (UI)**: Remove hardcoded year from app title — '2023' removed from `GenPres.fs`; title now reads 'GenPRES \<page\>' without a stale year (PR #237)
+- **Client (UI)**: Replace confusing language flag emoji with short language code in title bar language selector (PR #239)
 - **Client (UI)**: Improve interactions management — InProgress guard prevents redundant server calls when a request is already in flight; unused `drugs` variable removed (PR #224)
 - **Scripts (FHIR)**: Fix `ImplementationPlan.fsx` — major rework with correct FHIR property mappings and a full end-to-end round trip from a calculated `GenOrder.Order` to `FhirMedicationRequest` and back (PR #222)
 - **Client (UI)**: Fix "Select All" in treatment plan table — rows now correctly toggle; unfiltered row search replaced with filtered-row lookup for O(n²) → O(n) improvement (PR #217)

--- a/src/Informedica.GenSOLVER.Lib/Scripts/LRUCapacityTuning.fsx
+++ b/src/Informedica.GenSOLVER.Lib/Scripts/LRUCapacityTuning.fsx
@@ -1,0 +1,289 @@
+#I __SOURCE_DIRECTORY__
+#load "load.fsx"
+
+// =============================================================
+// LRUCapacityTuning.fsx — LRU cache capacity tuning benchmark
+// =============================================================
+//
+// Context: LRUCache.fsx established that a session-level LRU cache
+// provides significant speedup over baseline and per-call memoization.
+// The default capacity was set to 512 entries without empirical tuning.
+//
+// This script answers: "What is the optimal LRU cache capacity for a
+// realistic hospital patient batch?"
+//
+// Method
+// ------
+//  • Run the same 10-patient dosing benchmark from LRUCache.fsx
+//    across multiple cache capacities: 32, 64, 128, 256, 512, 1024.
+//  • For each capacity, measure:
+//      - Mean time per iteration (ms)
+//      - Cache hit rate (%) over 5 warm-up passes
+//      - Cache size after warmup (entries used / capacity)
+//  • Identify the "knee point": smallest capacity achieving > 90% of
+//    the maximum speedup (diminishing returns beyond this point).
+//
+// Run:
+//   cd src/Informedica.GenSOLVER.Lib/Scripts
+//   dotnet fsi LRUCapacityTuning.fsx
+// =============================================================
+
+open System
+open System.Collections.Generic
+open MathNet.Numerics
+open Informedica.GenUnits.Lib
+open Informedica.GenSolver.Lib
+
+
+// ------------------------------------------------------------------
+// LRU cache implementation (copied from LRUCache.fsx for self-contained script)
+// ------------------------------------------------------------------
+
+/// Thread-safe LRU cache backed by a LinkedList + Dictionary.
+type LRUCache<'K, 'V when 'K : equality>(capacity: int) =
+
+    do
+        if capacity <= 0 then
+            invalidArg "capacity" "LRUCache capacity must be > 0."
+    let dict = Dictionary<'K, LinkedListNode<struct ('K * 'V)>>()
+    let list = LinkedList<struct ('K * 'V)>()
+    let mutable hits = 0
+    let mutable misses = 0
+
+    member _.Capacity = capacity
+    member _.Count = dict.Count
+
+    member _.Hits = hits
+    member _.Misses = misses
+
+    member _.ResetStats() =
+        hits <- 0
+        misses <- 0
+
+    member _.Clear() =
+        dict.Clear()
+        list.Clear()
+        hits <- 0
+        misses <- 0
+
+    member this.TryGet(key: 'K) =
+        lock this (fun () ->
+            match dict.TryGetValue(key) with
+            | false, _ ->
+                misses <- misses + 1
+                None
+            | true, node ->
+                hits <- hits + 1
+                // promote to front (most recently used)
+                list.Remove(node)
+                list.AddFirst(node)
+                let struct (_, v) = node.Value
+                Some v
+        )
+
+    member this.Put(key: 'K, value: 'V) =
+        lock this (fun () ->
+            match dict.TryGetValue(key) with
+            | true, node ->
+                // update existing entry and promote to front
+                list.Remove(node)
+                let newNode = list.AddFirst(struct (key, value))
+                dict[key] <- newNode
+            | false, _ ->
+                if dict.Count >= capacity then
+                    // evict least-recently-used (tail)
+                    let tail = list.Last
+                    list.RemoveLast()
+                    let struct (k, _) = tail.Value
+                    dict.Remove(k) |> ignore
+
+                let node = list.AddFirst(struct (key, value))
+                dict[key] <- node
+        )
+
+
+// ------------------------------------------------------------------
+// Solver helper (mirroring LRUCache.fsx Solver module)
+// ------------------------------------------------------------------
+
+module Solver =
+
+    open Informedica.GenSolver.Lib.Types
+
+    type SolveStats = { Hits: int; Misses: int }
+
+    let canonKey (eqs: Equation.T list) =
+        eqs
+        |> List.map CanonKey.ofEquation
+        |> String.concat ";"
+
+    let solveAllLRU onlyMinMax notify (cache: LRUCache<string, Equation.T list>) eqs =
+        let key = canonKey eqs
+
+        match cache.TryGet(key) with
+        | Some cached ->
+            let stats = { Hits = 1; Misses = 0 }
+            (cached, SolveResult.Unchanged), stats
+        | None ->
+            let result =
+                eqs
+                |> Api.solve onlyMinMax notify
+            let stats = { Hits = 0; Misses = 1 }
+            cache.Put(key, fst result)
+            result, stats
+
+
+// ------------------------------------------------------------------
+// Equation factories (identical to LRUCache.fsx)
+// ------------------------------------------------------------------
+
+let inline setValues u n vs eqs =
+    eqs |> Api.setVariableValues u (Variable.Name.createExc n) vs
+
+let patientWeights = [| 5N; 10N; 15N; 20N; 30N; 40N; 50N; 60N; 70N; 80N |]
+
+/// Patient-specific dosing equation: totalDose = weight × dosePerKg × timesPerDay
+let dosingSetup (weight: BigRational) =
+    [
+        "dose = weight * dosePerKg"
+        "totalDose = dose * timesPerDay"
+    ]
+    |> Api.init
+    |> setValues Units.Count.times "weight" [| weight |]
+    |> setValues Units.Count.times "dosePerKg" [| 10N; 15N; 20N |]
+    |> setValues Units.Count.times "timesPerDay" [| 2N; 3N; 4N |]
+
+let solveBaseline onlyMinIncrMax eqs =
+    eqs |> Api.solve onlyMinIncrMax (fun _ -> ())
+
+
+// ------------------------------------------------------------------
+// Benchmark helpers
+// ------------------------------------------------------------------
+
+let timeMean label n f =
+    let sw = Diagnostics.Stopwatch.StartNew()
+
+    for _ in 1..n do
+        f () |> ignore
+
+    sw.Stop()
+    float sw.ElapsedMilliseconds / float n
+
+
+let measureCapacity capacity iters =
+    let cache = LRUCache<string, Equation.T list>(capacity)
+
+    // warm up
+    for _ in 1..3 do
+        for w in patientWeights do
+            dosingSetup w |> Solver.solveAllLRU false (fun _ -> ()) cache |> ignore
+
+    // reset stats then measure
+    cache.ResetStats()
+
+    let ms =
+        timeMean $"capacity {capacity,6}" iters (fun () ->
+            for w in patientWeights do
+                dosingSetup w |> Solver.solveAllLRU false (fun _ -> ()) cache |> ignore
+        )
+
+    // hit rate over 5 extra passes
+    let mutable h = 0
+    let mutable m = 0
+
+    for _ in 1..5 do
+        for w in patientWeights do
+            let _, stats = dosingSetup w |> Solver.solveAllLRU false (fun _ -> ()) cache
+            h <- h + stats.Hits
+            m <- m + stats.Misses
+
+    let hitRate = float h / float (h + m) * 100.0
+
+    {|
+        Capacity = capacity
+        Ms = ms
+        HitRate = hitRate
+        UsedEntries = cache.Count
+    |}
+
+
+// ------------------------------------------------------------------
+// Run the benchmark
+// ------------------------------------------------------------------
+
+let iters = 20
+
+printfn "\n=== LRU Cache Capacity Tuning Benchmark ==="
+printfn "Setup: 10 patients × dosing formula, %d iterations each" iters
+printfn ""
+
+// baseline (no cache) for speedup calculation
+let baseMs =
+    timeMean "baseline (no cache)" iters (fun () ->
+        for w in patientWeights do
+            dosingSetup w |> solveBaseline false |> ignore
+    )
+
+printfn "\nCapacity results:"
+printfn "  %-12s  %-10s  %-12s  %-14s  %-10s" "Capacity" "ms/iter" "Speedup vs 0" "Hit Rate (%)" "Entries used"
+printfn "  %s" (String.replicate 66 "-")
+
+let capacities = [ 32; 64; 128; 256; 512; 1024 ]
+
+let results =
+    capacities
+    |> List.map (fun cap ->
+        let r = measureCapacity cap iters
+
+        printfn
+            "  %-12d  %-10.1f  %-12.2f  %-14.0f  %d / %d"
+            r.Capacity
+            r.Ms
+            (baseMs / r.Ms)
+            r.HitRate
+            r.UsedEntries
+            r.Capacity
+
+        r
+    )
+
+// -- find knee point (≥90% of max speedup)
+let maxSpeedup = results |> List.map (fun r -> baseMs / r.Ms) |> List.max
+let threshold = maxSpeedup * 0.90
+
+let kneePoint =
+    results
+    |> List.tryFind (fun r -> baseMs / r.Ms >= threshold)
+    |> Option.map (fun r -> r.Capacity)
+
+printfn ""
+printfn "  Baseline (no cache):  %.1f ms/iter" baseMs
+printfn "  Max speedup:          %.2fx" maxSpeedup
+printfn "  90%% threshold:        %.2fx" threshold
+
+match kneePoint with
+| Some cap -> printfn "  ✓ Knee-point capacity: %d (first to reach ≥90%% of max speedup)" cap
+| None -> printfn "  ! No capacity reached the 90%% threshold in the tested range"
+
+printfn
+    """
+
+=== Interpretation ===
+
+The knee-point capacity is the recommended default for solveAllLRU when
+integrated into Solver.fs. Choosing a larger capacity gives diminishing
+returns (marginal speedup for proportionally more memory).
+
+For a hospital-scale session (thousands of distinct dosing formulas),
+the actual hot-set will be larger than the 10-patient test above.
+Consider re-running this benchmark with a more diverse formula set
+(covering weight bands 1–100 kg) before finalising the production default.
+
+Next steps:
+  □ Integrate solveAllLRU into Solver.fs using the identified capacity.
+  □ Re-run with broader weight/dose ranges to validate the knee point.
+  □ Monitor cache.Count vs. Capacity in production to detect eviction pressure.
+
+Reference: docs/code-reviews/solver-memoization.md
+"""

--- a/src/Informedica.GenSOLVER.Lib/Scripts/SolverCanonPropertyTests.fsx
+++ b/src/Informedica.GenSOLVER.Lib/Scripts/SolverCanonPropertyTests.fsx
@@ -1,0 +1,337 @@
+#I __SOURCE_DIRECTORY__
+#load "load.fsx"
+
+// =============================================================
+// SolverCanonPropertyTests.fsx — Property-based tests for CanonKey
+// =============================================================
+//
+// Addresses the remaining W2 checklist item from
+// docs/code-reviews/solver-memoization.md:
+//
+//   "Property-based tests: randomly generated variable renamings
+//    must yield the same canonical key as the original equation."
+//
+// Properties verified (all via FsCheck):
+//
+//   P1. Stability      — CanonKey.ofEquation is idempotent: called
+//                        twice on the same equation, same key.
+//   P2. Name-invariance — Renaming all variables in an equation with
+//                         a fresh set of names yields the same
+//                         canonical key.
+//   P3. Structure-sensitivity — Changing the equation *type* (product
+//                         vs. sum) always produces a *different* key
+//                         (for the same variable values/ranges).
+//   P4. Value-sensitivity — Changing a variable's value range always
+//                           produces a different key.
+//
+// Run:
+//   cd src/Informedica.GenSOLVER.Lib/Scripts
+//   dotnet fsi SolverCanonPropertyTests.fsx
+// =============================================================
+
+#r "nuget: FsCheck, 2.16.6"
+#r "nuget: Expecto, 9.0.4"
+#r "nuget: Expecto.FsCheck, 9.0.4"
+
+open System
+open System.Collections.Generic
+open MathNet.Numerics
+open Informedica.GenUnits.Lib
+open Informedica.GenSolver.Lib
+open Expecto
+open Expecto.Flip
+open FsCheck
+
+
+// ------------------------------------------------------------------
+// CanonKey module — copied from MemoCanon.fsx (standalone)
+// ------------------------------------------------------------------
+
+module CanonKey =
+
+    let sortedNames (eq: Types.Equation.T) =
+        eq
+        |> Equation.toVars
+        |> List.map (Variable.getName >> Variable.Name.toString)
+        |> List.sort
+
+    let symbol i = $"x{i}"
+
+    let nameMap (eq: Types.Equation.T) =
+        eq |> sortedNames |> List.mapi (fun i n -> n, symbol i) |> Map.ofList
+
+    let canonicalise (nmap: Map<string, string>) (s: string) =
+        nmap
+        |> Map.toSeq
+        |> Seq.sortByDescending (fun (name, _) -> name.Length)
+        |> Seq.fold (fun (acc: string) (name, sym) -> acc.Replace(name, sym)) s
+
+    let ofEquation (eq: Types.Equation.T) =
+        let nmap = nameMap eq
+        eq |> Equation.toString true |> canonicalise nmap
+
+
+// ------------------------------------------------------------------
+// Helpers for building test equations
+// ------------------------------------------------------------------
+
+let private noLog = SolverLogging.create (fun _ -> ())
+
+let setValues u n vs eqs =
+    let nm = n |> Variable.Name.createExc
+    let prop = vs |> ValueUnit.create u |> Variable.ValueRange.ValueSet.create |> ValsProp
+
+    match eqs |> Api.setVariableValues nm prop with
+    | Some var -> eqs |> List.map (Equation.replace var)
+    | None -> eqs
+
+/// Build a product equation: lhs = rhs1 * rhs2 with given value sets.
+let makeProductEq lhs rhs1 rhs2 (vals: BigRational array) =
+    [ $"{lhs} = {rhs1} * {rhs2}" ]
+    |> Api.init
+    |> setValues Units.Count.times rhs1 vals
+    |> setValues Units.Count.times rhs2 vals
+
+/// Build a sum equation: lhs = rhs1 + rhs2 with given value sets.
+let makeSumEq lhs rhs1 rhs2 (vals: BigRational array) =
+    [ $"{lhs} = {rhs1} + {rhs2}" ]
+    |> Api.init
+    |> setValues Units.Count.times rhs1 vals
+    |> setValues Units.Count.times rhs2 vals
+
+
+// ------------------------------------------------------------------
+// FsCheck generators
+// ------------------------------------------------------------------
+
+/// Generate a non-empty, lowercase alphabetic identifier token (3–8 chars)
+/// suitable for use as a variable name segment.
+let genToken : Gen<string> =
+    Gen.choose (3, 8)
+    |> Gen.bind (fun len ->
+        Gen.arrayOfLength len (Gen.choose (97, 122))   // 'a'..'z'
+        |> Gen.map (fun cs -> String(cs |> Array.map char))
+    )
+
+/// Generate a list of n distinct tokens.
+let genDistinctTokens (n: int) : Gen<string list> =
+    Gen.sized (fun _ -> Gen.constant ())
+    |> Gen.bind (fun () ->
+        genToken |> Gen.listOf
+        |> Gen.map (fun ts -> ts |> List.distinct |> List.truncate n)
+        |> Gen.filter (fun ts -> ts.Length >= n)
+        |> Gen.map (List.take n)
+    )
+
+/// Generate a small array of distinct positive BigRationals (length 2..5).
+let genVals : Gen<BigRational array> =
+    Gen.choose (1, 9)
+    |> Gen.arrayOf
+    |> Gen.filter (fun arr -> arr.Length >= 2 && arr.Length <= 5)
+    |> Gen.map (Array.map (fun n -> BigRational.FromInt n) >> Array.distinct)
+    |> Gen.filter (fun arr -> arr.Length >= 2)
+
+
+// ------------------------------------------------------------------
+// P1: Stability — idempotent key
+// ------------------------------------------------------------------
+
+let p1_stability =
+    test "P1: CanonKey.ofEquation is idempotent" {
+        let vals = [| 1N; 2N; 3N |]
+
+        let eqs = makeProductEq "result" "factorA" "factorB" vals
+
+        match eqs with
+        | [] -> failwith "empty equation list"
+        | eq :: _ ->
+            let key1 = CanonKey.ofEquation eq
+            let key2 = CanonKey.ofEquation eq
+
+            key1 |> Expect.equal "same call should return same key" key2
+    }
+
+
+// ------------------------------------------------------------------
+// P2: Name-invariance — renaming variables preserves canonical key
+// ------------------------------------------------------------------
+
+let p2_nameInvariance =
+    testProperty "P2: renaming all variables preserves canonical key" (fun
+        (NonEmptyString result1)
+        (NonEmptyString a1)
+        (NonEmptyString b1)
+        (NonEmptyString result2)
+        (NonEmptyString a2)
+        (NonEmptyString b2)
+        ->
+            let vals = [| 1N; 2N; 3N; 4N; 5N |]
+
+            // Original names
+            let eq1 = makeProductEq result1 a1 b1 vals
+
+            // Completely different variable names, same structure + values
+            let eq2 = makeProductEq result2 a2 b2 vals
+
+            match eq1, eq2 with
+            | h1 :: _, h2 :: _ ->
+                let k1 = CanonKey.ofEquation h1
+                let k2 = CanonKey.ofEquation h2
+                k1 = k2
+            // If equation generation unexpectedly fails, the property should fail
+            | _ -> false
+    )
+
+
+// ------------------------------------------------------------------
+// P3: Structure-sensitivity — product vs sum → different key
+// ------------------------------------------------------------------
+
+let p3_structureSensitivity =
+    test "P3: product equation and sum equation have different canonical keys" {
+        let vals = [| 1N; 2N; 3N |]
+
+        let prodEqs = makeProductEq "r" "a" "b" vals
+        let sumEqs = makeSumEq "r" "a" "b" vals
+
+        match prodEqs, sumEqs with
+        | prodEq :: _, sumEq :: _ ->
+            let kProd = CanonKey.ofEquation prodEq
+            let kSum = CanonKey.ofEquation sumEq
+
+            kProd
+            |> Expect.notEqual "product and sum should have different canonical keys" kSum
+        | _ -> failwith "empty equation list"
+    }
+
+
+// ------------------------------------------------------------------
+// P4: Value-sensitivity — different value ranges → different key
+// ------------------------------------------------------------------
+
+let p4_valueSensitivity =
+    test "P4: equations with different variable value sets have different canonical keys" {
+        let vals1 = [| 1N; 2N; 3N |]
+        let vals2 = [| 10N; 20N; 30N |]
+
+        let eq1 = makeProductEq "result" "factorA" "factorB" vals1
+        let eq2 = makeProductEq "result" "factorA" "factorB" vals2
+
+        match eq1, eq2 with
+        | h1 :: _, h2 :: _ ->
+            let k1 = CanonKey.ofEquation h1
+            let k2 = CanonKey.ofEquation h2
+
+            k1 |> Expect.notEqual "different value sets should produce different keys" k2
+        | _ -> failwith "empty equation list"
+    }
+
+
+// ------------------------------------------------------------------
+// P5: Arity-sensitivity — adding a variable changes the key
+// ------------------------------------------------------------------
+
+let p5_aritySensitivity =
+    test "P5: equations with different arity have different canonical keys" {
+        // Binary product: result = a * b
+        let vals = [| 1N; 2N; 3N |]
+        let eq2 = makeProductEq "result" "factorA" "factorB" vals
+
+        // Three-variable sum: result = a + b + c
+        let eq3 =
+            [ "result = a + b + c" ]
+            |> Api.init
+            |> setValues Units.Count.times "a" vals
+            |> setValues Units.Count.times "b" vals
+            |> setValues Units.Count.times "c" vals
+
+        match eq2, eq3 with
+        | h2 :: _, h3 :: _ ->
+            let k2 = CanonKey.ofEquation h2
+            let k3 = CanonKey.ofEquation h3
+
+            k2 |> Expect.notEqual "different arity should produce different keys" k3
+        | _ -> failwith "empty equation list"
+    }
+
+
+// ------------------------------------------------------------------
+// P6: Name-invariance under several random renamings
+// ------------------------------------------------------------------
+
+let p6_randomRenaming =
+    test "P6: five random renamings of the same equation yield the same canonical key" {
+        let vals = [| 2N; 4N; 6N; 8N |]
+
+        // Build the same equation with five sets of distinct variable names.
+        let nameSets =
+            [
+                "res", "alpha", "beta"
+                "total", "dose", "weight"
+                "z", "x1", "x2"
+                "output", "inA", "inB"
+                "calc", "p", "q"
+            ]
+
+        let keys =
+            nameSets
+            |> List.choose (fun (lhs, r1, r2) ->
+                makeProductEq lhs r1 r2 vals
+                |> List.tryHead
+                |> Option.map CanonKey.ofEquation
+            )
+
+        match keys with
+        | [] -> failwith "no equations generated"
+        | first :: rest ->
+            for k in rest do
+                k |> Expect.equal "all renamings must produce the same canonical key" first
+    }
+
+
+// ------------------------------------------------------------------
+// Run all tests
+// ------------------------------------------------------------------
+
+let allTests =
+    testList
+        "SolverCanonPropertyTests"
+        [
+            p1_stability
+            p2_nameInvariance
+            p3_structureSensitivity
+            p4_valueSensitivity
+            p5_aritySensitivity
+            p6_randomRenaming
+        ]
+
+printfn "\n=== Running CanonKey property tests ===\n"
+
+runTestsWithCLIArgs [] [||] allTests |> ignore
+
+printfn
+    """
+
+=== Summary ===
+
+These tests verify the key invariants of CanonKey.ofEquation:
+
+  P1  Stability      : same equation → same key every time (idempotent)
+  P2  Name-invariance: renaming variables does not change canonical key
+  P3  Structure-sensitivity: product ≠ sum, even for same values
+  P4  Value-sensitivity: different value ranges → different key
+  P5  Arity-sensitivity: different variable count → different key
+  P6  Random renaming: five distinct name sets → identical canonical key
+
+Status against W2 memoization roadmap (solver-memoization.md):
+  ✅ Canonical serializer (MemoCanon.fsx)
+  ✅ Per-call memoization (Memo.fsx)
+  ✅ LRU session cache with eviction (LRUCache.fsx)
+  ✅ Correctness & benchmark tests (LRUCache.fsx)
+  ✅ Property-based tests for CanonKey (this script)
+  □  Full result remapping: remap canonical names → original on cache hit
+  □  Integrate LRU cache into Solver.fs at solveE call site
+  □  Capacity tuning benchmark (128 / 256 / 512 / 1024 entries)
+
+Reference: docs/code-reviews/solver-memoization.md
+"""


### PR DESCRIPTION
This pull request introduces several improvements to how dose and adjustment quantities are handled and displayed in medication order logic, with a focus on ensuring all relevant dose adjustment fields are included in the output and that single-component medications are treated correctly. The changes primarily affect the logic for displaying and processing dose quantities, adjustments, and constraints throughout the order creation and printing process.

**Dose and Adjustment Display Enhancements:**

* Updated all relevant `wrap` calls to include both the base dose (e.g., `Quantity`, `Rate`) and their adjustment fields (e.g., `QuantityAdjust`, `RateAdjust`, `PerTimeAdjust`) in the alert/caution outputs, ensuring that adjustment variables are always visible where applicable. [[1]](diffhunk://#diff-a676677fdafe289649911ce1ae46114cf86aa8e4668182a43621efe8d51e3c4fL3889-R3894) [[2]](diffhunk://#diff-a676677fdafe289649911ce1ae46114cf86aa8e4668182a43621efe8d51e3c4fL3937-R4006) [[3]](diffhunk://#diff-a676677fdafe289649911ce1ae46114cf86aa8e4668182a43621efe8d51e3c4fL4044-R4100) [[4]](diffhunk://#diff-a676677fdafe289649911ce1ae46114cf86aa8e4668182a43621efe8d51e3c4fL4112-R4197) [[5]](diffhunk://#diff-a676677fdafe289649911ce1ae46114cf86aa8e4668182a43621efe8d51e3c4fL4134-R4218) [[6]](diffhunk://#diff-a676677fdafe289649911ce1ae46114cf86aa8e4668182a43621efe8d51e3c4fL4194-R4283)

* Added logic to print constraints for adjustment fields (such as `QuantityAdjust`, `RateAdjust`, `PerTimeAdjust`) when they are solved, and to display these constraints in the output, improving clarity for complex dose adjustments. [[1]](diffhunk://#diff-a676677fdafe289649911ce1ae46114cf86aa8e4668182a43621efe8d51e3c4fR3905-R3912) [[2]](diffhunk://#diff-a676677fdafe289649911ce1ae46114cf86aa8e4668182a43621efe8d51e3c4fL3937-R4006) [[3]](diffhunk://#diff-a676677fdafe289649911ce1ae46114cf86aa8e4668182a43621efe8d51e3c4fR4113-R4125)

**Medication Dose Calculation Logic:**

* Modified the dose assignment logic so that if a medication has exactly one component and no orderable-level dose, the single component's dose is used as the orderable dose. This ensures correct dose handling for single-component medications.

**Dose Rule Utility Enhancement:**

* Improved the `DoseRule.useAdjust` function to check for adjustment usage at all relevant levels (substance, component, and form), making the check more comprehensive and robust.

@greptile: review