### PR TITLE
ci: make server tests run and pass on a clean CI checkout

### DIFF
--- a/Build.fs
+++ b/Build.fs
@@ -168,6 +168,10 @@ Target.create
 
             if result.ExitCode <> 0 then
                 failwithf "Tests failed with exit code %d" result.ExitCode
+
+            if totalTests.Value = 0 then
+                failwith
+                    "No tests were discovered or run. The solution was likely not built/restored before 'dotnet test'."
     )
 
 
@@ -247,6 +251,8 @@ let dependencies =
 
         "RestoreClient" ==> "Build" ==> "TestHeadless"
         "RestoreClient" ==> "Build" ==> "WatchTests"
+
+        "Build" ==> "ServerTests"
     ]
 
 

--- a/Build.fs
+++ b/Build.fs
@@ -106,7 +106,14 @@ Target.create
 
         let started = ref false
 
+        // Capture all output so we can surface the failing tests on a non-zero
+        // exit. The progress dots replace the raw `dotnet test` output, so
+        // without this the CI log shows no indication of *what* failed.
+        let captured = System.Collections.Generic.List<string>()
+
         let parseLine (line: string) =
+            captured.Add line
+
             if line.Contains("Passed:") && line.Contains("Failed:") && line.Contains("Total:") then
                 let grab (key: string) =
                     let i = line.IndexOf(key)
@@ -139,7 +146,13 @@ Target.create
 
                 printf "."
 
-        dotnet
+        // Build the process directly rather than via the `dotnet` helper: that
+        // helper attaches an `addOnExited` that throws on a non-zero exit code
+        // from inside `Proc.run`, which would pre-empt the result handler below
+        // (so the captured output would never be printed and the test summary
+        // never shown). Here we handle the exit code ourselves.
+        CreateProcess.fromRawCommand
+            "dotnet"
             [
                 "test"
                 sln
@@ -149,9 +162,14 @@ Target.create
                 "--logger"
                 "console;verbosity=minimal"
             ]
-            "."
+        |> CreateProcess.withWorkingDirectory "."
         |> CreateProcess.redirectOutputIfNotRedirected
-        |> CreateProcess.withOutputEventsNotNull parseLine (eprintfn "%s")
+        |> CreateProcess.withOutputEventsNotNull
+            parseLine
+            (fun line ->
+                captured.Add line
+                eprintfn "%s" line
+            )
         |> Proc.run
         |> fun result ->
             printfn ""
@@ -167,6 +185,14 @@ Target.create
             printfn "====================================================================="
 
             if result.ExitCode <> 0 then
+                // The progress dots replace the raw `dotnet test` output, so dump
+                // the captured output to reveal *what* failed. At minimal verbosity
+                // this is just the per-project summaries plus the failure blocks
+                // (no passing-test noise), so it stays readable.
+                printfn "------------------------- dotnet test output ----------------------------"
+                captured |> Seq.iter (printfn "%s")
+                printfn "-------------------------------------------------------------------------"
+
                 failwithf "Tests failed with exit code %d" result.ExitCode
 
             if totalTests.Value = 0 then

--- a/tests/Informedica.Agents.Tests/Tests.fs
+++ b/tests/Informedica.Agents.Tests/Tests.fs
@@ -30,6 +30,32 @@ module Tests =
 
     module AgentTests  =
 
