### PR TITLE
fix: dose rule and medication fix avoding empty value units

### DIFF
--- a/src/Informedica.GenFORM.Lib/DoseRule.fs
+++ b/src/Informedica.GenFORM.Lib/DoseRule.fs
@@ -543,7 +543,10 @@ module DoseRule =
             match doseType with
             | NoDoseType -> false
             | Once _ -> true
-            | OnceTimed _ -> dd.MaxTime.IsSome && dd.TimeUnit |> String.notEmpty
+            | OnceTimed _ ->
+                (dd.MaxTime.IsSome && dd.TimeUnit |> String.notEmpty)
+                || dd.MaxRate.IsSome
+                || dd.MaxRateAdj.IsSome
             | Discontinuous _ -> dd.Frequencies |> Array.length > 0 && dd.FreqUnit |> String.notEmpty
             | Timed _ ->
                 dd.Frequencies |> Array.length > 0
@@ -561,8 +564,11 @@ module DoseRule =
                 | Once _ -> []
                 | OnceTimed _ ->
                     [
-                        missing dd.MaxTime.IsSome "MaxTime is missing"
-                        missing (dd.TimeUnit |> String.notEmpty) "TimeUnit is missing"
+                        missing
+                            ((dd.MaxTime.IsSome && dd.TimeUnit |> String.notEmpty)
+                             || dd.MaxRate.IsSome
+                             || dd.MaxRateAdj.IsSome)
+                            "MaxTime (with TimeUnit) or MaxRate or MaxRateAdj is missing"
                     ]
                     |> List.choose id
                 | Discontinuous _ ->

--- a/src/Informedica.GenORDER.Lib/OrderVariable.fs
+++ b/src/Informedica.GenORDER.Lib/OrderVariable.fs
@@ -75,7 +75,9 @@ module ValueUnit =
 
                 failwith $"Cannot collect the ValueUnit array to a single ValueUnit, values: [{details}]"
 
-            vus |> Array.collect (toBase >> getValue) |> withUnit u |> toUnit |> Some
+            let result = vus |> Array.collect (toBase >> getValue) |> withUnit u |> toUnit
+
+            if result |> isEmpty then None else result |> Some
 
 
     /// <summary>

--- a/src/Informedica.GenORDER.Lib/Scripts/Medication.fsx
+++ b/src/Informedica.GenORDER.Lib/Scripts/Medication.fsx
@@ -1240,3 +1240,41 @@ MedicationTexts.adenosinDayOne
     | Error _ -> "fail" |> failwith
     | Ok med -> [ CalcMinMax ] |> HelperFunctions.run None med
 |> ignore
+
+
+"""
+Id: 0b404ef4-22c2-46fd-b553-77818e64ed0b
+Name: natriumbenzoaat/natriumfenylacetaat
+Quantity:
+Quantities:
+Route: INTRAVENEUS
+OrderType: OnceTimedOrder
+Adjust: 17 kg
+Frequencies:
+Time: 90 min - 120 min
+Dose:
+Div:
+DoseCount: 1 x
+Components:
+
+	Name: natriumbenzoaat/natriumfenylacetaat
+	Form: natriumbenzoaat/natriumfenylacetaat
+	Quantities:
+	Divisible:
+	Dose:
+	Solution:
+	Substances:
+
+		Name: natriumbenzoaat
+		Quantities:
+		Concentrations:
+		Dose: natriumbenzoaat, [dun] mg, [qty-adj] 250 mg/kg/dosis
+		Solution:
+
+		Name: natriumfenylacetaat
+		Quantities:
+		Concentrations:
+		Dose: natriumfenylacetaat, [dun] mg, [qty-adj] 250 mg/kg/dosis
+		Solution:
+"""
+|> Medication.fromString

--- a/src/Informedica.GenORDER.Lib/Scripts/Scenarios.fsx
+++ b/src/Informedica.GenORDER.Lib/Scripts/Scenarios.fsx
@@ -40,7 +40,7 @@ let createScenarios (ctx: OrderContext) =
     let getRules filter =
         { ctx with Filter = filter }
         |> OrderContext.getRules OrderLogging.noOp provider
-        |> fun (ctx, res) -> ctx, res |> GenFormResult.get
+        |> fun (ctx, res) -> ctx, res |> Result.get
 
     let noEval ctx =
         let g = ctx.Filter.Generic
@@ -56,7 +56,7 @@ let createScenarios (ctx: OrderContext) =
                 ctx
                 |> OrderContext.UpdateOrderContext
                 |> OrderContext.evaluate OrderLogging.noOp provider
