### PR TITLE
feat: improve managed agents script

### DIFF
--- a/src/Informedica.Agents.Lib/Scripts/AgentLifecycle.fsx
+++ b/src/Informedica.Agents.Lib/Scripts/AgentLifecycle.fsx
@@ -85,7 +85,7 @@ type ManagedAgent<'Req, 'Reply>(name: string, processor: 'Req -> 'Reply) =
 ///   ...
 type AgentRegistry() =
 
-    let agents = System.Collections.Generic.List<IDisposable>()
+    let agents = System.Collections.Generic.List<{| Name: string; Disposable: IDisposable |}>()
     let mutable stopped = false
 
     /// Create and register a named agent backed by <c>processor</c>.
@@ -93,7 +93,7 @@ type AgentRegistry() =
         if stopped then
             invalidOp $"Cannot register agent '%s{name}' after AgentRegistry has been stopped."
         let a = new ManagedAgent<'Req, 'Reply>(name, processor)
-        agents.Add(a)
+        agents.Add({| Name = name; Disposable = a |})
         a
 
     /// Number of agents registered in this registry.
@@ -112,9 +112,9 @@ type AgentRegistry() =
             |> Array.rev
             |> Array.iter (fun d ->
                 try
-                    d.Dispose()
+                    d.Disposable.Dispose()
                 with ex ->
-                    printfn $"[AgentRegistry] Error stopping agent: %s{ex.Message}")
+                    printfn $"[AgentRegistry] Error stopping agent '%s{d.Name}': %s{ex.Message}")
 
     interface IDisposable with
         member this.Dispose() = this.StopAll()
@@ -168,8 +168,6 @@ type AgentRegistry() =
 // 4. Tests — validate naming, request-reply, and lifecycle
 // -----------------------------------------------------------------
 
-#r "nuget: Expecto, 9.0.4"
-
 open Expecto
 open Expecto.Flip
 
@@ -208,7 +206,7 @@ let lifecycleTests =
             a.Stop()
 
             // second Stop must not throw
-            (fun () -> a.Stop()) |> Expect.notThrows "double Stop should not throw"
+            a.Stop() // second Stop must not throw
         }
 
         test "AgentRegistry — AgentCount reflects registrations" {
@@ -240,15 +238,26 @@ let lifecycleTests =
             let registry = new AgentRegistry()
             let _a = registry.Register<EchoReq, EchoReply>("idem-reg", echoProcessor)
             registry.StopAll()
-            (fun () -> registry.StopAll()) |> Expect.notThrows "double StopAll should not throw"
+            registry.StopAll() // second StopAll must not throw
         }
 
         test "AgentRegistry — use binding disposes automatically" {
-            let registry = new AgentRegistry()
-            let a = registry.Register<EchoReq, EchoReply>("scoped", echoProcessor)
-            (registry :> IDisposable).Dispose()
-            registry.IsStopped |> Expect.isTrue "registry stopped"
-            a.IsDisposed |> Expect.isTrue "agent disposed"
+            let mutable agentRef = Unchecked.defaultof<ManagedAgent<EchoReq, EchoReply>>
+
+            do
+                use registry = new AgentRegistry()
+                let a = registry.Register<EchoReq, EchoReply>("scoped", echoProcessor)
+                agentRef <- a
+                a.IsDisposed |> Expect.isFalse "agent alive inside use scope"
+
+            agentRef.IsDisposed |> Expect.isTrue "agent disposed after use scope exit"
+        }
+
+        test "AgentRegistry — registered agent preserves name through registry" {
+            use registry = new AgentRegistry()
+            let a = registry.Register<EchoReq, EchoReply>("named-agent", echoProcessor)
+            a.Name |> Expect.equal "name should be preserved" "named-agent"
+            a.Request("test") |> Expect.equal "should still reply" "echo: test"
         }
 
     ]


### PR DESCRIPTION
This pull request refactors the `AgentRegistry` in `AgentLifecycle.fsx` to improve agent management by associating agent names with their disposables, enhances error reporting, and expands the test suite for better lifecycle and naming coverage. The notable changes are grouped below:

**AgentRegistry Refactoring and Improvements:**

* The internal `agents` list now stores records containing both agent `Name` and `Disposable`, allowing for improved tracking and error reporting.
* The `StopAll` method now reports the agent name in error messages if disposal fails, making debugging easier.

**Test Suite Enhancements:**

* Tests for double stopping (`Stop`/`StopAll`) have been simplified to direct calls instead of using `Expect.notThrows`, clarifying intent. [[1]](diffhunk://#diff-e9470a0ea286a88a5323294f1a5f84334edb8496133110ef2c843aa48853952cL211-R209) [[2]](diffhunk://#diff-e9470a0ea286a88a5323294f1a5f84334edb8496133110ef2c843aa48853952cL243-R260)
* The test for automatic disposal via `use` binding now verifies the agent is alive within the scope and disposed after, ensuring correct lifecycle behavior.
* Added a test to confirm that a registered agent's name is preserved and that the agent continues to function as expected.

These changes collectively make agent lifecycle management more robust and the tests more expressive and comprehensive.