+        // Poll until a condition holds or a timeout elapses. Used instead of a
+        // fixed Async.Sleep/Thread.Sleep after Post so the tests stay deterministic
+        // on slow or heavily-loaded CI runners, where a fixed wait can expire
+        // before the agent has processed the posted message(s).
+        let waitUntil (timeoutMs: int) (predicate: unit -> bool) =
+            let sw = Diagnostics.Stopwatch.StartNew()
+
+            while not (predicate ()) && sw.ElapsedMilliseconds < int64 timeoutMs do
+                Thread.Sleep 5
+
+            predicate ()
+
+        // Async variant for use inside `testAsync` bodies. It MUST yield the
+        // thread (Async.Sleep) rather than block it (Thread.Sleep): Expecto runs
+        // tests in parallel, and the MailboxProcessor agents under test run their
+        // loops on thread-pool threads. A blocking wait here would occupy those
+        // threads and starve the agents — on a few-core CI runner that prevents
+        // the posted messages from ever being processed.
+        let waitUntilAsync (timeoutMs: int) (predicate: unit -> bool) =
+            async {
+                let sw = Diagnostics.Stopwatch.StartNew()
+
+                while not (predicate ()) && sw.ElapsedMilliseconds < int64 timeoutMs do
+                    do! Async.Sleep 5
+            }
+
         // Basic agent tests
         let basicAgentTests =
             testList "Basic Agent Operations" [
@@ -57,8 +83,7 @@ module Tests =
 
                     agent.Post "Hello, World!"
 
-                    // Give time for message processing
-                    do! Async.Sleep 100
+                    do! waitUntilAsync 5000 (fun () -> receivedMessage = Some "Hello, World!")
 
                     receivedMessage |> Expect.equal "Should receive the message" (Some "Hello, World!")
                     agent |> Agent.dispose
@@ -78,8 +103,7 @@ module Tests =
                     agent.Post "Second"
                     agent.Post "Third"
 
-                    // Give time for message processing
-                    do! Async.Sleep 200
+                    do! waitUntilAsync 5000 (fun () -> List.length receivedMessages = 3)
 
                     let expectedOrder = ["Third"; "Second"; "First"] // Reversed due to cons
                     receivedMessages |> Expect.equal "Should process messages in order" expectedOrder
@@ -97,11 +121,11 @@ module Tests =
                         })
 
                     agent.Post (SimpleMessage "test")
-                    do! Async.Sleep 50
+                    do! waitUntilAsync 5000 (fun () -> lastMessage = Some (SimpleMessage "test"))
                     lastMessage |> Expect.equal "Should handle SimpleMessage" (Some (SimpleMessage "test"))
 
                     agent.Post (NumberMessage 42)
-                    do! Async.Sleep 50
+                    do! waitUntilAsync 5000 (fun () -> lastMessage = Some (NumberMessage 42))
                     lastMessage |> Expect.equal "Should handle NumberMessage" (Some (NumberMessage 42))
 
                     agent |> Agent.dispose
@@ -184,8 +208,7 @@ module Tests =
 
                     agent.Post (ErrorMessage "trigger error")
 
-                    // Give time for error to propagate
-                    do! Async.Sleep 200
+                    do! waitUntilAsync 5000 (fun () -> errorReceived.IsSome)
 
                     errorReceived |> Expect.isSome "Should receive error event"
                     errorReceived.Value |> Expect.stringContains "Should contain error message" "Test exception"
@@ -207,13 +230,10 @@ module Tests =
                         | ex -> errorCount <- errorCount + 1)
 
                     agent.Post (SimpleMessage "first")
-                    do! Async.Sleep 50
-
                     agent.Post (ErrorMessage "error")
-                    do! Async.Sleep 50
-
                     agent.Post (SimpleMessage "second")
-                    do! Async.Sleep 50
+
+                    do! waitUntilAsync 5000 (fun () -> messageCount = 2 && errorCount = 1)
 
                     messageCount |> Expect.equal "Should process normal messages" 2
                     errorCount |> Expect.equal "Should handle one error" 1
@@ -311,8 +331,7 @@ module Tests =
                     for i in 1..messageCount do
                         agent.Post i
 
-                    // Wait for processing
-                    do! Async.Sleep 2000
+                    do! waitUntilAsync 10000 (fun () -> processedCount = messageCount)
 
                     processedCount |> Expect.equal "Should process all messages" messageCount
 
@@ -339,39 +358,32 @@ module Tests =
 
                 testAsync "disposal should stop agent processing" {
                     let mutable isProcessing = true
+                    let mutable started = false
 
                     let agent = Agent.Start (fun agent ->
                         async {
                             try
                                 while true do
                                     let! _ = agent.Receive()
-                                    ()
+                                    started <- true
                             finally
                                 isProcessing <- false
                         })
 
                     agent.Post "test"
-                    do! Async.Sleep 50
+                    // Make sure the agent is actually running its receive loop
+                    // before we dispose it, so the `finally` is reached.
+                    do! waitUntilAsync 5000 (fun () -> started)
 
                     agent |> Agent.dispose
-                    do! Async.Sleep 100
+                    // Disposal cancels the agent's Receive loop; wait for the
+                    // `finally` to run rather than guessing a fixed duration.
+                    do! waitUntilAsync 5000 (fun () -> not isProcessing)
 
                     isProcessing |> Expect.isFalse "Agent should stop processing after disposal"
                 }
             ]
 
