### PR TITLE
chore: updated headings for local scripts

### DIFF
--- a/.husky/scripts/format-staged.sh
+++ b/.husky/scripts/format-staged.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Auto-format staged F# files with Fantomas and re-stage them
 #
 # WARNING: If a developer stages only specific hunks of a file (git add -p),

--- a/benchmark/run.sh
+++ b/benchmark/run.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-sudo dotnet run -c Release $@
+sudo dotnet run -c Release "$@"

--- a/benchmark/run.sh
+++ b/benchmark/run.sh
@@ -1,1 +1,2 @@
+#!/usr/bin/env bash
 sudo dotnet run -c Release $@

--- a/debugTests.sh
+++ b/debugTests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # debugTests - Run all test projects with debug mode
 # Usage: ./debugTests.sh


### PR DESCRIPTION
This pull request standardizes the shebang lines across several shell scripts in the repository to use `/usr/bin/env bash` for improved portability. Additionally, it adds a missing shebang to the `benchmark/run.sh` script.

**Shebang standardization and improvements:**

* Changed the shebang in `.husky/scripts/format-staged.sh` and `debugTests.sh` to use `#!/usr/bin/env bash` for better portability across environments. [[1]](diffhunk://#diff-39220fcefc1adad1b81ae84945b5c4ccf1f73bdd97855eba78e1087298638119L1-R1) [[2]](diffhunk://#diff-3cde361839f7e48b596dfe794bf2e67474322bb0204bb97a15dda500e6a63667L1-R1)
* Added a missing shebang line (`#!/usr/bin/env bash`) to the top of `benchmark/run.sh` to ensure it is executed with the correct shell interpreter.