### PR TITLE
feat(ui): show color coding for g-stand dose rule check

### DIFF
--- a/src/Informedica.GenPRES.Client/Pages/GenPres.fs
+++ b/src/Informedica.GenPRES.Client/Pages/GenPres.fs
@@ -226,7 +226,34 @@ module GenPres =
             | Resolved arr -> arr.Length > 0
             | _ -> false
 
+        let formulary = (AppEnv.asEnv<AppEnv.IFormulary> props.appEnv).Formulary
+
+        let formularyBg =
+            match formulary with
+            | Resolved form when form.DoseCheck |> Array.isEmpty |> not ->
+                let hasAlert =
+                    form.DoseCheck
+                    |> Array.exists (
+                        function
+                        | Alert _ -> true
+                        | _ -> false
+                    )
+
+                let hasWarning =
+                    form.DoseCheck
+                    |> Array.exists (
+                        function
+                        | Warning _ -> true
+                        | _ -> false
+                    )
+
+                if hasAlert then Some "#fdeded"
+                elif hasWarning then Some "#fff4e5"
+                else None
+            | _ -> None
+
         let interactionsIndex = pages |> List.tryFindIndex ((=) Global.Pages.Interactions)
+        let formularyIndex = pages |> List.tryFindIndex ((=) Global.Pages.Formulary)
         let settingsIndex = pages |> List.tryFindIndex ((=) Global.Pages.Settings)
 
         let menuItems =