-
-        // Poll until a condition holds or a timeout elapses. Used instead of a
-        // fixed Thread.Sleep so the property tests stay deterministic on slow or
-        // heavily-loaded CI runners (where a fixed wait can expire before the
-        // agent has drained its message queue).
-        let waitUntil (timeoutMs: int) (predicate: unit -> bool) =
-            let sw = Diagnostics.Stopwatch.StartNew()
-
-            while not (predicate ()) && sw.ElapsedMilliseconds < int64 timeoutMs do
-                Thread.Sleep 5
-
-            predicate ()
 
         // Property-based tests using FsCheck
         let propertyTests =
@@ -465,7 +477,7 @@ module Tests =
                             receivedNull <- true)
 
                     agent.Post null
-                    do! Async.Sleep 100
+                    do! waitUntilAsync 5000 (fun () -> receivedNull)
 
                     receivedNull |> Expect.isTrue "Should handle null messages"
                     agent |> Agent.dispose

--- a/tests/Informedica.Agents.Tests/Tests.fs
+++ b/tests/Informedica.Agents.Tests/Tests.fs
@@ -361,6 +361,18 @@ module Tests =
             ]
 
 
+        // Poll until a condition holds or a timeout elapses. Used instead of a
+        // fixed Thread.Sleep so the property tests stay deterministic on slow or
+        // heavily-loaded CI runners (where a fixed wait can expire before the
+        // agent has drained its message queue).
+        let waitUntil (timeoutMs: int) (predicate: unit -> bool) =
+            let sw = Diagnostics.Stopwatch.StartNew()
+
+            while not (predicate ()) && sw.ElapsedMilliseconds < int64 timeoutMs do
+                Thread.Sleep 5
+
+            predicate ()
+
         // Property-based tests using FsCheck
         let propertyTests =
             testList "Property-based Tests" [
@@ -375,8 +387,9 @@ module Tests =
                         try
                             messages |> List.iter agent.Post
 
-                            // Wait for processing
-                            Thread.Sleep(messages.Length * 5 + 100)
+                            // Wait until every posted message has been processed.
+                            waitUntil 5000 (fun () -> List.length receivedMessages = List.length messages)
+                            |> ignore
 
                             let result = List.rev receivedMessages = messages
                             agent |> Agent.dispose
@@ -399,10 +412,12 @@ module Tests =
                         try
                             operations |> List.iter agent.Post
 
-                            // Wait for processing
-                            Thread.Sleep(operations.Length * 5 + 100)
-
                             let expectedSum = List.sum operations
+
+                            // Wait until the accumulated state reaches the expected sum.
+                            waitUntil 5000 (fun () -> finalState = Some expectedSum)
+                            |> ignore
+
                             let result = finalState = Some expectedSum
                             agent |> Agent.dispose
                             result

--- a/tests/Informedica.Agents.Tests/Tests.fs
+++ b/tests/Informedica.Agents.Tests/Tests.fs
@@ -608,10 +608,30 @@ module Tests =
                         Directory.Delete(path, true)
                 with _ -> ()
 
+            // Read with FileShare.ReadWrite so the read can coexist with the
+            // FileWriterAgent's still-open write handle. On Windows a plain
+            // File.ReadAllLines/ReadAllText (FileShare.Read) cannot open a file
+            // that already has an open write handle and throws — which the catch
+            // would otherwise turn into a misleading empty result. On Linux/macOS
+            // share modes are advisory so the plain read happened to work.
+            let openSharedRead (path: string) =
+                let fs =
+                    new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite ||| FileShare.Delete)
+
+                new StreamReader(fs)
+
             let readAllLines path =
                 try
                     if File.Exists path then
-                        File.ReadAllLines(path)
+                        use sr = openSharedRead path
+                        let lines = ResizeArray<string>()
+                        let mutable line = sr.ReadLine()
+
+                        while not (isNull line) do
+                            lines.Add line
+                            line <- sr.ReadLine()
+
+                        lines.ToArray()
                     else
                         [||]
                 with _ -> [||]
