### PR TITLE
fix(genorder): add missing ordervar for minincrmax to values

### DIFF
--- a/src/Informedica.GenORDER.Lib/Order.fs
+++ b/src/Informedica.GenORDER.Lib/Order.fs
@@ -3594,6 +3594,7 @@ module Order =
                 // - orderable dose rate
                 [
                     yield! ord.Orderable.Components |> List.map (_.OrderableQuantity >> Quantity.toOrdVar)
+                    ord.Orderable.Dose.Quantity |> Quantity.toOrdVar
                     ord.Orderable.Dose.Rate |> Rate.toOrdVar
                 ]
                 |> List.map (fun ovar ->


### PR DESCRIPTION
This pull request introduces a minor but important update to the `Order` module in `Order.fs`. The change ensures that the dose quantity of an orderable item is now included in the list of order variables, which improves the completeness of the data being processed.

- Logic enhancement:
  * Added the conversion of `ord.Orderable.Dose.Quantity` to an order variable using `Quantity.toOrdVar`, ensuring dose quantity is included in the output list.
