### PR TITLE
Add login icon

### DIFF
--- a/src/Informedica.GenPRES.Client/Components/TitleBar.fs
+++ b/src/Informedica.GenPRES.Client/Components/TitleBar.fs
@@ -69,7 +69,10 @@ module TitleBar =
                 s |> props.switchHosp
 
         let handleLoginClick =
-            fun _ ->
+            fun (e: Browser.Types.MouseEvent) ->
+                let target = e.currentTarget :?> Browser.Types.HTMLElement
+                target.blur ()
+
                 if props.isAuthenticated then
                     props.onLogout ()
                 else
@@ -79,15 +82,15 @@ module TitleBar =
 
         let handleLoginClose = fun _ -> setLoginDialogOpen false
 
-        let handleLoginConfirm =
-            fun _ ->
-                loginAttempted.current <- true
-                setLoginError false
-                props.onLogin password
+        let handleLoginSubmit (e: Browser.Types.Event) =
+            e.preventDefault ()
+            loginAttempted.current <- true
+            setLoginError false
+            props.onLogin password
 
-        let handleLoginKeyDown (e: Browser.Types.KeyboardEvent) =
-            if e.key = "Enter" then
-                handleLoginConfirm ()
+        let handlePasswordChange (e: Browser.Types.Event) =
+            setPassword (e.target?value: string)
+            setLoginError false
 
         let menuItems =
             let sxFlag = {| marginRight = 1 |}
@@ -230,28 +233,37 @@ module TitleBar =
                 </Toolbar>
             </AppBar>
             <Dialog open={loginDialogOpen} onClose={handleLoginClose}>
-                <DialogTitle>{"Login"}</DialogTitle>
-                <DialogContent>
-                    <TextField
-                        autoFocus={true}
-                        margin="dense"
-                        label="Password"
-                        type="password"
-                        fullWidth={true}
-                        variant="outlined"
-                        value={password}
-                        error={loginError}
-                        helperText={if loginError then "Invalid password" else ""}
-                        onChange={fun (e: Browser.Types.Event) ->
-                                      setPassword (e.target?value: string)
-                                      setLoginError false}
-                        onKeyDown={handleLoginKeyDown}
+                <form onSubmit={handleLoginSubmit}>
+                    <input
+                        type="text"
+                        name="username"
+                        autoComplete="username"
+                        value="genpres"
+                        readOnly={true}
+                        style={ {| display = "none" |} }
                     />
-                </DialogContent>
-                <DialogActions>
-                    <Button onClick={handleLoginClose}>{"Cancel"}</Button>
-                    <Button onClick={handleLoginConfirm} variant="contained">{"Login"}</Button>
-                </DialogActions>
+                    <DialogTitle>{"Login"}</DialogTitle>
+                    <DialogContent>
+                        <TextField
+                            autoFocus={true}
+                            margin="dense"
+                            name="password"
+                            autoComplete="current-password"
+                            label="Password"
+                            type="password"
+                            fullWidth={true}
+                            variant="outlined"
+                            value={password}
+                            error={loginError}
+                            helperText={if loginError then "Invalid password" else ""}
+                            onChange={handlePasswordChange}
+                        />
+                    </DialogContent>
+                    <DialogActions>
+                        <Button onClick={handleLoginClose} type="button">{"Cancel"}</Button>
+                        <Button type="submit" variant="contained">{"Login"}</Button>
+                    </DialogActions>
+                </form>
             </Dialog>
         </Box>
         """

--- a/src/Informedica.GenPRES.Client/Components/TitleBar.fs
+++ b/src/Informedica.GenPRES.Client/Components/TitleBar.fs
@@ -122,7 +122,10 @@ module TitleBar =
             {|
                 display = "flex"
                 alignItems = "center"
+                marginLeft = 2
             |}
+
+        let loginButtonSx = {| marginLeft = 2 |}
 
         let sxLangLabel =
             {|
@@ -132,6 +135,12 @@ module TitleBar =
             |}
 
         let loginButtonText = if props.isAuthenticated then "Logout" else "Login"
+
+        let loginButtonIcon =
+            if props.isAuthenticated then
+                Mui.Icons.Logout
+            else
+                Mui.Icons.Login
 
         let flexGrowSx = {| flexGrow = 1 |}
         let menuIconSx = {| marginRight = 2 |}
@@ -217,7 +226,7 @@ module TitleBar =
                             {menuItems}
                         </Menu>
                     </Box>
-                    <Button color="inherit" onClick={handleLoginClick}>{loginButtonText}</Button>
+                    <Button color="inherit" onClick={handleLoginClick} startIcon={loginButtonIcon} sx={loginButtonSx}>{loginButtonText}</Button>
                 </Toolbar>
             </AppBar>
             <Dialog open={loginDialogOpen} onClose={handleLoginClose}>

--- a/src/Informedica.GenPRES.Client/MUI.fs
+++ b/src/Informedica.GenPRES.Client/MUI.fs
@@ -351,6 +351,22 @@ module Icons =
         <LocalHospital />
     """
 
+    [<JSX.Component>]
+    let Login =
+        JSX.jsx
+            $"""
+        import LoginIcon from '@mui/icons-material/Login';
+        <LoginIcon />
+    """
+
+    [<JSX.Component>]
+    let Logout =
+        JSX.jsx
+            $"""
+        import LogoutIcon from '@mui/icons-material/Logout';
+        <LogoutIcon />
+    """
+
     let PsychologyIcon =
         JSX.jsx
             $"""


### PR DESCRIPTION
This pull request improves the user experience of the login/logout button in the `TitleBar` component by adding contextually appropriate icons and minor layout adjustments. The main changes are the introduction of new login/logout icon components, updating the button to display these icons, and refining the button's styling.

**UI/UX Improvements:**

* The login/logout button in the `TitleBar` now displays a relevant icon (`Login` or `Logout`) depending on the authentication state, making the action clearer to users. [[1]](diffhunk://#diff-827a71f99b1a8f692a81a825c8e9d471cfa511253b4899d5bc275f895187c93eR139-R144) [[2]](diffhunk://#diff-827a71f99b1a8f692a81a825c8e9d471cfa511253b4899d5bc275f895187c93eL220-R229)
* Added a left margin to the login/logout button for better spacing.

**Component Additions:**

* Introduced new `Login` and `Logout` icon components in `Mui.Icons` by importing them from MUI's icon library.