@@ -619,7 +639,8 @@ module Tests =
             let readAllText path =
                 try
                     if File.Exists path then
-                        File.ReadAllText(path)
+                        use sr = openSharedRead path
+                        sr.ReadToEnd()
                     else
                         ""
                 with _ -> ""

--- a/tests/Informedica.ZForm.Tests/Tests.fs
+++ b/tests/Informedica.ZForm.Tests/Tests.fs
@@ -146,6 +146,19 @@ module DoseRangeTests =
     module Dto = DoseRule.DoseRange.Dto
     module DoseRange = DoseRule.DoseRange
 
+    // Rendering a DoseRange to string loads unit mappings from Google Sheets,
+    // which requires GENPRES_URL_ID. When it is not configured (e.g. CI, where
+    // only demo/cached data is available) these tests cannot run, so skip them.
+    // The DTO round-trip tests below need no sheet data and always run.
+    // Resolution mirrors ZForm.Lib Web.genpresUrlId exactly.
+    let private hasUrlId =
+        Informedica.Utils.Lib.Env.loadDotEnv () |> ignore
+        Informedica.Utils.Lib.Env.getItem "GENPRES_URL_ID" |> Option.isSome
+
+    /// `test` when GENPRES_URL_ID is configured, otherwise a skipped (pending) test.
+    let testUrl name =
+        if hasUrlId then test name else ptest name
+
     let setMinNormDose = Optic.set DoseRange.Optics.inclMinNormLens
     let setMaxNormDose = Optic.set DoseRange.Optics.inclMaxNormLens
 
@@ -215,7 +228,7 @@ module DoseRangeTests =
                     expct |> Dto.toDto |> Dto.fromDto |> Expect.equal "should be equal" expct
                 }
 
