### PR TITLE
chore: bumb fstoolkit version

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -29,7 +29,7 @@ nuget Fake.IO.FileSystem 6.1.3
 nuget FSharp.Data
 nuget HtmlAgilityPack 1.12.3
 nuget FParsec
-nuget FsToolkit.ErrorHandling 5.1.0
+nuget FsToolkit.ErrorHandling 5.2.0
 nuget MathNet.Numerics.FSharp
 nuget Microsoft.Net.Test.Sdk 18.3.0
 nuget Validus

--- a/paket.lock
+++ b/paket.lock
@@ -227,7 +227,7 @@ NUGET
       System.Text.Json (>= 6.0.10)
     FSharpPlus (1.7)
       FSharp.Core (>= 6.0.6)
-    FsToolkit.ErrorHandling (5.1)
+    FsToolkit.ErrorHandling (5.2)
       FSharp.Core (>= 9.0.300)
     Giraffe (8.2)
       FSharp.Core (>= 6.0)


### PR DESCRIPTION
This pull request updates a dependency version in the `paket.dependencies` file. The only change is upgrading `FsToolkit.ErrorHandling` from version 5.1.0 to 5.2.0.