### PR TITLE
refactor(ui): extract inlined lambdas

### DIFF
--- a/.github/instructions/fsharp-coding.instructions.md
+++ b/.github/instructions/fsharp-coding.instructions.md
@@ -676,6 +676,8 @@ module Prescription =
 - Reuse shared style bindings across components by placing them at the module level (e.g., `let private flexEndSx = {| alignItems = "flex-end" |}`)
 - Place one-off style bindings as local `let` bindings just before the JSX expression that uses them
 - Exception: trivial single-property records (e.g., `{| marginBottom = 2 |}`) may remain inline if they appear only once
+- Never inline non-trivial lambdas (event handlers like `onChange`, `onClick`, `onSubmit`) inside JSX interpolated strings — extract them to named `let` bindings before the JSX template
+- Trivial one-line lambdas that just dispatch a message (e.g., `fun _ -> Close \|> dispatch`) may remain inline; multi-line lambdas, lambdas with type annotations, or lambdas accessing `e.target`/`e.currentTarget` must be extracted
 
 ```fsharp
 // Bad - inline anonymous record in JSX string
@@ -708,6 +710,38 @@ JSX.jsx
 // Good - shared styles at module level for reuse across components
 let private flexEndSx = {| alignItems = "flex-end" |}
 let private boldCellSx = {| fontWeight = "bold" |}
+```
+
+```fsharp
+// Bad - non-trivial lambda inlined in JSX string
+JSX.jsx
+    $"""
+    <TextField
+        value={password}
+        onChange={fun (e: Browser.Types.Event) ->
+                      setPassword (e.target?value: string)
+                      setLoginError false}
+    />
+    """
+
+// Good - extracted to a named handler
+let handlePasswordChange (e: Browser.Types.Event) =
+    setPassword (e.target?value: string)
+    setLoginError false
+
+JSX.jsx
+    $"""
+    <TextField
+        value={password}
+        onChange={handlePasswordChange}
+    />
+    """
+
+// Acceptable - trivial dispatch lambda may remain inline
+JSX.jsx
+    $"""
+    <Button onClick={fun _ -> Close |> dispatch}>Close</Button>
+    """
 ```
 
 ## References

--- a/src/Informedica.GenPRES.Client/Views/Patient.fs
+++ b/src/Informedica.GenPRES.Client/Views/Patient.fs
@@ -199,6 +199,10 @@ module Patient =
             | None -> None
 
         let checkBox (name: string) item ev =
+            let handleAccessChange _ =
+                handleChange ()
+                ev |> dispatch
+
             JSX.jsx
                 $"""
             import Checkbox from '@mui/material/Checkbox';
@@ -209,9 +213,7 @@ module Patient =
                 checked={patient
                          |> Option.map (fun p -> p.Access |> List.exists ((=) item))
                          |> Option.defaultValue false}
-                onChange={fun _ ->
-                              handleChange ()
-                              ev |> dispatch} >
+                onChange={handleAccessChange} >
             </Checkbox>
             """
 

--- a/src/Informedica.GenPRES.Client/Views/Prescribe.fs
+++ b/src/Informedica.GenPRES.Client/Views/Prescribe.fs
@@ -173,6 +173,10 @@ module Prescribe =
                     | Resolved tp -> { tp with Scenarios = [| sc |] |> Array.append tp.Scenarios } |> updateOrderPlan
                     | _ -> ()
 
+                let handleEditClick () =
+                    setModalOpen true
+                    onClick sc
+
                 let cellSx =
                     {|
                         paddingTop = 1
@@ -310,9 +314,7 @@ module Prescribe =
                             <Button
                                 size="small"
                                 disabled={isAnythingLoading}
-                                onClick={fun () ->
-                                             setModalOpen true
-                                             onClick sc}
+                                onClick={handleEditClick}
                                 startIcon={Mui.Icons.CalculateIcon}
                             >{Edit |> getTerm "bewerken"}</Button>
                             <Button

--- a/src/Informedica.GenPRES.Client/Views/Settings.fs
+++ b/src/Informedica.GenPRES.Client/Views/Settings.fs
@@ -114,6 +114,10 @@ module Settings =
             if e.key = "Enter" then
                 handleConfirm ()
 
+        let handlePasswordChange (e: Browser.Types.Event) =
+            setPassword (e.target?value: string)
+            setPasswordError false
+
         let handleRefreshLogs = fun _ -> logAnalyzer.ListLogFiles()
 
         let handleFileClick (fileName: string) =
@@ -292,9 +296,7 @@ module Settings =
                         fullWidth={true}
                         variant="outlined"
                         value={password}
-                        onChange={fun (e: Browser.Types.Event) ->
-                                      setPassword (e.target?value: string)
-                                      setPasswordError false}
+                        onChange={handlePasswordChange}
                         error={passwordError}
                         helperText={if passwordError then
                                         Terms.``Invalid password`` |> getTerm "Invalid password"


### PR DESCRIPTION
This pull request improves code clarity and maintainability by enforcing best practices for handling event handlers in F# React components. It updates both the documentation and code to extract non-trivial event handler lambdas from JSX, replacing them with named `let` bindings. This makes the codebase more readable and easier to debug.

**Documentation updates (Coding standards):**
- Updated `.github/instructions/fsharp-coding.instructions.md` to explicitly require that non-trivial lambdas (such as event handlers for `onChange`, `onClick`, `onSubmit`) are not inlined in JSX, but instead extracted to named `let` bindings. Provided clear examples of both good and bad practices. [[1]](diffhunk://#diff-8cd6a5cdb8685487771bbf7ee80ab33ec56b27b82f2e34be749b7d7599145d84R679-R680) [[2]](diffhunk://#diff-8cd6a5cdb8685487771bbf7ee80ab33ec56b27b82f2e34be749b7d7599145d84R715-R746)

**Refactoring event handlers in code:**
- Extracted the `onChange` handler in `Patient.fs`'s `checkBox` function to a named `let handleAccessChange`, improving readability and following the new guideline. [[1]](diffhunk://#diff-5967e6122bcc4a6e202419b991726618680f9f7712e60074b1f11c31f423313dR202-R205) [[2]](diffhunk://#diff-5967e6122bcc4a6e202419b991726618680f9f7712e60074b1f11c31f423313dL212-R216)
- Refactored the `onClick` handler for the edit button in `Prescribe.fs` to a named `let handleEditClick`, removing the inline lambda from JSX. [[1]](diffhunk://#diff-33e8e62dbc22e2f0bee8a46facb93db3a8a519012c535792ee2888b63f4d448cR176-R179) [[2]](diffhunk://#diff-33e8e62dbc22e2f0bee8a46facb93db3a8a519012c535792ee2888b63f4d448cL313-R317)
- Extracted the password field's `onChange` handler in `Settings.fs` to a named `let handlePasswordChange`, replacing the previous inline lambda. [[1]](diffhunk://#diff-4f4beeec7f04eeee31c844649a23eb1d13d1e15fc238f97872a62cdc0ce40233R117-R120) [[2]](diffhunk://#diff-4f4beeec7f04eeee31c844649a23eb1d13d1e15fc238f97872a62cdc0ce40233L295-R299)