-                test "can create a dose range" {
+                testUrl "can create a dose range" {
                     DoseRange.empty
                     |> setMaxNormDose (vuFromStr 10N "milligram")
                     |> setMaxAbsDose (vuFromStr 100N "milligram")
@@ -223,7 +236,7 @@ module DoseRangeTests =
                     |> shouldContainAll "dose range" [ "10 mg"; "100 mg"; "maximaal" ]
                 }
 
-                test "can create a dose range with a rate" {
+                testUrl "can create a dose range with a rate" {
                     DoseRange.empty
                     |> setMinNormDose (vuFromStr 10N "milligram")
                     |> setMaxNormDose (vuFromStr 100N "milligram")
@@ -231,7 +244,7 @@ module DoseRangeTests =
                     |> shouldContainAll "dose range rate" [ "10 mg/uur"; "100 mg/uur" ]
                 }
 
-                test "can create a dose range with a rate per kg" {
+                testUrl "can create a dose range with a rate per kg" {
                     DoseRange.empty
                     |> setMinNormPerKgDose (vuFromStr (1N / 1_000N) "milligram")
                     |> setMaxNormPerKgDose (vuFromStr 1N "milligram")
@@ -240,7 +253,7 @@ module DoseRangeTests =
                     |> shouldContainAll "dose range rate per kg" [ "1 microg/kg/uur"; "1000 microg/kg/uur" ]
                 }
 
-                test "can covert a unit" {
+                testUrl "can covert a unit" {
                     DoseRange.empty
                     |> setMaxNormDose (vuFromStr 1N "milligram")
                     |> setMinNormDose (vuFromStr (1N / 1_000N) "milligram")

--- a/tests/Informedica.ZIndex.Tests/Tests.fs
+++ b/tests/Informedica.ZIndex.Tests/Tests.fs
@@ -591,7 +591,11 @@ module Tests =
         let tot =
             try
                 GenPresProduct.get [] |> Array.length
-            with _ ->
+            with ex ->
+                // Don't crash the whole assembly during static init, but surface
+                // the failure rather than silently using 0 (which could let the
+                // tests that compare against `tot` pass vacuously).
+                eprintfn "GenPresProduct.get [] failed during module init (tot = 0): %s" ex.Message
                 0
 
 

--- a/tests/Informedica.ZIndex.Tests/Tests.fs
+++ b/tests/Informedica.ZIndex.Tests/Tests.fs
@@ -14,6 +14,18 @@ module Tests =
     open Informedica.ZIndex.Lib
 
 
+    // Lay down the synthetic Z-Index fixture files BEFORE anything else in this
+    // file's static initializer. F# initializes every nested-module binding here
+    // as part of `$Tests..cctor` in source order, and several of those bindings
+    // (e.g. DoseRuleTests.frqs/rts) transitively touch raw ZIndex tables. Because
+    // .NET caches a type initializer's exception permanently, a single such touch
+    // before the fixtures exist would poison the ZIndex types for the whole test
+    // process. The `dotnet test` adapter bypasses Main.fs, so forcing the fixture
+    // here is what makes the synthetic-data tests pass under `dotnet test`.
+    // (Main.fs forces the same cached value for the `dotnet run` path.)
+    do FixtureSetup.fixtureCreatedFiles |> ignore
+
+
     module FilePathTests =
 
         let tests =
@@ -572,7 +584,15 @@ module Tests =
 
     module GenPresProductTests =
 
-        let tot = GenPresProduct.get [] |> Array.length
+        // Tolerant of a missing/unresolved product cache: module-level bindings
+        // in this file are evaluated eagerly during Tests static init (before any
+        // test runs), so an unguarded data access here would crash the whole
+        // assembly rather than fail a single test.
+        let tot =
+            try
+                GenPresProduct.get [] |> Array.length
+            with _ ->
+                0
 
 
         let tests =


### PR DESCRIPTION
## Overview

CI ran `dotnet run ServerTests` but executed **zero tests** while reporting success: the `ServerTests` FAKE target invoked `dotnet test --no-restore` with no `Build` dependency, so on a fresh CI checkout nothing was restored or built. Under .NET 10, `dotnet test` on an unbuilt solution exits 0 with zero tests discovered — so CI was green while testing nothing.

Making tests actually run, and improving failure visibility, surfaced several pre-existing failures that only occur in a clean / CI / Windows / slow-runner environment. This PR fixes the root cause and each surfaced failure. All changes are build-infrastructure or test-only — no domain/clinical source is touched.

Final result: **ubuntu ✓ windows ✓ macOS ✓** for `dotnet run ServerTests` (confirmed green twice across the matrix).

## Further information

Six commits, peeling back one failure at a time:

1. **`ci: run server tests on clean CI checkout`** — `Build.fs`: add `Build ==> ServerTests` so the solution is restored and built before `dotnet test`, and fail the target when zero tests run (guards against a silent "ran nothing" regression). Also fixes two clean-env failures the no-op had hidden:
   - **ZIndex.Tests**: the `dotnet test` adapter discovers the `[<Tests>]` value directly and bypasses `Main.fs`, where the synthetic BST fixture setup was forced. Module init also touched raw ZIndex tables before any test, and because .NET caches a failed type initializer for the life of the process, a single early touch poisoned the types for every subsequent test. Fixed by forcing the fixture at the top of `module Tests` (before any nested-module binding) and making the eager `tot` binding tolerant. Runs on the tracked synthetic `BST*.test` data — no proprietary files needed.
   - **ZForm.Tests**: four `DoseRange` tests render strings via Google Sheets unit mappings (need `GENPRES_URL_ID`, unset in CI). Skipped when it is absent, using the same `loadDotEnv` + `getItem` resolution as `Web.genpresUrlId`, so they skip in CI and run locally.

2. **`ci: surface dotnet test output when ServerTests fails`** — the target replaced `dotnet test` stdout with progress dots, so a failing CI run showed no indication of *what* failed (the original `failwithf` was also dead code: the `dotnet` helper's `addOnExited` throws on a non-zero exit inside `Proc.run`, pre-empting the result handler). Build the process directly and dump the captured output on a non-zero exit. This is what made every subsequent failure diagnosable.

3. **`test(agents): deflake property tests on slow CI`** — two FsCheck property tests read a mutable after a fixed `Thread.Sleep`; under load the agent had not drained its queue, so they read stale state (shrinking to minimal input — a timing race). Replaced with a bounded poll-until-condition.

4. **`test(agents): read files with shared access on Windows`** — 14 FileWriterAgent tests wrote via the agent (which holds the file open with `FileShare.ReadWrite`) then read it back with `File.ReadAllLines`, whose default `FileShare.Read` cannot coexist with an open write handle **on Windows**. The read threw and the helpers' `with _ -> [||]` swallowed it into an empty result. Now read through a `FileStream` opened with `FileShare.ReadWrite ||| FileShare.Delete`. (Linux/macOS share modes are advisory, so the plain read happened to work.)

5. **`test(zindex): log instead of silently swallowing tot init failure`** — review follow-up: the `tot` module-init binding caught all exceptions and used 0, which could let the tests comparing against `tot` pass vacuously. Keep the no-crash behaviour but log the exception.

6. **`test(agents): deterministic, non-blocking waits for agent tests`** — more agent tests (basic message passing, ordering, message types, OnError, recoverable error, high throughput, null messages, disposal) used the same fixed-`Async.Sleep`-then-read-mutable pattern. The key subtlety: the wait used inside `testAsync` bodies **must yield the thread** (`do! Async.Sleep`) rather than block it (`Thread.Sleep`). Expecto runs tests in parallel and the MailboxProcessor agents under test run their loops on thread-pool threads; a blocking wait occupies those threads and **starves the very agents being tested**, so on a few-core runner the posted messages are never processed (a first, all-synchronous attempt made this worse — tests timed out at the full 5s). The async variant yields the thread back to the pool; a synchronous `waitUntil` remains only for the two non-async FsCheck property tests. The disposal test additionally waits for the agent to start (so its `finally` is reached) and for that `finally` to run, instead of sleeping.

## Divergence from plan

n/a — CI/test correctness fix; no implementation plan.

## Verification

Reproduced and fixed in a clean `git worktree` (no `.env`, no proprietary cache), mimicking a fresh CI checkout, and confirmed on the CI matrix:

- **Before:** `dotnet test GenPRES.sln --no-restore` → exit 0, 0 tests, ~2s (matches the original CI log).
- **After (CI matrix):** ubuntu, windows, macOS all green — confirmed on two consecutive matrix runs to rule out a lucky pass on the previously-flaky agent tests.
- Agents.Tests: 48/48, stable across repeated local runs and both CI matrix runs.
- ZIndex.Tests passes 24/24 on synthetic data under both `dotnet test` and `dotnet run`; fixture teardown leaves the data dir clean.
- ZForm.Tests: 6 passed, 6 skipped, 0 failed with `GENPRES_URL_ID` unset; the 4 skipped tests run for real when it is set.
- The 10 other test projects that transitively reference `ZIndex.Lib` were confirmed unaffected (they use demo caches, never touch raw tables).

Reviewer repro: check out the branch into a fresh clone / `git worktree` with no `.env`, then run `dotnet run ServerTests`.

## Author checklist

- [x] Follow the process described in CONTRIBUTING.md.
- [x] Make the changes proposed in the linked issue (if applicable): n/a
- [x] Follow the approach documented in the linked implementation plan (if applicable): n/a
- [x] Are no more than 200 lines of changed code, ideally 25-100. (+151 −34 across 4 files; small per-file, single concern — each commit is independently reviewable.)
- [x] Are not more complex than necessary.
- [x] Cannot easily be split in a way that would make reviewing them significantly easier. (The Build.fs fix is what surfaces the test failures; splitting would leave CI red. Commits are scoped for review.)
- [x] Follow the guidelines specified in DEVELOPMENT.md.
- [x] Have been thoroughly tested.
- [x] Don't introduce new security vulnerabilities.
- [x] Follow the AI/LLM Usage Policy — see disclosure below.

### AI/Vibe Coding Disclosure

- [x] Some or all code in this PR is **vibe coded** (substantially AI-generated).

All changes were authored by Claude Code (Opus 4.8) and reviewed/verified by me. The `.fs` test-file edits (ZIndex.Tests, ZForm.Tests, Agents.Tests) were AI-written under an explicit, scoped overrule of the script-only policy for this test-infrastructure fix; no domain/clinical `.fs` source was touched. Verification: full `dotnet run ServerTests` on a clean worktree, targeted per-project runs, and two green CI matrix runs.

- [x] Added appropriate automated tests. (Restores execution of the existing suite and deflakes it; no behaviour change to tested code.)
- [ ] Updated documentation appropriately. (n/a — no doc changes needed.)
- [x] Added comments that highlight important changes and add justification.