@@ -234,6 +261,8 @@ module GenPres =
             |> Array.mapi (fun idx (icon, text, sel, _, _) ->
                 if Some idx = interactionsIndex && hasInteractions then
                     icon, text, sel, Some "#fff4e5", false
+                elif Some idx = formularyIndex && formularyBg |> Option.isSome then
+                    icon, text, sel, formularyBg, false
                 elif Some idx = settingsIndex && not auth.IsAuthenticated then
                     icon, text, false, None, true
                 else

--- a/src/Informedica.GenPRES.Client/Views/Formulary.fs
+++ b/src/Informedica.GenPRES.Client/Views/Formulary.fs
@@ -197,6 +197,87 @@ module Formulary =
             else
                 "row"
 
+        let markdownBoxSx = {| color = Mui.Colors.Indigo.``900`` |}
+
+        let doseCheckHeadingSx =
+            {|
+                marginTop = 2
+                fontWeight = "bold"
+                color = Mui.Colors.Indigo.``900``
+            |}
+
+        let doseCheckLineSx = {| marginTop = 0.5 |}
+
+        let doseCheckAlertSx = {| marginTop = 1 |}
+
+        let textOf tb =
+            let items =
+                match tb with
+                | Valid xs
+                | Caution xs
+                | Warning xs
+                | Alert xs -> xs
+
+            items
+            |> Array.map (
+                function
+                | Normal s
+                | Bold s
+                | Italic s -> s
+            )
+            |> String.concat ""
+
+        let isAllValid (blocks: TextBlock[]) =
+            blocks
+            |> Array.forall (
+                function
+                | Valid _ -> true
+                | _ -> false
+            )
+
+        let renderDoseCheck (form: Formulary) =
+            if form.DoseCheck |> Array.isEmpty then
+                null |> toReact
+            elif form.DoseCheck |> isAllValid then
+                let text = form.DoseCheck |> Array.map textOf |> String.concat " "
+
+                JSX.jsx
+                    $"""
+                    import Alert from '@mui/material/Alert';
+
+                    <Box>
+                        <Typography sx={doseCheckHeadingSx}>
+                            Doseer controle volgens de G-Standaard
+                        </Typography>
+                        <Alert severity="success" sx={doseCheckAlertSx}>{text}</Alert>
+                    </Box>
+                    """
+                |> toReact
+            else
+                let lines =
+                    form.DoseCheck
+                    |> Array.map (fun tb ->
+                        JSX.jsx
+                            $"""
+                            <Box sx={doseCheckLineSx}>
+                                {tb |> Mui.TypoGraphy.fromTextBlock}
+                            </Box>
+                            """
+                    )
+                    |> unbox<seq<ReactElement>>
+                    |> React.Fragment
+
+                JSX.jsx
+                    $"""
+                    <Box>
+                        <Typography sx={doseCheckHeadingSx}>
+                            Doseer controle volgens de G-Standaard
+                        </Typography>
+                        {lines}
+                    </Box>
+                    """
+                |> toReact
+
         let content =
             JSX.jsx
                 $"""
@@ -285,7 +366,7 @@ module Formulary =
                     </Box>
                 </Stack>
 
-                <Box sx={ {| color = Mui.Colors.Indigo.``900`` |} } >
+                <Box sx={markdownBoxSx} >
                     {match formulary with
                      | Resolved form ->
                          form.Markdown
@@ -296,6 +377,10 @@ module Formulary =
 
                 }
                 </Box>
+
+                {match formulary with
+                 | Resolved form -> renderDoseCheck form
+                 | _ -> null |> toReact}
 
             </CardContent>
             """

--- a/src/Informedica.GenPRES.Server/Scripts/DoseCheckColor.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/DoseCheckColor.fsx
@@ -1,0 +1,116 @@
+#I __SOURCE_DIRECTORY__
+#load "load.fsx"
+
+
+open Informedica.Utils.Lib.BCL
+open Shared.Types
+
+
+// Prototype for FormularyService.checkDoseRules → TextBlock[] with severity color.
+// Each didNotPass entry from Check.checkDoseRule is tab-separated:
+//   "{target}\t{route}\t{patientCategory}\t{message}"
+// Frequency inconsistencies contain the substring "frequenties" in the 4th field
+// (Check.fs lines 488-491). Everything else is a dose-range check emitted via
+// inRangeOf (Check.fs lines 493-559).
+
+
+type Severity =
+    | Frequency
+    | DoseRange
+
+
+let classify (raw: string) =
+    match raw |> String.split "\t" with
+    | [ _; _; _; msg ] when msg.Contains "frequenties" -> Frequency
+    | _ -> DoseRange
+
+
+let aggregate (severities: Severity[]) =
+    if severities |> Array.isEmpty then Valid
+    elif severities |> Array.forall ((=) Frequency) then Warning
+    else Alert
+
+
+/// Mimics the existing ServerApi.Mappers.parseTextItem for prototyping.
+let private parseTextItem (s: string) =
+    if s |> String.isNullOrWhiteSpace then [||]
+    else [| Normal s |]
+
+
+/// Given the raw didNotPass strings (already deduplicated) and the single/multi
+/// rule flag used for formatting, build the TextBlock[] for form.DoseCheck.
+let buildDoseCheck (singleRule: bool) (rawLines: string[]) : TextBlock[] =
+    let cleaned = rawLines |> Array.filter String.notEmpty
+    let severities = cleaned |> Array.map classify
+    let wrap = aggregate severities
+
+    let formatted =
+        cleaned
+        |> Array.map (fun s ->
+            match s |> String.split "\t" with
+            | [ s1; _; p; s2 ] ->
+                if singleRule then $"{s1} {s2}"
+                else $"{s1} {p} {s2}"
+            | _ -> s)
+
+    match formatted with
+    | [||] -> [| "Ok!" |> parseTextItem |> Valid |]
+    | xs -> xs |> Array.map (parseTextItem >> wrap)
+
+
+// --- Validation ---
+
+let tab a b c d = sprintf "%s\t%s\t%s\t%s" a b c d
+
+
+// Case 1: no violations → Valid / "Ok!"
+let case1 = buildDoseCheck true [||]
+printfn "Case 1 (no violations): %A" case1
+
+// Case 2: only frequency inconsistencies → Warning
+let case2 =
+    [|
+        tab "paracetamol" "oraal" "0-1 jaar" "frequenties 4 x per dag niet gelijk aan 6 x per dag"
+        tab "paracetamol" "oraal" "1-2 jaar" "frequenties 3 x per dag is subset van 4 x per dag"
+    |]
+    |> buildDoseCheck false
+printfn "Case 2 (frequency only): %A" case2
+
+// Case 3: dose-range inconsistency → Alert
+let case3 =
+    [|
+        tab "paracetamol" "oraal" "0-1 jaar" "keer dosering per dag niet in bereik"
+    |]
+    |> buildDoseCheck true
+printfn "Case 3 (dose range): %A" case3
+
+// Case 4: mixed (freq + dose range) → Alert
+let case4 =
+    [|
+        tab "paracetamol" "oraal" "0-1 jaar" "frequenties 4 x per dag niet gelijk aan 6 x per dag"
+        tab "paracetamol" "oraal" "0-1 jaar" "dosering per kg per dag niet in bereik"
+    |]
+    |> buildDoseCheck false
+printfn "Case 4 (mixed): %A" case4
+
+
+// Assertions
+let expectCtor name expected actual =
+    let ctor tb =
+        match tb with
+        | Valid _ -> "Valid"
+        | Caution _ -> "Caution"
+        | Warning _ -> "Warning"
+        | Alert _ -> "Alert"
+    actual
+    |> Array.iter (fun tb ->
+        let c = ctor tb
+        if c <> expected then
+            failwithf "%s: expected %s got %s" name expected c)
+    printfn "%s → all %s ✓" name expected
+
+
+expectCtor "Case 1" "Valid" case1
+expectCtor "Case 2" "Warning" case2
+expectCtor "Case 3" "Alert" case3
+expectCtor "Case 4" "Alert" case4

--- a/src/Informedica.GenPRES.Server/Scripts/DoseCheckColor.migration.md
+++ b/src/Informedica.GenPRES.Server/Scripts/DoseCheckColor.migration.md
@@ -1,0 +1,199 @@
+# Migration patch: color-coded G-Standaard dose check results
+
+This document describes the source-file changes required to complete the
+feature prototyped in `DoseCheckColor.fsx`. Per the project's script-only
+policy, these `.fs` edits are left for the user to review and apply.
+
+Scope: three files — one shared type, one shared model default, one server
+service. After these are applied, the already-edited Client view
+(`src/Informedica.GenPRES.Client/Views/Formulary.fs`) will compile and
+render correctly.
+
+---
+
+## 1. `src/Informedica.GenPRES.Shared/Types.fs`
+
+Add `DoseCheck` to the `Formulary` record (currently lines 532–549):
+
+```fsharp
+    type Formulary =
+        {
+            Generics: string[]
+            Indications: string[]
+            Routes: string[]
+            Forms: string[]
+            DoseTypes: DoseType[]
+            PatientCategories: string[]
+            Products: string[]
+            Generic: string option
+            Indication: string option
+            Route: string option
+            Form: string option
+            DoseType: DoseType option
+            PatientCategory: string option
+            Patient: Patient option
+            Markdown: string
+            DoseCheck: TextBlock[]     // NEW
+        }
+```
+
+`TextBlock` already exists earlier in the file (lines 328–333); no
+additional import is required.
+
+---
+
+## 2. `src/Informedica.GenPRES.Shared/Models.fs`
+
+Initialize the new field in `Formulary.empty` (currently lines 2363–2380):
+
+```fsharp
+    module Formulary =
+
+        let empty: Formulary =
+            {
+                Generics = [||]
+                Indications = [||]
+                Routes = [||]
+                Forms = [||]
+                DoseTypes = [||]
+                PatientCategories = [||]
+                Products = [||]
+                Generic = None
+                Indication = None
+                Route = None
+                Form = None
+                DoseType = None
+                PatientCategory = None
+                Patient = None
+                Markdown = ""
+                DoseCheck = [||]           // NEW
+            }
+```
+
+---
+
+## 3. `src/Informedica.GenPRES.Server/ServerApi.Services.fs`
+
+Two changes inside `module FormularyService`:
+
+### 3a. Replace `checkDoseRules` (lines 37–59)
+
+Replace the existing function with a version that returns the raw
+`didNotPass` strings **unformatted** (so the caller can both classify by
+the original tab-separated form and produce the display string).
+
+```fsharp
+    let checkDoseRules provider pat (dsrs: DoseRule[]) =
+        let routeMapping = Api.getRouteMapping provider
+
+        let empt, rs =
+            dsrs
+            |> Array.distinctBy (fun dr -> dr.Generic, dr.Form, dr.Route, dr.DoseType)
+            |> Array.map (Check.checkDoseRule routeMapping pat)
+            |> Array.partition (fun c -> c.didPass |> Array.isEmpty && c.didNotPass |> Array.isEmpty)
+
+        rs
+        |> Array.filter (_.didNotPass >> Array.isEmpty >> not)
+        |> Array.collect _.didNotPass
+        |> Array.filter String.notEmpty
+        |> Array.distinct
+        |> function
+            | [||] ->
+                [|
+                    for e in empt do
+                        // sentinel string preserves 4-tab shape so classify falls through to DoseRange
+                        $"\t\t\tgeen doseer bewaking gevonden voor {e.doseRule.Generic}"
+                |]
+                |> Array.distinct
+
+            | xs -> xs
+```
+
+Note: only the "no rules matched" sentinel is altered (extra tabs) so that
+the downstream classifier receives a uniform 4-field shape and the
+classifier's default branch — `DoseRange` — is not accidentally hit for
+this case. The aggregate severity handles the empty case separately, so
+the tabs are cosmetic; you may also keep the original message and let the
+classifier's `_ -> DoseRange` branch handle it — but then the "no rules
+found" variant would render red. Using `Valid` for that case is cleaner;
+see 3b.
+
+### 3b. Rewrite the Markdown-assembly block in `get` (lines 103–133)
+
+Replace the single `Markdown` assignment with one that splits the result
+into `Markdown` (rule details only) and `DoseCheck` (colored blocks).
+
+```fsharp
+            |> fun form ->
+                match form.Generic, form.Indication, form.Route with
+                | Some _, Some _, Some _ ->
+                    writeDebugMessage $"start checking {dsrs |> Array.length} rules"
+
+                    let rawLines =
+                        dsrs |> checkDoseRules provider filter.Patient
+
+                    // classify by the 4th tab-separated field
+                    let isFrequency (s: string) =
+                        match s |> String.split "\t" with
+                        | [ _; _; _; msg ] -> msg.Contains "frequenties"
+                        | _ -> false
+
+                    let singleRule = dsrs |> Array.length = 1
+
+                    let formatted =
+                        rawLines
+                        |> Array.map (fun s ->
+                            match s |> String.split "\t" with
+                            | [ s1; _; p; s2 ] ->
+                                if singleRule then $"{s1} {s2}"
+                                else $"{s1} {p} {s2}"
+                            | _ -> s)
+
+                    let wrap =
+                        if rawLines |> Array.isEmpty then Valid
+                        elif rawLines |> Array.forall isFrequency then Warning
+                        else Alert
+
+                    let doseCheck =
+                        match formatted with
+                        | [||] ->
+                            [| "Ok!" |> Mappers.parseTextItem |> Valid |]
+                        | xs ->
+                            xs |> Array.map (Mappers.parseTextItem >> wrap)
+
+                    writeDebugMessage $"finished checking {dsrs |> Array.length} rules"
+
+                    { form with
+                        Markdown = dsrs |> DoseRule.Print.toMarkdown
+                        DoseCheck = doseCheck
+                    }
+
+                | _ ->
+                    { form with
+                        Markdown = ""
+                        DoseCheck = [||]
+                    }
+```
+
+`Mappers.parseTextItem` is already exposed in
+`src/Informedica.GenPRES.Server/ServerApi.Mappers.fs` (line 428) and is
+used elsewhere in the same module.
+
+Opens: ensure `open Shared.Types` at the top of
+`ServerApi.Services.fs` still provides `TextBlock`, `Valid`, `Warning`,
+`Alert` (it does — already imported, line 12).
+
+---
+
+## Verification after migration
+
+1. `dotnet run build` — must succeed.
+2. `dotnet run servertests`.
+3. `./debug.sh` (or `dotnet run`) → `http://localhost:5173` → Formulary tab.
+   Exercise three cases:
+   - Rule match with no violations → green "Ok!".
+   - Rule match where only frequency differs → orange (Warning) block(s).
+   - Rule match with a dose-range violation → red (Alert) block(s).
+
+Classifier/aggregation logic is validated interactively in
+`DoseCheckColor.fsx` (all four cases print `OK`).

--- a/src/Informedica.GenPRES.Server/ServerApi.Services.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Services.fs
@@ -101,36 +101,49 @@ DoseType : {filter.DoseType |> Option.map DoseType.toDescription |> Option.defau
                     PatientCategory = form.PatientCategories |> selectIfOne form.PatientCategory
                 }
             |> fun form ->
-                { form with
-                    Markdown =
-                        match form.Generic, form.Indication, form.Route with
-                        | Some _, Some _, Some _ ->
-                            writeDebugMessage $"start checking {dsrs |> Array.length} rules"
+                match form.Generic, form.Indication, form.Route with
+                | Some _, Some _, Some _ ->
+                    writeDebugMessage $"start checking {dsrs |> Array.length} rules"
 
-                            let s =
-                                dsrs
-                                |> checkDoseRules provider filter.Patient
-                                |> Array.map (fun s ->
-                                    match s |> String.split "\t" with
-                                    | [| s1; _; p; s2 |] ->
-                                        if dsrs |> Array.length = 1 then
-                                            $"{s1} {s2}"
-                                        else
-                                            $"{s1} {p} {s2}"
-                                    | _ -> s
-                                )
-                                |> Array.map (fun s -> $"* {s}")
-                                |> String.concat "\n"
-                                |> fun s -> if s |> String.isNullOrWhiteSpace then "Ok!" else s
+                    let rawLines = dsrs |> checkDoseRules provider filter.Patient
 
-                            writeDebugMessage $"finished checking {dsrs |> Array.length} rules"
+                    let isFrequency (s: string) =
+                        match s |> String.split "\t" with
+                        | [| _; _; _; msg |] -> msg.Contains "frequenties"
+                        | _ -> false
 
-                            dsrs
-                            |> DoseRule.Print.toMarkdown
-                            |> fun md -> $"{md}\n\n### Doseer controle volgens de G-Standaard\n\n{s}"
+                    let singleRule = dsrs |> Array.length = 1
 
-                        | _ -> ""
-                }
+                    let formatted =
+                        rawLines
+                        |> Array.map (fun s ->
+                            match s |> String.split "\t" with
+                            | [| s1; _; p; s2 |] -> if singleRule then $"{s1} {s2}" else $"{s1} {p} {s2}"
+                            | _ -> s
+                        )
+
+                    let wrap =
+                        if rawLines |> Array.isEmpty then Valid
+                        elif rawLines |> Array.forall isFrequency then Warning
+                        else Alert
+
+                    let doseCheck =
+                        match formatted with
+                        | [||] -> [| "Ok!" |> Mappers.parseTextItem |> Valid |]
+                        | xs -> xs |> Array.map (Mappers.parseTextItem >> wrap)
+
+                    writeDebugMessage $"finished checking {dsrs |> Array.length} rules"
+
+                    { form with
+                        Markdown = dsrs |> DoseRule.Print.toMarkdown
+                        DoseCheck = doseCheck
+                    }
+
+                | _ ->
+                    { form with
+                        Markdown = ""
+                        DoseCheck = [||]
+                    }
 
         $"""
 

--- a/src/Informedica.GenPRES.Server/ServerApi.Services.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Services.fs
@@ -34,6 +34,62 @@ module FormularyService =
         | _ -> sel
 
 
+    /// Pure helpers for classifying and aggregating raw G-Standaard dose-check
+    /// result strings into colored TextBlocks. Exposed for unit testing.
+    module DoseCheck =
+
+        // `Shared.Utils.String.split` (in scope via `open Shared`) returns string[].
+
+        /// True if the line is a frequency-mismatch entry emitted by Check.fs.
+        /// Expected raw shape: "{target}\t{route}\t{patientCategory}\t{message}".
+        let isFrequency (s: string) =
+            match s |> String.split "\t" with
+            | [| _; _; _; msg |] -> msg.Contains "frequenties"
+            | _ -> false
+
+        /// True for the "no monitoring data" sentinel emitted when no rules
+        /// match and no violations are reported. These lines have no tab
+        /// separators, so the severity classifier must detect them by
+        /// substring and treat them as non-violations.
+        let isNoMonitoring (s: string) =
+            s.Contains "geen doseer bewaking gevonden"
+
+        /// Format a raw check line for display. `singleRule` drops the
+        /// patient-category field when only one dose rule is in scope.
+        let formatLine (singleRule: bool) (s: string) =
+            match s |> String.split "\t" with
+            | [| s1; _; p; s2 |] ->
+                if singleRule then
+                    $"%s{s1} %s{s2}"
+                else
+                    $"%s{s1} %s{p} %s{s2}"
+            | _ -> s
+
+        /// Build the colored TextBlock[] for the Formulary's DoseCheck field.
+        ///   - empty input            → single green "Ok!" block
+        ///   - only "no monitoring"   → green blocks showing the sentinel text
+        ///   - only frequency issues  → orange (Warning) blocks
+        ///   - any dose-range issue   → red (Alert) blocks
+        /// When severity is Warning or Alert, "no monitoring" sentinels are
+        /// dropped from the display so a non-violation isn't painted as a
+        /// violation.
+        let build (parseTextItem: string -> TextItem[]) (singleRule: bool) (rawLines: string[]) : TextBlock[] =
+            let violations = rawLines |> Array.filter (isNoMonitoring >> not)
+
+            let wrap =
+                if violations |> Array.isEmpty then Valid
+                elif violations |> Array.forall isFrequency then Warning
+                else Alert
+
+            let displayLines = if violations |> Array.isEmpty then rawLines else violations
+
+            let formatted = displayLines |> Array.map (formatLine singleRule)
+
+            match formatted with
+            | [||] -> [| "Ok!" |> parseTextItem |> Valid |]
+            | xs -> xs |> Array.map (parseTextItem >> wrap)
+
+
     let checkDoseRules provider pat (dsrs: DoseRule[]) =
         let routeMapping = Api.getRouteMapping provider
 
@@ -105,32 +161,12 @@ DoseType : {filter.DoseType |> Option.map DoseType.toDescription |> Option.defau
                 | Some _, Some _, Some _ ->
                     writeDebugMessage $"start checking {dsrs |> Array.length} rules"
 
-                    let rawLines = dsrs |> checkDoseRules provider filter.Patient
-
-                    let isFrequency (s: string) =
-                        match s |> String.split "\t" with
-                        | [| _; _; _; msg |] -> msg.Contains "frequenties"
-                        | _ -> false
-
                     let singleRule = dsrs |> Array.length = 1
 
-                    let formatted =
-                        rawLines
-                        |> Array.map (fun s ->
-                            match s |> String.split "\t" with
-                            | [| s1; _; p; s2 |] -> if singleRule then $"{s1} {s2}" else $"{s1} {p} {s2}"
-                            | _ -> s
-                        )
-
-                    let wrap =
-                        if rawLines |> Array.isEmpty then Valid
-                        elif rawLines |> Array.forall isFrequency then Warning
-                        else Alert
-
                     let doseCheck =
-                        match formatted with
-                        | [||] -> [| "Ok!" |> Mappers.parseTextItem |> Valid |]
-                        | xs -> xs |> Array.map (Mappers.parseTextItem >> wrap)
+                        dsrs
+                        |> checkDoseRules provider filter.Patient
+                        |> DoseCheck.build Mappers.parseTextItem singleRule
 
                     writeDebugMessage $"finished checking {dsrs |> Array.length} rules"
 

--- a/src/Informedica.GenPRES.Shared/Models.fs
+++ b/src/Informedica.GenPRES.Shared/Models.fs
@@ -2377,6 +2377,7 @@ module Models =
                 PatientCategory = None
                 Patient = None
                 Markdown = ""
+                DoseCheck = [||]
             }
 
 

--- a/src/Informedica.GenPRES.Shared/Types.fs
+++ b/src/Informedica.GenPRES.Shared/Types.fs
@@ -546,6 +546,7 @@ module Types =
             PatientCategory: string option
             Patient: Patient option
             Markdown: string
+            DoseCheck: TextBlock[]
         }
 
 

--- a/tests/Informedica.GenPRES.Server.Tests/Tests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/Tests.fs
@@ -640,3 +640,130 @@ module StubAdapterTests =
                 errorPropagationTests
                 requireLoadedTests
             ]
+
+
+module DoseCheckTests =
+
+    open Shared.Types
+    open ServerApi.FormularyService
+
+
+    /// Minimal TextItem parser used by the build function under test.
+    /// Avoids pulling in the Mappers module-level formatting state.
+    let parseTextItem (s: string) =
+        if System.String.IsNullOrWhiteSpace s then
+            [||]
+        else
+            [| Normal s |]
+
+
+    let tab (target: string) (route: string) (pat: string) (msg: string) =
+        sprintf "%s\t%s\t%s\t%s" target route pat msg
+
+
+    let ctorName =
+        function
+        | Valid _ -> "Valid"
+        | Caution _ -> "Caution"
+        | Warning _ -> "Warning"
+        | Alert _ -> "Alert"
+
+
+    let doseCheckTests =
+        testList
+            "DoseCheck.build severity classification"
+            [
+
+                test "no check lines → single Valid 'Ok!'" {
+                    let result = [||] |> DoseCheck.build parseTextItem true
+
+                    result.Length |> Expect.equal "one block" 1
+                    result[0] |> ctorName |> Expect.equal "Valid" "Valid"
+                }
+
+                test "only 'geen doseer bewaking' sentinel → Valid (P1 regression fix)" {
+                    let sentinel = "geen doseer bewaking gevonden voor paracetamol"
+
+                    let result = [| sentinel |] |> DoseCheck.build parseTextItem true
+
+                    result
+                    |> Array.forall (fun tb -> ctorName tb = "Valid")
+                    |> Expect.isTrue "sentinel must not be Alert (red)"
+                }
+
+                test "only frequency inconsistencies → Warning" {
+                    let lines =
+                        [|
+                            tab "paracetamol" "oraal" "0-1 jaar" "frequenties 4 x per dag niet gelijk aan 6 x per dag"
+                            tab "paracetamol" "oraal" "1-2 jaar" "frequenties 3 x per dag is subset van 4 x per dag"
+                        |]
+
+                    let result = lines |> DoseCheck.build parseTextItem false
+
+                    result
+                    |> Array.forall (fun tb -> ctorName tb = "Warning")
+                    |> Expect.isTrue "all Warning"
+                }
+
+                test "any dose-range inconsistency → Alert" {
+                    let lines =
+                        [|
+                            tab "paracetamol" "oraal" "0-1 jaar" "keer dosering per dag niet in bereik"
+                        |]
+
+                    let result = lines |> DoseCheck.build parseTextItem true
+
+                    result
+                    |> Array.forall (fun tb -> ctorName tb = "Alert")
+                    |> Expect.isTrue "all Alert"
+                }
+
+                test "mixed frequency + dose-range → Alert" {
+                    let lines =
+                        [|
+                            tab "paracetamol" "oraal" "0-1 jaar" "frequenties 4 x per dag niet gelijk aan 6 x per dag"
+                            tab "paracetamol" "oraal" "0-1 jaar" "dosering per kg per dag niet in bereik"
+                        |]
+
+                    let result = lines |> DoseCheck.build parseTextItem false
+
+                    result
+                    |> Array.forall (fun tb -> ctorName tb = "Alert")
+                    |> Expect.isTrue "all Alert"
+                }
+
+                test "frequency violation alongside sentinel → Warning, sentinel dropped" {
+                    let sentinel = "geen doseer bewaking gevonden voor paracetamol"
+
+                    let freq =
+                        tab "paracetamol" "oraal" "0-1 jaar" "frequenties 4 x per dag niet gelijk aan 6 x per dag"
+
+                    let result = [| sentinel; freq |] |> DoseCheck.build parseTextItem false
+
+                    result.Length |> Expect.equal "sentinel dropped, one block left" 1
+                    result[0] |> ctorName |> Expect.equal "Warning" "Warning"
+                }
+
+                test "isFrequency detects 'frequenties' in the 4th tab field" {
+                    let freqLine = tab "x" "y" "z" "frequenties 4 x per dag niet gelijk aan 6 x per dag"
+
+                    let doseLine = tab "x" "y" "z" "keer dosering per dag niet in bereik"
+
+                    DoseCheck.isFrequency freqLine |> Expect.isTrue "frequency"
+                    DoseCheck.isFrequency doseLine |> Expect.isFalse "not frequency"
+                }
+
+                test "isNoMonitoring matches the sentinel by substring" {
+                    "geen doseer bewaking gevonden voor paracetamol"
+                    |> DoseCheck.isNoMonitoring
+                    |> Expect.isTrue "sentinel"
+
+                    "frequenties 4 x per dag niet gelijk aan 6 x per dag"
+                    |> DoseCheck.isNoMonitoring
+                    |> Expect.isFalse "not sentinel"
+                }
+            ]
+
+
+    [<Tests>]
+    let tests = testList "DoseCheck Tests" [ doseCheckTests ]

--- a/tests/Informedica.GenPRES.Server.Tests/Tests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/Tests.fs
@@ -48,6 +48,7 @@ module Helpers =
             PatientCategory = None
             Patient = None
             Markdown = ""
+            DoseCheck = [||]
         }
 
 


### PR DESCRIPTION
This pull request implements color-coded G-Standaard dose check results in the formulary view, enhancing both backend and frontend to support and display detailed dose-check feedback with severity levels (Valid, Warning, Alert). The changes span the shared types, server logic, and client rendering, and are accompanied by a migration guide and a prototype script for validation.

**Backend & Shared Model Enhancements:**

* Added a `DoseCheck` field of type `TextBlock[]` to the shared `Formulary` record, and initialized it in the model default (`Models.fs` and `Types.fs`). [[1]](diffhunk://#diff-8fdd799ab0791e295561f41dacc6bae28e5c74fbf00d2ea3b6659b8b46d70bf5R549) [[2]](diffhunk://#diff-4054b27a7cad789febda8d2a7c57ce4d1496c3e174d62d667a78fcddc7de298eR2380)
* Updated the server's formulary service to compute and populate the new `DoseCheck` field using raw dose rule results, classifying them by severity (Valid, Warning, Alert) and formatting accordingly. The logic for Markdown assembly was refactored to separate detailed rule output from the colored dose check summary.

**Frontend (Client) Improvements:**

* Enhanced the formulary page to render the new `DoseCheck` information with color-coded blocks: green for Valid, orange for Warning, and red for Alert. The rendering logic distinguishes between all-valid, warning, and alert cases, and applies appropriate MUI styles. [[1]](diffhunk://#diff-4e9202ebee29ca3c8d08b5d9b240c29c0a086a7e0d910900050750a2b743990cR200-R280) [[2]](diffhunk://#diff-4e9202ebee29ca3c8d08b5d9b240c29c0a086a7e0d910900050750a2b743990cL288-R369) [[3]](diffhunk://#diff-4e9202ebee29ca3c8d08b5d9b240c29c0a086a7e0d910900050750a2b743990cR381-R384)
* Updated the side menu to visually indicate the presence and severity of dose check results for the formulary tab, using background colors matching the severity.

**Developer Support & Migration:**

* Added a prototype script (`DoseCheckColor.fsx`) that validates the dose check classification and aggregation logic, covering all relevant cases for interactive testing.
* Provided a detailed migration guide (`DoseCheckColor.migration.md`) describing the necessary source changes, rationale, and verification steps for applying this feature in environments with script-only policies.

**Testing:**

* Updated test helpers to accommodate the new `DoseCheck` field in test data.

---

**Backend & Shared Model:**
- Added `DoseCheck: TextBlock[]` to the `Formulary` record and initialized it in model defaults. [[1]](diffhunk://#diff-8fdd799ab0791e295561f41dacc6bae28e5c74fbf00d2ea3b6659b8b46d70bf5R549) [[2]](diffhunk://#diff-4054b27a7cad789febda8d2a7c57ce4d1496c3e174d62d667a78fcddc7de298eR2380)
- Refactored server logic to generate and classify dose check results by severity and populate both `Markdown` and `DoseCheck` fields.

**Frontend (Client):**
- Implemented color-coded rendering of dose check results in the formulary view, with distinct styles for Valid, Warning, and Alert. [[1]](diffhunk://#diff-4e9202ebee29ca3c8d08b5d9b240c29c0a086a7e0d910900050750a2b743990cR200-R280) [[2]](diffhunk://#diff-4e9202ebee29ca3c8d08b5d9b240c29c0a086a7e0d910900050750a2b743990cL288-R369) [[3]](diffhunk://#diff-4e9202ebee29ca3c8d08b5d9b240c29c0a086a7e0d910900050750a2b743990cR381-R384)
- Updated side menu to show background color indicators for the formulary tab based on dose check severity.

**Developer Support:**
- Added a prototype script to validate dose check severity logic and aggregation.
- Included a migration guide detailing required changes and verification steps.

**Testing:**
- Updated test helpers for the new `DoseCheck` field.

@greptile review