-                |> GenFormResult.get
+                |> Result.get
                 |> OrderContext.Command.get
 
             if ctx.Scenarios |> Array.isEmpty |> not then
@@ -316,7 +316,7 @@ module Order =
 let dro =
     Patient.newBorn
     |> Api.getPrescriptionRules provider
-    |> GenFormResult.get
+    |> Result.get
     |> Array.filter (fun pr -> pr.DoseRule.Generic |> String.equalsCapInsens "MM met BMF")
     |> Array.head
     |> Medication.fromRule Logging.noOp
@@ -329,7 +329,7 @@ dro.Dose
 let ord =
     Patient.newBorn
     |> Api.getPrescriptionRules provider
-    |> GenFormResult.get
+    |> Result.get
     |> Array.filter (fun pr -> pr.DoseRule.Generic |> String.equalsCapInsens "MM met BMF")
     |> Array.head
     |> Medication.fromRule Logging.noOp
@@ -344,7 +344,7 @@ ord |> Order.printTable ConsoleTables.Format.Minimal
 Patient.teenager
 |> Patient.setWeight (33m |> Kilogram |> Some)
 |> Api.getPrescriptionRules provider
-|> GenFormResult.get
+|> Result.get
 |> Array.filter (fun pr -> pr.DoseRule.Generic |> String.equalsCapInsens "piperacilline/tazobactam")
 |> Array.head
 |> Medication.fromRule Logging.noOp
@@ -358,7 +358,7 @@ Patient.teenager
 Patient.teenager
 |> Patient.setWeight (33m |> Kilogram |> Some)
 |> Api.getPrescriptionRules provider
-|> GenFormResult.get
+|> Result.get
 |> Array.filter (fun pr -> pr.DoseRule.Generic |> String.equalsCapInsens "noradrenaline")
 |> Array.head
 |> Medication.fromRule Logging.noOp
@@ -376,6 +376,6 @@ Patient.infant
 |> OrderContext.UpdateOrderContext
 |> OrderContext.evaluate OrderLogging.noOp provider
 |> fun res ->
-    let ctx = res |> GenFormResult.get |> OrderContext.Command.get
+    let ctx = res |> Result.get |> OrderContext.Command.get
 
     ctx.Scenarios |> Array.item 0 |> _.Order |> Order.print |> ignore


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the dose rule validation logic, order variable handling, and scenario scripts. The most notable changes are enhancements to the validation of "OnceTimed" dose types, improved handling of empty value units, and a shift from a custom result type (`GenFormResult`) to the standard `Result` type in scenario scripts.

**Dose Rule Validation Improvements**
* Updated the `DoseRule` logic for the `OnceTimed` dose type to consider not only `MaxTime` and `TimeUnit`, but also `MaxRate` and `MaxRateAdj` as valid conditions, making the validation more flexible and accurate.
* Enhanced the missing-field check for `OnceTimed` dose types to ensure that at least one of `MaxTime` (with `TimeUnit`), `MaxRate`, or `MaxRateAdj` is present, providing clearer validation messages.

**Order Variable Handling**
* Improved the `ValueUnit` collection logic to return `None` when the result is empty, preventing the creation of empty or invalid value units.

**Scenario Script Refactoring**
* Replaced usage of the custom `GenFormResult.get` with the standard `Result.get` throughout the scenario scripts for consistency and better integration with F#'s result handling. [[1]](diffhunk://#diff-cccfb1f439e5099453d31eb9782fb92d40b68352b58110ff3ebf591785dcf287L43-R43) [[2]](diffhunk://#diff-cccfb1f439e5099453d31eb9782fb92d40b68352b58110ff3ebf591785dcf287L59-R59) [[3]](diffhunk://#diff-cccfb1f439e5099453d31eb9782fb92d40b68352b58110ff3ebf591785dcf287L319-R319) [[4]](diffhunk://#diff-cccfb1f439e5099453d31eb9782fb92d40b68352b58110ff3ebf591785dcf287L332-R332) [[5]](diffhunk://#diff-cccfb1f439e5099453d31eb9782fb92d40b68352b58110ff3ebf591785dcf287L347-R347) [[6]](diffhunk://#diff-cccfb1f439e5099453d31eb9782fb92d40b68352b58110ff3ebf591785dcf287L361-R361) [[7]](diffhunk://#diff-cccfb1f439e5099453d31eb9782fb92d40b68352b58110ff3ebf591785dcf287L379-R379)

**Test Data and Example Additions**
* Added a new medication test case for `natriumbenzoaat/natriumfenylacetaat` in the medication script, providing a detailed example for further testing and validation.