### PR TITLE
docs: updated sections on use of shell scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,6 +128,20 @@ Join our [Slack workspace](https://genpresworkspace.slack.com) for:
 
 Documented in [./DEVELOPMENT.md](./DEVELOPMENT.md).
 
+## Code Formatting (Pre-Commit Hook)
+
+F# files staged for commit are automatically formatted by [Fantomas](https://github.com/fsprojects/fantomas) via the Husky pre-commit hook. The hook delegates to `.husky/scripts/format-staged.sh`, which receives the staged F# files as positional arguments, runs `dotnet fantomas` on them, and re-stages the formatted output.
+
+> **Caveat**: Fantomas always formats the **full working-tree** version of each file, not just the hunks you staged. If you used `git add -p` to stage only specific hunks, the unstaged hunks of the same file will be silently pulled into the commit. The hook prints a warning when this is about to happen — read it carefully and abort the commit if necessary.
+
+You can also run Fantomas manually on the entire repo:
+
+```bash
+dotnet run Format
+```
+
+For the full list of helper scripts (run modes, Docker, tests, hooks) and what each one does, see [Helper Shell Scripts](DEVELOPMENT.md#helper-shell-scripts) in DEVELOPMENT.md.
+
 ## Markdown Linting
 
 Markdown files are linted automatically as a pre-commit hook using [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2). The hook is **non-blocking** — it prints warnings but never prevents a commit from succeeding.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -88,6 +88,50 @@ The `Run` target starts two long-running processes **in parallel**:
 
 Output from both processes is printed concurrently with colour-coded prefixes (`server:`, `client:`).
 
+### Helper Shell Scripts
+
+The repository ships a set of bash helper scripts at the project root (and in `benchmark/`) that wrap the most common `dotnet run`, `docker build`, `docker run`, and Fantomas hook invocations. They exist so you don't have to remember which `GENPRES_*` environment variables to set for each run mode, or which long Docker command to type.
+
+**Prerequisites:**
+
+- A `.env` file at the repo root (see [Environment Configuration](#environment-configuration)). Most scripts source it via `set -a; source .env; set +a`.
+- A POSIX shell environment with `bash` available on `PATH`. Every script starts with `#!/usr/bin/env bash` and is marked executable.
+- Run the scripts from the **repo root** (e.g. `./debug.sh`), with the single exception of `benchmark/run.sh`, which expects to be invoked from the `benchmark/` directory.
+
+#### Run modes (`dotnet run` wrappers)
+
+Five scripts launch the full stack (`dotnet run`) with different `GENPRES_*` presets. They all source `.env` first and then export overrides — the exported values **win** over anything coming from `.env`. For the full priority order, see [Environment Configuration](#environment-configuration).
+
+| Script | Mode | `GENPRES_LOG` | `GENPRES_PROD` | `GENPRES_DEBUG` | Notes |
+|---|---|---|---|---|---|
+| `debug.sh` | Demo, info logging | `i` | `0` | `1` | Default for local development against the demo dataset. |
+| `debugprod.sh` | Production data, debug logging | `d` | `1` | `1` | Clears `src/Informedica.GenPRES.Server/data/logs/` before starting. Requires a real `GENPRES_URL_ID` in `.env`. |
+| `infoprod.sh` | Production data, info logging | `i` | `1` | `1` | Clears the logs folder. Less verbose than `debugprod.sh`. |
+| `logprod.sh` | Production data, info logging, no debug | `i` | `1` | `0` | Same logging level as `infoprod.sh` but with the debug flag off. |
+| `prod.sh` | Production data, no logging | `0` | `1` | `0` | Mirrors a real production launch locally. |
+
+#### Docker helpers
+
+- `docker-local.sh` — runs `docker build -t halcwb/genpres .`. Builds for the local processor architecture (Apple Silicon → arm64; Intel/Linux → amd64).
+- `docker-amd64.sh` — runs `docker build --platform linux/amd64 -t halcwb/genpres .`. Cross-builds an amd64 image on Apple Silicon for deployment to a typical Linux host.
+- `docker-run.sh` — sources `.env`, validates that both `GENPRES_URL_ID` and `GENPRES_PASSWORD` are set (it fails fast with `:` parameter expansion if either is missing), then runs `docker run -e GENPRES_URL_ID=… -e GENPRES_PASSWORD=… -p 8080:8085 halcwb/genpres`. Use this instead of typing the long `docker run` invocation by hand.
+
+None of these scripts bake `GENPRES_URL_ID` into the image — that constraint is enforced by the `Dockerfile` itself and described in the [Environment Configuration](#environment-configuration) section.
+
+#### Tests
+
+- `debugTests.sh` — sources `.env`, then iterates through eight test projects (`Utils`, `Agents`, `Logging`, `GenUnits`, `GenCore`, `GenSolver`, `GenForm`, `GenOrder`, plus the `Server` test project) and runs each with `dotnet run --project <proj> -- --debug --summary --sequenced`. Exits non-zero on the first failure. This is similar to `dotnet run ServerTests` but with per-project isolation, debug output, and forced sequential execution — useful when chasing flaky tests or test interactions. The project list is hardcoded in the script; if you add a new test project, update both `debugTests.sh` and the `ServerTests` FAKE target.
+
+#### Benchmarks
+
+- `benchmark/run.sh` — runs `sudo dotnet run -c Release "$@"`. Must be invoked from the `benchmark/` directory; it does not `cd` for you. The `sudo` is required because some BenchmarkDotNet diagnostics need elevated privileges. Any extra arguments are forwarded to `dotnet run`.
+
+#### Git hooks
+
+- `.husky/scripts/format-staged.sh` — invoked by the Husky pre-commit hook. It receives staged F# files as positional arguments, warns about partially-staged files (because Fantomas formats the *full working-tree* version of each file, not just the staged hunks), runs `dotnet fantomas` on them, and re-stages the formatted output. You normally never call this directly; it runs automatically on `git commit`. See also the corresponding note in [CONTRIBUTING.md](CONTRIBUTING.md#code-formatting-pre-commit-hook).
+
+If you add a new helper script, document it in this section and make sure its first line is `#!/usr/bin/env bash` so it stays portable across Linux and macOS.
+
 ### CI/CD Pipeline (GitHub Actions)
 
 The CI pipeline is defined in `.github/workflows/build.yml` and runs on every push or pull request to `master` across three operating systems:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -90,47 +90,174 @@ Output from both processes is printed concurrently with colour-coded prefixes (`
 
 ### Helper Shell Scripts
 
-The repository ships a set of bash helper scripts at the project root (and in `benchmark/`) that wrap the most common `dotnet run`, `docker build`, `docker run`, and Fantomas hook invocations. They exist so you don't have to remember which `GENPRES_*` environment variables to set for each run mode, or which long Docker command to type.
+The project uses a small number of bash helper scripts to wrap common `dotnet run`, `docker build`, `docker run`, and Fantomas-hook invocations. They fall into **two categories**:
 
-**Prerequisites:**
+1. **Tracked scripts** — committed to the repo. Available immediately after `git clone`.
+2. **Optional local scripts** — recipes you can paste into your working copy as a personal convenience. They are deliberately **not** committed: the opt-in `.gitignore` strategy (`*` followed by explicit `!path` allow-lines) excludes them so each developer can keep their own variants without polluting the repo.
 
-- A `.env` file at the repo root (see [Environment Configuration](#environment-configuration)). Most scripts source it via `set -a; source .env; set +a`.
-- A POSIX shell environment with `bash` available on `PATH`. Every script starts with `#!/usr/bin/env bash` and is marked executable.
-- Run the scripts from the **repo root** (e.g. `./debug.sh`), with the single exception of `benchmark/run.sh`, which expects to be invoked from the `benchmark/` directory.
+Common conventions for both categories:
 
-#### Run modes (`dotnet run` wrappers)
+- Every script starts with `#!/usr/bin/env bash` so it stays portable across Linux and macOS.
+- After creating a local script, mark it executable: `chmod +x scriptname.sh`.
+- Run from the **repo root** (e.g. `./debug.sh`), with the single exception of `benchmark/run.sh`, which is invoked from the `benchmark/` directory.
+- Scripts that use environment variables source the repo-root `.env` file via `set -a; source .env; set +a`. See [Environment Configuration](#environment-configuration) for what `.env` contains and how the priority order works.
 
-Five scripts launch the full stack (`dotnet run`) with different `GENPRES_*` presets. They all source `.env` first and then export overrides — the exported values **win** over anything coming from `.env`. For the full priority order, see [Environment Configuration](#environment-configuration).
+#### Tracked scripts (in the repo)
 
-| Script | Mode | `GENPRES_LOG` | `GENPRES_PROD` | `GENPRES_DEBUG` | Notes |
+These three scripts ship with the repository and are listed explicitly in `.gitignore` with `!` allow-entries.
+
+- **`debugTests.sh`** — sources `.env`, then iterates through eight test projects (`Utils`, `Agents`, `Logging`, `GenUnits`, `GenCore`, `GenSolver`, `GenForm`, `GenOrder`, plus the `Server` test project) and runs each with `dotnet run --project <proj> -- --debug --summary --sequenced`. Exits non-zero on the first failure. Similar to `dotnet run ServerTests` but with per-project isolation, debug output, and forced sequential execution — useful when chasing flaky tests or test interactions. The project list is hardcoded; if you add a new test project, update both this script and the `ServerTests` FAKE target.
+- **`benchmark/run.sh`** — runs `sudo dotnet run -c Release "$@"`. Must be invoked from the `benchmark/` directory; it does not `cd` for you. The `sudo` is required because some BenchmarkDotNet diagnostics need elevated privileges. Extra arguments are forwarded to `dotnet run`.
+- **`.husky/scripts/format-staged.sh`** — invoked by the Husky pre-commit hook. Receives staged F# files as positional arguments, warns about partially-staged files (Fantomas formats the *full working-tree* version of each file, not just the staged hunks), runs `dotnet fantomas` on them, and re-stages the formatted output. You normally never call this directly; it runs automatically on `git commit`. See also [CONTRIBUTING.md](CONTRIBUTING.md#code-formatting-pre-commit-hook).
+
+#### Optional local scripts (not in the repo — paste into your working copy)
+
+Everything in this subsection is a **template**. Nothing here exists after a fresh `git clone` — `git status` will not show these files even after you create them, because the opt-in `.gitignore` excludes them by design. Save each block at the path indicated, run `chmod +x` once, and you're done.
+
+##### Run-mode wrappers (`dotnet run`)
+
+Five wrappers launch the full stack with different `GENPRES_*` presets. They all source `.env` first and then export overrides — the exported values **win** over anything coming from `.env`. For the full priority order, see [Environment Configuration](#environment-configuration).
+
+| File | Mode | `GENPRES_LOG` | `GENPRES_PROD` | `GENPRES_DEBUG` | Purpose |
 |---|---|---|---|---|---|
 | `debug.sh` | Demo, info logging | `i` | `0` | `1` | Default for local development against the demo dataset. |
-| `debugprod.sh` | Production data, debug logging | `d` | `1` | `1` | Clears `src/Informedica.GenPRES.Server/data/logs/` before starting. Requires a real `GENPRES_URL_ID` in `.env`. |
-| `infoprod.sh` | Production data, info logging | `i` | `1` | `1` | Clears the logs folder. Less verbose than `debugprod.sh`. |
+| `debugprod.sh` | Production data, debug logging | `d` | `1` | `1` | Clears the log folder first. Requires a real `GENPRES_URL_ID` in `.env`. |
+| `infoprod.sh` | Production data, info logging | `i` | `1` | `1` | Clears the log folder first. Less verbose than `debugprod.sh`. |
 | `logprod.sh` | Production data, info logging, no debug | `i` | `1` | `0` | Same logging level as `infoprod.sh` but with the debug flag off. |
 | `prod.sh` | Production data, no logging | `0` | `1` | `0` | Mirrors a real production launch locally. |
 
-#### Docker helpers
+**`debug.sh`** — save at the repo root:
 
-- `docker-local.sh` — runs `docker build -t halcwb/genpres .`. Builds for the local processor architecture (Apple Silicon → arm64; Intel/Linux → amd64).
-- `docker-amd64.sh` — runs `docker build --platform linux/amd64 -t halcwb/genpres .`. Cross-builds an amd64 image on Apple Silicon for deployment to a typical Linux host.
-- `docker-run.sh` — sources `.env`, validates that both `GENPRES_URL_ID` and `GENPRES_PASSWORD` are set (it fails fast with `:` parameter expansion if either is missing), then runs `docker run -e GENPRES_URL_ID=… -e GENPRES_PASSWORD=… -p 8080:8085 halcwb/genpres`. Use this instead of typing the long `docker run` invocation by hand.
+```bash
+#!/usr/bin/env bash
+# Load env vars from .env (GENPRES_URL_ID etc.)
+set -a; source .env; set +a
 
-None of these scripts bake `GENPRES_URL_ID` into the image — that constraint is enforced by the `Dockerfile` itself and described in the [Environment Configuration](#environment-configuration) section.
+# Override for debug mode
+export GENPRES_LOG=i
+export GENPRES_PROD=0
+export GENPRES_DEBUG=1
 
-#### Tests
+dotnet run
+```
 
-- `debugTests.sh` — sources `.env`, then iterates through eight test projects (`Utils`, `Agents`, `Logging`, `GenUnits`, `GenCore`, `GenSolver`, `GenForm`, `GenOrder`, plus the `Server` test project) and runs each with `dotnet run --project <proj> -- --debug --summary --sequenced`. Exits non-zero on the first failure. This is similar to `dotnet run ServerTests` but with per-project isolation, debug output, and forced sequential execution — useful when chasing flaky tests or test interactions. The project list is hardcoded in the script; if you add a new test project, update both `debugTests.sh` and the `ServerTests` FAKE target.
+**`debugprod.sh`** — save at the repo root:
 
-#### Benchmarks
+```bash
+#!/usr/bin/env bash
+# clear ./src/Informedica.GenPRES.Server/data/logs folder
+if [ -d "./src/Informedica.GenPRES.Server/data/logs" ]; then
+    echo "Clearing logs folder..."
+    rm -rf ./src/Informedica.GenPRES.Server/data/logs/*
+    echo "Logs folder cleared."
+else
+    echo "Logs folder does not exist, creating it..."
+    mkdir -p ./src/Informedica.GenPRES.Server/data/logs
+fi
 
-- `benchmark/run.sh` — runs `sudo dotnet run -c Release "$@"`. Must be invoked from the `benchmark/` directory; it does not `cd` for you. The `sudo` is required because some BenchmarkDotNet diagnostics need elevated privileges. Any extra arguments are forwarded to `dotnet run`.
+# Load env vars from .env (GENPRES_URL_ID etc.)
+set -a; source .env; set +a
 
-#### Git hooks
+# Override for debug-production mode
+export GENPRES_LOG="d"
+export GENPRES_PROD=1
+export GENPRES_DEBUG=1
 
-- `.husky/scripts/format-staged.sh` — invoked by the Husky pre-commit hook. It receives staged F# files as positional arguments, warns about partially-staged files (because Fantomas formats the *full working-tree* version of each file, not just the staged hunks), runs `dotnet fantomas` on them, and re-stages the formatted output. You normally never call this directly; it runs automatically on `git commit`. See also the corresponding note in [CONTRIBUTING.md](CONTRIBUTING.md#code-formatting-pre-commit-hook).
+dotnet run
+```
 
-If you add a new helper script, document it in this section and make sure its first line is `#!/usr/bin/env bash` so it stays portable across Linux and macOS.
+**`infoprod.sh`** — save at the repo root. Same shape as `debugprod.sh`, but with `GENPRES_LOG="i"`:
+
+```bash
+#!/usr/bin/env bash
+# clear ./src/Informedica.GenPRES.Server/data/logs folder
+if [ -d "./src/Informedica.GenPRES.Server/data/logs" ]; then
+    echo "Clearing logs folder..."
+    rm -rf ./src/Informedica.GenPRES.Server/data/logs/*
+    echo "Logs folder cleared."
+else
+    echo "Logs folder does not exist, creating it..."
+    mkdir -p ./src/Informedica.GenPRES.Server/data/logs
+fi
+
+# Load env vars from .env (GENPRES_URL_ID etc.)
+set -a; source .env; set +a
+
+# Override for info-production mode
+export GENPRES_LOG="i"
+export GENPRES_PROD=1
+export GENPRES_DEBUG=1
+
+dotnet run
+```
+
+**`logprod.sh`** — save at the repo root:
+
+```bash
+#!/usr/bin/env bash
+# Load env vars from .env (GENPRES_URL_ID etc.)
+set -a; source .env; set +a
+
+# Override for log-production mode
+export GENPRES_LOG=i
+export GENPRES_PROD=1
+export GENPRES_DEBUG=0
+
+dotnet run
+```
+
+**`prod.sh`** — save at the repo root:
+
+```bash
+#!/usr/bin/env bash
+# Load env vars from .env (GENPRES_URL_ID etc.)
+set -a; source .env; set +a
+
+# Override for production mode
+export GENPRES_LOG=0
+export GENPRES_PROD=1
+export GENPRES_DEBUG=0
+
+dotnet run
+```
+
+##### Docker wrappers
+
+None of these wrappers bake `GENPRES_URL_ID` into the image — that constraint is enforced by the `Dockerfile` itself and described in [Environment Configuration](#environment-configuration).
+
+**`docker-local.sh`** — build for the local processor architecture (Apple Silicon → arm64; Intel/Linux → amd64). Save at the repo root:
+
+```bash
+#!/usr/bin/env bash
+docker build -t halcwb/genpres .
+```
+
+**`docker-amd64.sh`** — cross-build an amd64 image on Apple Silicon for deployment to a typical Linux host. Save at the repo root:
+
+```bash
+#!/usr/bin/env bash
+docker build --platform linux/amd64 -t halcwb/genpres .
+```
+
+**`docker-run.sh`** — source `.env`, validate that both `GENPRES_URL_ID` and `GENPRES_PASSWORD` are set (the `:` parameter expansion fails fast if either is missing), then run the container with the right `-e` flags. Save at the repo root:
+
+```bash
+#!/usr/bin/env bash
+# Load env vars from .env (single source of truth — same as prod.sh / debug.sh).
+set -a; source .env; set +a
+
+# Fail fast if .env did not provide the secrets, so we don't start an
+# unauthenticated container that the in-server validateProductionPassword
+# would refuse later anyway.
+: "${GENPRES_URL_ID:?GENPRES_URL_ID is not set in .env}"
+: "${GENPRES_PASSWORD:?GENPRES_PASSWORD is not set in .env}"
+
+docker run -e GENPRES_URL_ID="${GENPRES_URL_ID}" \
+           -e GENPRES_PASSWORD="${GENPRES_PASSWORD}" \
+           -p 8080:8085 halcwb/genpres
+```
+
+If you find yourself wanting to commit one of these local scripts (e.g. because the team agrees it should be standardized), add a `!`-prefixed allow-line for the file to `.gitignore` in the same PR — otherwise the opt-in strategy will silently keep it untracked.
 
 ### CI/CD Pipeline (GitHub Actions)
 

--- a/README.md
+++ b/README.md
@@ -77,12 +77,15 @@ docker build -t [USERNAME]/genpres .
 ```
 
 **Note**: this will build using the local processor architecture.
+Convenience wrapper: `./docker-local.sh`.
 
 To build on macOS (M1/M2/Apple Silicon) and still want to publish for AMD64 (x86_64):
 
 ```bash
 docker build --platform linux/amd64 -t [USERNAME]/genpres .
 ```
+
+Convenience wrapper: `./docker-amd64.sh`.
 
 To run the Docker image locally, inject `GENPRES_URL_ID` and (for admin
 operations) `GENPRES_PASSWORD` at runtime:
@@ -94,9 +97,17 @@ docker run -it -p 8080:8085 \
   [USERNAME]/genpres
 ```
 
+Convenience wrapper: `./docker-run.sh` — sources `.env`, validates that
+both `GENPRES_URL_ID` and `GENPRES_PASSWORD` are set, and runs the
+container with the right flags.
+
 For production deployments use a Docker / Kubernetes secret rather than
 passing the value on the command line. Open a browser to
 <http://localhost:8080> to view the site.
+
+See [Helper Shell Scripts](DEVELOPMENT.md#helper-shell-scripts) in
+DEVELOPMENT.md for the full list of local development and deployment
+scripts (debug/prod run modes, Docker, tests, hooks).
 
 ## User Documentation
 

--- a/README.md
+++ b/README.md
@@ -77,15 +77,12 @@ docker build -t [USERNAME]/genpres .
 ```
 
 **Note**: this will build using the local processor architecture.
-Convenience wrapper: `./docker-local.sh`.
 
 To build on macOS (M1/M2/Apple Silicon) and still want to publish for AMD64 (x86_64):
 
 ```bash
 docker build --platform linux/amd64 -t [USERNAME]/genpres .
 ```
-
-Convenience wrapper: `./docker-amd64.sh`.
 
 To run the Docker image locally, inject `GENPRES_URL_ID` and (for admin
 operations) `GENPRES_PASSWORD` at runtime:
@@ -97,17 +94,17 @@ docker run -it -p 8080:8085 \
   [USERNAME]/genpres
 ```
 
-Convenience wrapper: `./docker-run.sh` — sources `.env`, validates that
-both `GENPRES_URL_ID` and `GENPRES_PASSWORD` are set, and runs the
-container with the right flags.
-
 For production deployments use a Docker / Kubernetes secret rather than
 passing the value on the command line. Open a browser to
 <http://localhost:8080> to view the site.
 
-See [Helper Shell Scripts](DEVELOPMENT.md#helper-shell-scripts) in
-DEVELOPMENT.md for the full list of local development and deployment
-scripts (debug/prod run modes, Docker, tests, hooks).
+> **Tip**: If you find yourself typing these commands often, see
+> [Helper Shell Scripts](DEVELOPMENT.md#helper-shell-scripts) in
+> DEVELOPMENT.md for ready-to-paste templates of `docker-local.sh`,
+> `docker-amd64.sh`, and `docker-run.sh`. These are *local-only*
+> convenience wrappers — they are not committed to the repo, and the
+> opt-in `.gitignore` strategy deliberately keeps them untracked so
+> each developer can customize them.
 
 ## User Documentation
 


### PR DESCRIPTION
This pull request improves the developer experience by adding comprehensive documentation for the repository's helper shell scripts and pre-commit code formatting, and by making it easier to use Docker and other local development tools. The changes clarify how to use provided scripts for common tasks, document caveats with automated code formatting, and add references to these scripts in the main documentation.

**Documentation of helper scripts and automation:**

* Added a detailed "Helper Shell Scripts" section to `DEVELOPMENT.md`, documenting all provided bash scripts for running, testing, building Docker images, and formatting code. This includes usage instructions, prerequisites, and a table of run modes for local development.
* Documented the Fantomas pre-commit formatting hook in `CONTRIBUTING.md`, including a warning about the behavior with partially-staged files and instructions for running formatting manually.

**Improved Docker workflow documentation:**

* Updated `README.md` to reference new convenience wrapper scripts for building and running Docker images (`docker-local.sh`, `docker-amd64.sh`, `docker-run.sh`), making these workflows more accessible. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R80-R89) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R100-R111)
* Added cross-references in `README.md` to the new helper scripts documentation in `DEVELOPMENT.md` for easier discoverability.