### PR TITLE
perf: improved performance by using special rational and change some …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -351,6 +351,19 @@
 !/benchmark/BenchmarkDotNet.Artifacts/
 !/benchmark/BenchmarkDotNet.Artifacts/results/
 !/benchmark/BenchmarkDotNet.Artifacts/results/*.md
+# Add benchmark sub-projects (.fs/.fsproj allowed globally; results md opt-in)
+!/benchmark/RationalXBench/
+!/benchmark/RationalXBench/BenchmarkDotNet.Artifacts/
+!/benchmark/RationalXBench/BenchmarkDotNet.Artifacts/results/
+!/benchmark/RationalXBench/BenchmarkDotNet.Artifacts/results/*.md
+!/benchmark/ScenarioBench/
+!/benchmark/ScenarioBench/BenchmarkDotNet.Artifacts/
+!/benchmark/ScenarioBench/BenchmarkDotNet.Artifacts/results/
+!/benchmark/ScenarioBench/BenchmarkDotNet.Artifacts/results/*.md
+!/benchmark/ValueUnitBench/
+!/benchmark/ValueUnitBench/BenchmarkDotNet.Artifacts/
+!/benchmark/ValueUnitBench/BenchmarkDotNet.Artifacts/results/
+!/benchmark/ValueUnitBench/BenchmarkDotNet.Artifacts/results/*.md
 
 #Add debug test runner
 !/debugTests.sh

--- a/benchmark/RationalXBench/BenchmarkDotNet.Artifacts/results/Program.Benchmarks-report-github.md
+++ b/benchmark/RationalXBench/BenchmarkDotNet.Artifacts/results/Program.Benchmarks-report-github.md
@@ -1,0 +1,14 @@
+```
+
+BenchmarkDotNet v0.14.0, macOS 26.5.1 (25F80) [Darwin 25.5.0]
+Apple M2 Max, 1 CPU, 12 logical and 12 physical cores
+.NET SDK 10.0.100
+  [Host]     : .NET 10.0.0 (10.0.25.52411), Arm64 RyuJIT AdvSIMD DEBUG
+  DefaultJob : .NET 10.0.0 (10.0.25.52411), Arm64 RyuJIT AdvSIMD
+
+
+```
+| Method                | Mean     | Error    | StdDev   | Ratio | Gen0    | Allocated | Alloc Ratio |
+|---------------------- |---------:|---------:|---------:|------:|--------:|----------:|------------:|
+| MathNet_BigRational   | 71.79 μs | 0.066 μs | 0.062 μs |  1.00 | 18.5547 |  156096 B |        1.00 |
+| RationalX_CrossReduce | 16.64 μs | 0.017 μs | 0.016 μs |  0.23 |       - |         - |        0.00 |

--- a/benchmark/RationalXBench/Program.fs
+++ b/benchmark/RationalXBench/Program.fs
@@ -1,0 +1,136 @@
+// A/B micro-benchmark: the two-tier RationalX (the live BigRational alias in
+// Informedica.Utils.Lib.BCL) vs the original MathNet.Numerics.BigRational.
+//
+// Workload mirrors the GenSOLVER hot path: a pool of base-unit fractions run
+// through (a * b) / c, summed via ToDouble so the JIT cannot dead-code-
+// eliminate the result.
+//
+// Run from this directory:  dotnet run -c Release
+
+open BenchmarkDotNet.Attributes
+open BenchmarkDotNet.Running
+
+type RX = Informedica.Utils.Lib.BCL.BigRational // = RationalX
+type MB = MathNet.Numerics.BigRational
+
+
+module Pool =
+
+    // Base-unit fractions reconstructed from a real GenPRES OrderContext log.
+    // Denominators are products of small primes (from /1000, /86400, ...), so
+    // numerators cancel hard and RationalX rarely spills out of int64.
+    let pairs: (int64 * int64)[] =
+        [|
+            (1L, 10000L) // 0.1 mL -> 1e-4 L
+            (7L, 86400000000L) // 7 mg/kg/day in base units
+            (727L, 100000000L)
+            (1L, 1000L)
+            (3L, 1000L)
+            (5L, 2L)
+            (1L, 3L)
+            (2L, 3L)
+            (10L, 86400L)
+            (250L, 1000L)
+            (1L, 7L)
+            (40L, 1000L)
+            (1L, 24L)
+            (9L, 100L)
+            (1L, 2L)
+            (3L, 5L)
+            (500L, 1000L)
+            (1L, 86400L)
+            (60L, 1000L)
+            (4L, 3L)
+            (15L, 1000L)
+            (1L, 1000000L)
+            (3L, 8L)
+            (11L, 50L)
+        |]
+
+
+module Check =
+
+    let private toRX (n: int64, d: int64) = RX.FromInt64Fraction(n, d)
+
+    let private toMB (n: int64, d: int64) =
+        MB.FromBigIntFraction(bigint n, bigint d)
+
+    /// (maxAbsDoubleDiff, spillCount, total) for (a*b)/c across the pool.
+    let run () =
+        let pool = Pool.pairs
+        let m = pool.Length
+        let mutable maxDiff = 0.0
+        let mutable spills = 0
+        let mutable total = 0
+
+        for i in 0 .. m - 1 do
+            let a = pool[i % m]
+            let b = pool[(i * 7 + 1) % m]
+            let c = pool[(i * 13 + 2) % m]
+            let rx = (toRX a * toRX b) / toRX c
+            let mb = (toMB a * toMB b) / toMB c
+            let diff = abs (RX.ToDouble rx - MB.ToDouble mb)
+
+            if diff > maxDiff then
+                maxDiff <- diff
+
+            total <- total + 1
+            // a value spills if it did not narrow back to the int64 (small) tier
+            if rx.IsSpilled then
+                spills <- spills + 1
+
+        maxDiff, spills, total
+
+
+[<MemoryDiagnoser>]
+type Benchmarks() =
+
+    let ops = 1000
+
+    let mutable mb: MB[] = [||]
+    let mutable rx: RX[] = [||]
+
+    [<GlobalSetup>]
+    member _.Setup() =
+        mb <-
+            Pool.pairs
+            |> Array.map (fun (n, d) -> MB.FromBigIntFraction(bigint n, bigint d))
+
+        rx <- Pool.pairs |> Array.map (fun (n, d) -> RX.FromInt64Fraction(n, d))
+
+    [<Benchmark(Baseline = true)>]
+    member _.MathNet_BigRational() =
+        let m = mb.Length
+        let mutable s = 0.0
+
+        for i in 0 .. ops - 1 do
+            let r = (mb[i % m] * mb[(i * 7 + 1) % m]) / mb[(i * 13 + 2) % m]
+            s <- s + MB.ToDouble r
+
+        s
+
+    [<Benchmark>]
+    member _.RationalX_CrossReduce() =
+        let m = rx.Length
+        let mutable s = 0.0
+
+        for i in 0 .. ops - 1 do
+            let r = (rx[i % m] * rx[(i * 7 + 1) % m]) / rx[(i * 13 + 2) % m]
+            s <- s + RX.ToDouble r
+
+        s
+
+
+[<EntryPoint>]
+let main _ =
+    let maxDiff, spills, total = Check.run ()
+    printfn "Correctness gate: max |double diff| vs MathNet = %.3e over %d ops" maxDiff total
+    printfn "Spill rate (results not fitting int64): %d / %d" spills total
+
+    if maxDiff > 1e-9 then
+        printfn "CORRECTNESS GATE FAILED — aborting benchmark"
+        1
+    else
+        printfn "Correctness gate passed; running benchmarks..."
+        BenchmarkRunner.Run<Benchmarks>() |> ignore
+        0

--- a/benchmark/RationalXBench/RationalXBench.fsproj
+++ b/benchmark/RationalXBench/RationalXBench.fsproj
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Optimize>true</Optimize>
+    <ServerGarbageCollection>false</ServerGarbageCollection>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="10.1.203" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageReference Include="MathNet.Numerics.FSharp" Version="5.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Informedica.Utils.Lib\Informedica.Utils.Lib.fsproj" />
+  </ItemGroup>
+</Project>

--- a/benchmark/ScenarioBench/BenchmarkDotNet.Artifacts/results/Program.ScenarioBenchmarks-report-github.md
+++ b/benchmark/ScenarioBench/BenchmarkDotNet.Artifacts/results/Program.ScenarioBenchmarks-report-github.md
@@ -1,0 +1,13 @@
+```
+
+BenchmarkDotNet v0.14.0, macOS 26.5.1 (25F80) [Darwin 25.5.0]
+Apple M2 Max, 1 CPU, 12 logical and 12 physical cores
+.NET SDK 10.0.100
+  [Host]     : .NET 10.0.0 (10.0.25.52411), Arm64 RyuJIT AdvSIMD DEBUG
+  DefaultJob : .NET 10.0.0 (10.0.25.52411), Arm64 RyuJIT AdvSIMD
+
+
+```
+| Method            | Mean     | Error   | StdDev  | Gen0       | Gen1     | Allocated |
+|------------------ |---------:|--------:|--------:|-----------:|---------:|----------:|
+| SolveAllScenarios | 118.3 ms | 2.19 ms | 3.47 ms | 23800.0000 | 400.0000 | 190.99 MB |

--- a/benchmark/ScenarioBench/Program.fs
+++ b/benchmark/ScenarioBench/Program.fs
@@ -1,0 +1,250 @@
+// Integrated end-to-end benchmark: drive the real GenORDER scenario templates
+// (Scenarios.fs) through OrderProcessor.processPipeline (the GenSOLVER-heavy
+// solve, the hot path RationalX accelerates).
+//
+// The same harness is compiled against whichever BigRational backing is in the
+// tree: build/run it in the perf/rational-x worktree (RationalX) and on master
+// (original MathNet BigRational), then compare the numbers.
+//
+// Run:  dotnet run -c Release           (full BenchmarkDotNet run)
+//       dotnet run -c Release -- quick  (per-scenario stopwatch only, fast)
+
+open System.Diagnostics
+open System.Collections.Generic
+
+open Informedica.Utils.Lib
+open Informedica.Logging.Lib
+open Informedica.GenOrder.Lib
+open Informedica.GenOrder.Lib.Types
+
+open BenchmarkDotNet.Attributes
+open BenchmarkDotNet.Running
+
+let private noLogger = Logging.noOp
+
+/// All scenario templates we exercise, by name.
+let scenarioMeds: (string * Medication)[] =
+    [|
+        "pcmSupp", Scenarios.pcmSupp
+        "pcmDrink", Scenarios.pcmDrink
+        "amfo", Scenarios.amfo
+        "morfCont", Scenarios.morfCont
+        "cotrim", Scenarios.cotrim
+        "tpn", Scenarios.tpn
+        "tpnComplete", Scenarios.tpnComplete
+        "fullMedication", Scenarios.fullMedication
+    |]
+
+/// Build an Order from a Medication template (not timed — done once in setup).
+let buildOrder (med: Medication) : Order =
+    med |> Medication.toOrderDto |> Order.Dto.fromDto |> Result.get
+
+/// Solve one order through the full pipeline; return a cheap hash so the JIT /
+/// BenchmarkDotNet cannot dead-code-eliminate the work.
+let solve (ord: Order) : int =
+    OrderProcessor.processPipeline noLogger (SolveOrder ord)
+    |> box
+    |> LanguagePrimitives.PhysicalHash
+
+
+[<MemoryDiagnoser>]
+type ScenarioBenchmarks() =
+
+    let mutable orders: (string * Order)[] = [||]
+
+    [<GlobalSetup>]
+    member _.Setup() =
+        orders <-
+            scenarioMeds
+            |> Array.choose (fun (name, med) ->
+                try
+                    Some(name, buildOrder med)
+                with e ->
+                    printfn "  ! could not build order for %s: %s" name e.Message
+                    None
+            )
+
+    [<Benchmark>]
+    member _.SolveAllScenarios() =
+        let mutable sink = 0
+
+        for _, ord in orders do
+            sink <- sink + solve ord
+
+        sink
+
+
+/// Per-scenario stopwatch report (warm + repeated), useful as a quick A/B
+/// readout without a full BenchmarkDotNet run.
+let quickReport () =
+    printfn "Per-scenario solve time (mean of 20 runs after 5 warmups):"
+    printfn "%-16s %12s" "scenario" "mean (ms)"
+
+    let mutable totalMs = 0.0
+
+    for name, med in scenarioMeds do
+        try
+            let ord = buildOrder med
+
+            for _ in 1..5 do
+                solve ord |> ignore // warmup / JIT
+
+            let sw = Stopwatch.StartNew()
+            let reps = 20
+            let mutable sink = 0
+
+            for _ in 1..reps do
+                sink <- sink + solve ord
+
+            sw.Stop()
+            let meanMs = sw.Elapsed.TotalMilliseconds / float reps
+            totalMs <- totalMs + meanMs
+            printfn "%-16s %12.3f   (sink=%d)" name meanMs sink
+        with e ->
+            printfn "%-16s %12s   (%s)" name "ERROR" e.Message
+
+    printfn "%-16s %12.3f" "TOTAL" totalMs
+
+
+/// Coarse stage profiler. Times the two DTO stages directly, and attributes
+/// time inside the SolveOrder pipeline to its named steps by diffing the
+/// "PIPELINE START/END {step}" boundary events the pipeline emits.
+let profile () =
+    let stepTotals = Dictionary<string, float>()
+    let stack = Stack<string * float>()
+    let sw = Stopwatch.StartNew()
+
+    let add (d: Dictionary<string, float>) k v =
+        d[k] <-
+            (match d.TryGetValue k with
+             | true, x -> x
+             | _ -> 0.0)
+            + v
+
+    // extract a "PIPELINE START/END <name>" boundary from a scenario log string
+    let boundary (s: string) =
+        let grab (marker: string) =
+            let i = s.IndexOf marker
+
+            if i < 0 then
+                None
+            else
+                let rest = s.Substring(i + marker.Length)
+                let j = rest.IndexOf " ==="
+                if j < 0 then None else Some(rest.Substring(0, j))
+
+        match grab "PIPELINE START " with
+        | Some n -> Some(true, n)
+        | None -> grab "PIPELINE END " |> Option.map (fun n -> (false, n))
+
+    let timingLogger: Logger =
+        {
+            Log =
+                fun (e: Event) ->
+                    match e.Message with
+                    | :? Informedica.GenOrder.Lib.Types.Logging.OrderMessage as om ->
+                        match om with
+                        | Informedica.GenOrder.Lib.Types.Logging.OrderEventMessage(Informedica.GenOrder.Lib.Types.Events.OrderScenario s) ->
+                            match boundary s with
+                            | Some(true, name) -> stack.Push(name, sw.Elapsed.TotalMilliseconds)
+                            | Some(false, name) ->
+                                if stack.Count > 0 then
+                                    let (_, t0) = stack.Pop()
+                                    add stepTotals name (sw.Elapsed.TotalMilliseconds - t0)
+                            | None -> ()
+                        | _ -> ()
+                    | _ -> ()
+            Enabled = fun _ -> true
+        }
+
+    let stageTotals = Dictionary<string, float>()
+    let reps = 20
+
+    // warmup
+    for _, med in scenarioMeds do
+        try
+            let ord = buildOrder med
+            OrderProcessor.processPipeline noLogger (SolveOrder ord) |> ignore
+        with _ ->
+            ()
+
+    for _ in 1..reps do
+        for _, med in scenarioMeds do
+            try
+                let t0 = sw.Elapsed.TotalMilliseconds
+                let dto = Medication.toOrderDto med
+                let t1 = sw.Elapsed.TotalMilliseconds
+                let ord = dto |> Order.Dto.fromDto |> Result.get
+                let t2 = sw.Elapsed.TotalMilliseconds
+                OrderProcessor.processPipeline timingLogger (SolveOrder ord) |> ignore
+                let t3 = sw.Elapsed.TotalMilliseconds
+                add stageTotals "build: Medication.toOrderDto" (t1 - t0)
+                add stageTotals "build: Order.Dto.fromDto" (t2 - t1)
+                add stageTotals "solve: processPipeline(SolveOrder)" (t3 - t2)
+            with _ ->
+                ()
+
+    let perRun (v: float) = v / float reps
+
+    printfn "Stage breakdown (mean per full pass over all %d scenarios, %d reps):\n" scenarioMeds.Length reps
+    printfn "%-42s %10s" "stage" "mean (ms)"
+    let solveTotal = perRun stageTotals["solve: processPipeline(SolveOrder)"]
+
+    for KeyValue(k, v) in stageTotals |> Seq.sortByDescending (fun kv -> kv.Value) do
+        printfn "%-42s %10.3f" k (perRun v)
+
+    printfn "\nInside solve: per pipeline-step (sum across scenarios, mean per rep):\n"
+    printfn "%-42s %10s %8s" "pipeline step" "mean (ms)" "% solve"
+
+    for KeyValue(k, v) in stepTotals |> Seq.sortByDescending (fun kv -> kv.Value) do
+        let ms = perRun v
+        printfn "%-42s %10.3f %7.1f%%" k ms (100.0 * ms / solveTotal)
+
+
+/// Long-running loop so an external sampling profiler (dotnet-trace) can
+/// collect CPU samples of the solve path. Runs for ~`secs` seconds.
+let traceLoop (secs: float) =
+    let orders =
+        scenarioMeds
+        |> Array.choose (fun (_, m) ->
+            try
+                Some(buildOrder m)
+            with _ ->
+                None
+        )
+
+    let sw = Stopwatch.StartNew()
+    let mutable passes = 0
+    let mutable sink = 0
+
+    while sw.Elapsed.TotalSeconds < secs do
+        for ord in orders do
+            sink <-
+                sink
+                + (OrderProcessor.processPipeline noLogger (SolveOrder ord)
+                   |> box
+                   |> LanguagePrimitives.PhysicalHash)
+
+        passes <- passes + 1
+
+    printfn "trace loop done: %d passes in %.1fs (sink=%d)" passes sw.Elapsed.TotalSeconds sink
+
+
+[<EntryPoint>]
+let main argv =
+    match argv with
+    | [| "trace" |] ->
+        traceLoop 25.0
+        0
+    | [| "profile" |] ->
+        profile ()
+        0
+    | [| "quick" |] ->
+        quickReport ()
+        0
+    | _ ->
+        printfn "Warming up scenario build + solve..."
+        quickReport ()
+        printfn "\nRunning BenchmarkDotNet (SolveAllScenarios)..."
+        BenchmarkRunner.Run<ScenarioBenchmarks>() |> ignore
+        0

--- a/benchmark/ScenarioBench/ScenarioBench.fsproj
+++ b/benchmark/ScenarioBench/ScenarioBench.fsproj
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Optimize>true</Optimize>
+    <ServerGarbageCollection>false</ServerGarbageCollection>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- Reuse the GenORDER test scenario templates verbatim. -->
+    <Compile Include="..\..\tests\Informedica.GenORDER.Tests\Scenarios.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="10.1.203" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Informedica.GenORDER.Lib\Informedica.GenORDER.Lib.fsproj" />
+  </ItemGroup>
+</Project>

--- a/benchmark/ValueUnitBench/BenchmarkDotNet.Artifacts/results/Program.ValueUnitBenchmarks-report-github.md
+++ b/benchmark/ValueUnitBench/BenchmarkDotNet.Artifacts/results/Program.ValueUnitBenchmarks-report-github.md
@@ -1,0 +1,14 @@
+```
+
+BenchmarkDotNet v0.14.0, macOS 26.5.1 (25F80) [Darwin 25.5.0]
+Apple M2 Max, 1 CPU, 12 logical and 12 physical cores
+.NET SDK 10.0.100
+  [Host]     : .NET 10.0.0 (10.0.25.52411), Arm64 RyuJIT AdvSIMD DEBUG
+  DefaultJob : .NET 10.0.0 (10.0.25.52411), Arm64 RyuJIT AdvSIMD
+
+
+```
+| Method               | Mean     | Error    | StdDev   | Gen0      | Gen1      | Gen2      | Allocated |
+|--------------------- |---------:|---------:|---------:|----------:|----------:|----------:|----------:|
+| Mul_mgPerMl_x_mL_400 | 20.09 ms | 0.394 ms | 0.369 ms |  718.7500 |  718.7500 |  718.7500 |   21.1 MB |
+| Add_times_600        | 39.44 ms | 0.171 ms | 0.160 ms | 3230.7692 | 1923.0769 | 1923.0769 |     49 MB |

--- a/benchmark/ValueUnitBench/Program.fs
+++ b/benchmark/ValueUnitBench/Program.fs
@@ -1,0 +1,115 @@
+// Arithmetic-bound A/B benchmark: large ValueUnit.calc cartesian products.
+//
+// ValueUnit.calc runs BigRational.calcCartesian over the cross product of the
+// two operands' base values, then Array.distinct. This is the hot path that
+// RationalX should accelerate (cross-reduced int64 arithmetic, zero alloc,
+// plus cheaper equality/hashing for the distinct step).
+//
+// The same source compiles in both trees because values are built via the
+// version-agnostic BigRational.fromInt module function (MathNet in master,
+// RationalX in the perf/rational-x worktree).
+//
+// Run:  dotnet run -c Release            (full BenchmarkDotNet run)
+//       dotnet run -c Release -- quick   (stopwatch only, fast)
+
+open System.Diagnostics
+
+open Informedica.Utils.Lib.BCL
+open Informedica.GenUnits.Lib
+
+open BenchmarkDotNet.Attributes
+open BenchmarkDotNet.Running
+
+/// Deterministic pool of distinct-ish fractions (seeded, identical in both trees).
+let mkVals (seed: int) (n: int) (maxv: int) =
+    let rnd = System.Random seed
+
+    Array.init
+        n
+        (fun _ ->
+            BigRational.fromInt (rnd.Next(1, maxv))
+            / BigRational.fromInt (rnd.Next(1, maxv))
+        )
+
+// Units: vu1 = mg/mL, vu2 = mL  ->  (*) yields mg and exercises toBaseValue.
+let private mgPerMl = Units.Mass.milliGram |> ValueUnit.per Units.Volume.milliLiter
+let private ml = Units.Volume.milliLiter
+let private times = Units.Count.times
+
+let private resultSize (vu: ValueUnit) = (vu |> ValueUnit.getValue).Length
+
+
+[<MemoryDiagnoser>]
+type ValueUnitBenchmarks() =
+
+    // 400 x 400 = 160k cross products for the mixed-unit multiply
+    let mutable mul1 = Unchecked.defaultof<ValueUnit>
+    let mutable mul2 = Unchecked.defaultof<ValueUnit>
+    // 600 x 600 = 360k cross products for the same-unit add
+    let mutable add1 = Unchecked.defaultof<ValueUnit>
+    let mutable add2 = Unchecked.defaultof<ValueUnit>
+
+    [<GlobalSetup>]
+    member _.Setup() =
+        mul1 <- ValueUnit.create mgPerMl (mkVals 1 400 1000)
+        mul2 <- ValueUnit.create ml (mkVals 2 400 1000)
+        add1 <- ValueUnit.create times (mkVals 3 600 1000)
+        add2 <- ValueUnit.create times (mkVals 4 600 1000)
+
+    [<Benchmark>]
+    member _.Mul_mgPerMl_x_mL_400() =
+        ValueUnit.calc true (*) mul1 mul2 |> resultSize
+
+    [<Benchmark>]
+    member _.Add_times_600() =
+        ValueUnit.calc true (+) add1 add2 |> resultSize
+
+
+let quickReport () =
+    let cases =
+        [
+            "Mul mg/mL x mL 400",
+            (fun () ->
+                let a = ValueUnit.create mgPerMl (mkVals 1 400 1000)
+                let b = ValueUnit.create ml (mkVals 2 400 1000)
+                fun () -> ValueUnit.calc true (*) a b |> resultSize
+            )
+            "Add times 600",
+            (fun () ->
+                let a = ValueUnit.create times (mkVals 3 600 1000)
+                let b = ValueUnit.create times (mkVals 4 600 1000)
+                fun () -> ValueUnit.calc true (+) a b |> resultSize
+            )
+        ]
+
+    printfn "Large ValueUnit.calc cartesian products (mean of 10 runs after 3 warmups):"
+    printfn "%-22s %12s %12s" "case" "mean (ms)" "result size"
+
+    for name, prep in cases do
+        let run = prep ()
+
+        for _ in 1..3 do
+            run () |> ignore
+
+        let sw = Stopwatch.StartNew()
+        let reps = 10
+        let mutable sz = 0
+
+        for _ in 1..reps do
+            sz <- run ()
+
+        sw.Stop()
+        printfn "%-22s %12.3f %12d" name (sw.Elapsed.TotalMilliseconds / float reps) sz
+
+
+[<EntryPoint>]
+let main argv =
+    match argv with
+    | [| "quick" |] ->
+        quickReport ()
+        0
+    | _ ->
+        quickReport ()
+        printfn "\nRunning BenchmarkDotNet..."
+        BenchmarkRunner.Run<ValueUnitBenchmarks>() |> ignore
+        0

--- a/benchmark/ValueUnitBench/ValueUnitBench.fsproj
+++ b/benchmark/ValueUnitBench/ValueUnitBench.fsproj
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Optimize>true</Optimize>
+    <ServerGarbageCollection>false</ServerGarbageCollection>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="10.1.203" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Informedica.GenUNITS.Lib\Informedica.GenUNITS.Lib.fsproj" />
+  </ItemGroup>
+</Project>

--- a/docs/code-reviews/rational-x-perf-investigation.md
+++ b/docs/code-reviews/rational-x-perf-investigation.md
@@ -1,0 +1,179 @@
+# RationalX performance investigation — summary
+
+**Branch:** `perf/rational-x` (isolated git worktree)
+**Status:** experiment / proposal — all changes are `.fs` source written under an explicit waiver of the script-only policy; the human contributor remains gatekeeper for any merge to `master`.
+**Test status:** full suite green throughout — **5526 passed, 0 failed, 2 skipped**.
+
+---
+
+## 1. Goal
+
+Replace the rational-number backing of all dosing math — `MathNet.Numerics.BigRational`
+(a reference type; every op allocates and routes through `BigInteger`) — with a
+faster two-tier struct, `RationalX`, exposed under the existing `BigRational`
+name so the ~47 consuming files compile unchanged. Then measure, profile, and
+chase the bottlenecks the change exposed.
+
+---
+
+## 2. What was changed (in order)
+
+### 2.1 `RationalX` type + global drop-in alias
+- **New** `src/Informedica.Utils.Lib/BCL/RationalX.fs`: a `[<Struct; CustomEquality; CustomComparison>]`
+  two-tier rational. Small tier = reduced `int64` numerator/denominator (the
+  common, allocation-free path) with cross-reduction + branchless overflow
+  detection (`Math.BigMul`, sign-bit tests); spill tier wraps the existing
+  MathNet `BigRational` only on int64 overflow. Full MathNet API parity
+  (`FromInt/FromBigInt/FromDecimal/ToDouble/ToInt32/ToBigInt/Abs/Parse/Numerator/
+  Denominator/+ - * / ~-`), `NumericLiteralN` (so `0N`…`1000N` work), `IEquatable<RationalX>`,
+  and `type BigRational = RationalX`.
+- `BCL/BigRational.fs`: dropped `open MathNet.Numerics`; added the `ModuleSuffix`
+  compilation representation so the `BigRational` **module** and the new
+  `BigRational` **type** coexist.
+- Migration: removed `open MathNet.Numerics` from ~31 src + ~13 test files
+  (replaced with `open Informedica.Utils.Lib.BCL`). `Double.fs`/`BigInteger.fs`
+  keep MathNet (compiled before `RationalX.fs`; internal numeric use only).
+- **Canonical-representation invariant**: any value that fits int64 is always
+  stored small — guarantees one representation per value, so equality/hashing
+  stay consistent for `Array.distinct`, `Set`, and `Map` keys.
+
+### 2.2 Struct shrink — 32 B → 24 B
+- Replaced the struct **DU** (which spends 8 B on a tag) with a hand-rolled
+  struct `(int64 P, int64 Q, BigCell Big)` where `Big = null` is the small/big
+  discriminator. Removes the tag word; small case stays inline and alloc-free.
+
+### 2.3 Unboxed dedup in `ValueUnit.calc`
+- Added `BigRational.distinct` (order-preserving, `HashSet<BigRational>()` with
+  the default `EqualityComparer`, which uses the unboxed `IEquatable` path) next
+  to `calcCartesian`, and switched `ValueUnit.calc` (`ValueUnit.fs`) to use it.
+  F#'s structural `Array.distinct` boxes every `[<CustomEquality>]` struct; this
+  avoids it.
+
+### 2.4 Eager-logging guards
+- Added `Logging.isActive logger` (true unless the no-op logger) and guarded
+  every eager *build-then-log* site in the solve path so the expensive console
+  table / constraint dump is built **only when a logger will consume it**:
+  `Order.logOrder`, and `OrderProcessor` `setCalculatedConstraintsStep`,
+  `applyConstraintsStep`, `logUnmatched`.
+
+### 2.5 Dead-code removal in the solver
+- `GenSOLVER/Equation.fs`: removed a provably-dead per-iteration `List.sortBy`
+  (its output was re-sorted by the next iteration before `calcVars` ran, and the
+  loop's final list is consumed by index). Behaviour-preserving; perf-neutral.
+
+---
+
+## 3. Benchmark results
+
+A/B method: build + run the same harness in this worktree (RationalX) and on
+`master` (original BigRational); BenchmarkDotNet means. Harnesses live in
+`benchmark/{RationalXBench,ValueUnitBench,ScenarioBench}` (gitignored by the
+opt-in policy; build/run with `dotnet run -c Release`).
+
+### 3.1 Raw arithmetic micro-benchmark (`RationalXBench`)
+`(a*b)/c` over a real base-unit fraction pool:
+
+| | MathNet BigRational | RationalX |
+|---|---|---|
+| Time | 71.8 µs | **16.6 µs (≈4.3×)** |
+| Allocated | 156 KB | **0 B** |
+| Spill rate | — | 0 / 24 |
+
+### 3.2 Arithmetic-bound path — `ValueUnit.calc` cartesian (`ValueUnitBench`)
+
+| Case | BigRational | RX 32 B | RX 24 B | **RX 24 B + unboxed distinct** |
+|---|---|---|---|---|
+| Mul mg/mL × mL (160k) — time | 75.6 ms | 31.4 ms | 25.3 ms | **20.1 ms (3.8×)** |
+| Mul — alloc | 57.2 MB | 46.0 MB | 36.2 MB | **21.1 MB (−63%)** |
+| Add Count (360k) — time | 85.0 ms | 59.1 ms | 59.4 ms | **39.4 ms (2.2×)** |
+| Add — alloc | 57.7 MB | 99.9 MB | 80.2 MB | **49.0 MB (−15%)** |
+
+Note the journey: the 32 B struct DU *regressed* store-heavy allocation (+73%);
+the 24 B shrink and the unboxed dedup together turned it into a win on both axes.
+Distinct result sets identical throughout.
+
+### 3.3 End-to-end — GenORDER scenario solve (`ScenarioBench`, 8 scenarios)
+
+| Variant | Time | Allocated |
+|---|---|---|
+| BigRational baseline (master) | 153.9 ms | 301.8 MB |
+| RationalX (24 B + unboxed distinct) | 148.2 ms | 263.7 MB |
+| **+ eager-logging guards** | **117.4 ms** | **192.4 MB** |
+
+**Net vs original baseline: −24% time, −36% allocation, zero correctness cost**
+(per-scenario result hashes bit-identical; all tests pass).
+
+---
+
+## 4. Key findings
+
+1. **RationalX wins where work is arithmetic-bound** (2–4×, less memory), is
+   modestly positive end-to-end, and is correctness-neutral everywhere.
+2. **Amdahl in action.** Speedup shrinks up the stack as the rational-arithmetic
+   fraction shrinks: raw 4.3× → `ValueUnit.calc` 2–4× → full solve ~1.04×
+   (the solve is *not* bottlenecked on rational arithmetic).
+3. **The biggest end-to-end win was not the rational type — it was logging.**
+   `logOrder` built a full console table (sort + ConsoleTables + Wcwidth +
+   heavy allocation) on every solve step and handed it to a `noOp` logger that
+   discarded it. Guarding it cut ~21% off the (already optimized) solve.
+4. **Struct width matters for store-heavy paths.** A 24 B struct beats a 32 B
+   one when large arrays of values dominate; and a `[<CustomEquality>]` struct
+   must avoid boxing in `Array.distinct` (use a typed comparer).
+5. **Sampling-profiler self-time is not wall-clock under heavy GC.**
+   `dotnet-sampled-thread-time` attributed ~34% to `List.sortBy` in the solver;
+   a controlled A/B (disable the sort, measure) showed it costs ≈0 — the time
+   was GC/allocation charged to whatever frame was on the stack (`PollGC` = 51%).
+   The real solver cost is broad allocation pressure, not any single line.
+
+---
+
+## 5. Where the scenario solve time goes (after the wins above)
+
+- DTO build/parse (`toOrderDto` + `fromDto`): ~6%.
+- Solve pipeline: ~94%, dominated by **allocation/GC** (`PollGC` ~51% of samples).
+  Actual numeric kernels (`minIncrMaxToValues` ~6%, `Solver.solveAll` ~4%) are small.
+- **Next frontier:** holistic allocation reduction in `Equation.loop` (it rebuilds
+  immutable `vars` lists every propagation step via `List.map`/`replace`/`rotations`/
+  `sortBy`). A careful array-based / in-place refactor of core solver logic —
+  high validation cost, not a quick win.
+
+---
+
+## 6. Files changed
+
+**New**
+- `src/Informedica.Utils.Lib/BCL/RationalX.fs` — the type, `NumericLiteralN`, alias.
+- `src/Informedica.Utils.Lib/Scripts/RationalXCheck.fsx` — FSI correctness gate.
+- `benchmark/RationalXBench/`, `benchmark/ValueUnitBench/`, `benchmark/ScenarioBench/` —
+  A/B harnesses (ScenarioBench also has `profile` and `trace` modes).
+
+**Modified (36 tracked `.fs`)**
+- `Utils.Lib`: `BCL/BigRational.fs` (ModuleSuffix, removed MathNet open, added `distinct`),
+  `Json.fs`, `Set.fs` (removed MathNet open).
+- `GenUNITS.Lib`, `GenCORE.Lib`, `GenFORM.Lib`, `ZForm.Lib`, `NKF.Lib`,
+  `GenSOLVER.Lib` (`Utils.fs`, `Variable.fs`), `GenORDER.Lib`: the `open MathNet`
+  migration (mostly 1-line each).
+- `GenORDER.Lib/Logging.fs` (`isActive`), `Order.fs` + `OrderProcessor.fs`
+  (logging guards), `GenSOLVER.Lib/Equation.fs` (dead-sort removal).
+- `benchmark/Informedica.GenSolver.Lib_v1` left untouched (pre-existing, stale).
+
+---
+
+## 7. Recommendations
+
+1. **Adopt RationalX** — net win, correctness-neutral, all tests green. Migrate
+   per the script-only policy (human review of each `.fs`).
+2. **[DONE] Proper lazy-logging API.** `Logger` gained an `Enabled: Level -> bool`
+   field; `noOp` is `false`, `create`/real loggers `true`, `filterByLevel`/`combine`
+   propagate it. New thunk-based `logLazy`/`logInfoLazy` build the message only
+   when `Enabled level`. `Logging.isActive` is redefined as `Enabled Informative`,
+   so the existing guards generalise beyond `noOp` to **any** logger filtered
+   above informative; `logOrder` migrated to the thunk API. (8 `Logger` literal
+   sites updated for the new field — 2 in `Logging.Lib`, AgentLogger, SolverLogging,
+   OrderLogging, plus test/benchmark loggers.) Scenario solve holds at ~116 ms.
+3. **[DONE] Unboxed `distinct`** applied to the `cmp` sites `ValueUnit.fs:845/847`
+   (`toBaseValue |> BigRational.distinct |> Array.sort`). Sites `1320`/`1398` are
+   `string[]` (not `BigRational[]`) so they are left on `Array.distinct`.
+4. **Treat the solver's allocation profile as the next perf project** if
+   end-to-end latency matters — scope an `Equation.loop` allocation-reduction
+   refactor separately, with full solver-roundtrip validation.

--- a/src/Informedica.GenCORE.Lib/MinMax.fs
+++ b/src/Informedica.GenCORE.Lib/MinMax.fs
@@ -44,11 +44,9 @@ module LimitIncr =
 
 module Limit =
 
-    open MathNet.Numerics
-
-    open Informedica.Utils.Lib
     open Informedica.Utils.Lib.BCL
 
+    open Informedica.Utils.Lib
 
     let toString isMin lim =
         let s = if isMin then "Min" else "Max"
@@ -381,12 +379,10 @@ module Limit =
 module MinMax =
 
     open System
-    open MathNet.Numerics
+    open Informedica.Utils.Lib.BCL
     open Aether
 
     open Informedica.Utils.Lib
-    open Informedica.Utils.Lib.BCL
-
 
     module Calculator =
 

--- a/src/Informedica.GenCORE.Lib/ValueUnit.fs
+++ b/src/Informedica.GenCORE.Lib/ValueUnit.fs
@@ -3,10 +3,9 @@ namespace Informedica.GenCore.Lib.ValueUnits
 
 module ValueUnit =
 
-    open MathNet.Numerics
+    open Informedica.Utils.Lib.BCL
     open FsToolkit.ErrorHandling
 
-    open Informedica.Utils.Lib.BCL
     open Informedica.GenCore.Lib
     open Informedica.GenUnits.Lib
     open Informedica.GenUnits.Lib.ValueUnit

--- a/src/Informedica.GenFORM.Lib/Check.fs
+++ b/src/Informedica.GenFORM.Lib/Check.fs
@@ -4,7 +4,6 @@ namespace Informedica.GenForm.Lib
 module Check =
 
     open Informedica.Utils.Lib
-    open MathNet.Numerics
     open Informedica.Utils.Lib.BCL
     open Informedica.GenUnits.Lib
     open Informedica.GenCore.Lib.Ranges

--- a/src/Informedica.GenFORM.Lib/DoseRule.fs
+++ b/src/Informedica.GenFORM.Lib/DoseRule.fs
@@ -4,13 +4,12 @@ namespace Informedica.GenForm.Lib
 module DoseRule =
 
     open System
-    open MathNet.Numerics
+    open Informedica.Utils.Lib.BCL
 
     open FSharp.Data
     open FSharp.Data.JsonExtensions
 
     open Informedica.Utils.Lib
-    open Informedica.Utils.Lib.BCL
     open Informedica.GenCore.Lib.Ranges
 
     open Utils

--- a/src/Informedica.GenFORM.Lib/Export.fs
+++ b/src/Informedica.GenFORM.Lib/Export.fs
@@ -2,9 +2,8 @@ namespace Informedica.GenForm.Lib
 
 
 open System
-open MathNet.Numerics
-open Informedica.Utils.Lib
 open Informedica.Utils.Lib.BCL
+open Informedica.Utils.Lib
 open Informedica.GenUnits.Lib
 open Informedica.GenCore.Lib.Ranges
 

--- a/src/Informedica.GenFORM.Lib/Patient.fs
+++ b/src/Informedica.GenFORM.Lib/Patient.fs
@@ -53,7 +53,6 @@ module Gender =
 module PatientCategory =
 
 
-    open MathNet.Numerics
     open Informedica.Utils.Lib.BCL
     open Informedica.GenUnits.Lib
 
@@ -414,7 +413,6 @@ module PatientCategory =
 
 module Patient =
 
-    open MathNet.Numerics
     open Informedica.Utils.Lib.BCL
     open Informedica.GenUnits.Lib
 

--- a/src/Informedica.GenFORM.Lib/Product.fs
+++ b/src/Informedica.GenFORM.Lib/Product.fs
@@ -4,11 +4,9 @@ namespace Informedica.GenForm.Lib
 module Product =
 
 
-    open MathNet.Numerics
+    open Informedica.Utils.Lib.BCL
     open Informedica.Utils.Lib
     open ConsoleWriter.NewLineNoTime
-    open Informedica.Utils.Lib.BCL
-
     open Informedica.GenUnits.Lib
 
     open Utils

--- a/src/Informedica.GenFORM.Lib/RenalRule.fs
+++ b/src/Informedica.GenFORM.Lib/RenalRule.fs
@@ -3,9 +3,8 @@ namespace Informedica.GenForm.Lib
 
 module RenalRule =
 
-    open MathNet.Numerics
-    open Informedica.Utils.Lib
     open Informedica.Utils.Lib.BCL
+    open Informedica.Utils.Lib
     open ConsoleWriter.NewLineNoTime
 
     open Informedica.GenUnits.Lib

--- a/src/Informedica.GenFORM.Lib/SolutionRule.fs
+++ b/src/Informedica.GenFORM.Lib/SolutionRule.fs
@@ -3,10 +3,8 @@ namespace Informedica.GenForm.Lib
 
 module SolutionRule =
 
-    open MathNet.Numerics
-    open Informedica.Utils.Lib
     open Informedica.Utils.Lib.BCL
-
+    open Informedica.Utils.Lib
     open Informedica.GenUnits.Lib
     open Informedica.GenCore.Lib.Ranges
 

--- a/src/Informedica.GenFORM.Lib/Types.fs
+++ b/src/Informedica.GenFORM.Lib/Types.fs
@@ -4,7 +4,7 @@ namespace Informedica.GenForm.Lib
 [<AutoOpen>]
 module Types =
 
-    open MathNet.Numerics
+    open Informedica.Utils.Lib.BCL
 
     open Informedica.Logging.Lib
     open Informedica.GenUnits.Lib

--- a/src/Informedica.GenFORM.Lib/Utils.fs
+++ b/src/Informedica.GenFORM.Lib/Utils.fs
@@ -4,10 +4,9 @@ namespace Informedica.GenForm.Lib
 module Utils =
 
     open System
-    open MathNet.Numerics
+    open Informedica.Utils.Lib.BCL
 
     open Informedica.Utils.Lib
-    open Informedica.Utils.Lib.BCL
 
     module Parallel =
 

--- a/src/Informedica.GenORDER.Lib/Logging.fs
+++ b/src/Informedica.GenORDER.Lib/Logging.fs
@@ -29,13 +29,6 @@ module Logging =
     let noOp = Logging.noOp
 
 
-    /// True when the logger would consume an informative message, so hot paths
-    /// can skip building expensive debug strings (console tables, constraint
-    /// dumps). Generalises beyond the no-op logger to any logger filtered above
-    /// the informative level.
-    let isActive (logger: Logger) = logger.Enabled Level.Informative
-
-
     /// Log an order event built lazily at the given level: the thunk (and any
     /// expensive work inside it, e.g. a console table) runs only if the logger
     /// would actually consume a message at that level.

--- a/src/Informedica.GenORDER.Lib/Logging.fs
+++ b/src/Informedica.GenORDER.Lib/Logging.fs
@@ -27,3 +27,28 @@ module Logging =
 
     /// Ignore logger for backward compatibility
     let noOp = Logging.noOp
+
+
+    /// True when the logger would consume an informative message, so hot paths
+    /// can skip building expensive debug strings (console tables, constraint
+    /// dumps). Generalises beyond the no-op logger to any logger filtered above
+    /// the informative level.
+    let isActive (logger: Logger) = logger.Enabled Level.Informative
+
+
+    /// Log an order event built lazily at the given level: the thunk (and any
+    /// expensive work inside it, e.g. a console table) runs only if the logger
+    /// would actually consume a message at that level.
+    let logMessageLazy level (logger: Logger) (mk: unit -> Events.Event) =
+        Logging.logLazy level logger (fun () -> mk () |> OrderEventMessage :> IMessage)
+
+
+    /// Log an order event built lazily: the thunk (and any expensive work inside
+    /// it) runs only if the logger would consume an informative message.
+    let logInfoLazy (logger: Logger) (mk: unit -> Events.Event) =
+        logMessageLazy Level.Informative logger mk
+
+
+    /// Log an order event built lazily: the thunk runs only if the logger would
+    /// consume a warning message.
+    let logWarningLazy (logger: Logger) (mk: unit -> Events.Event) = logMessageLazy Level.Warning logger mk

--- a/src/Informedica.GenORDER.Lib/Medication.fs
+++ b/src/Informedica.GenORDER.Lib/Medication.fs
@@ -5,7 +5,6 @@ module Medication =
 
     open System
     open Informedica.Utils.Lib
-    open MathNet.Numerics
     open Informedica.Utils.Lib.BCL
     open ConsoleWriter.NewLineNoTime
     open Informedica.GenForm.Lib
@@ -1302,12 +1301,18 @@ module Medication =
 
         meds
         |> Array.iter (fun med ->
-            med
-            |> toString
-            |> List.map (sprintf "%s")
-            |> String.concat "\n"
-            |> Events.MedicationCreated
-            |> Informedica.GenOrder.Lib.Logging.logInfo logger
+            // FLAG: expensive message build (Medication.toString formats every
+            // substance/component incl. ValueUnits) — kept lazy so it is skipped
+            // when the logger is off.
+            Informedica.GenOrder.Lib.Logging.logInfoLazy
+                logger
+                (fun () ->
+                    med
+                    |> toString
+                    |> List.map (sprintf "%s")
+                    |> String.concat "\n"
+                    |> Events.MedicationCreated
+                )
         )
 
         meds

--- a/src/Informedica.GenORDER.Lib/Order.fs
+++ b/src/Informedica.GenORDER.Lib/Order.fs
@@ -12,9 +12,8 @@ module Order =
 
 
     open System
-    open MathNet.Numerics
-    open Informedica.Utils.Lib
     open Informedica.Utils.Lib.BCL
+    open Informedica.Utils.Lib
     open ConsoleWriter.NewLineNoTime
     open Informedica.GenUnits.Lib
     open WrappedString
@@ -3352,16 +3351,22 @@ module Order =
 
 
     let logOrder logger minMax msg ord =
-        let s = ord |> toConsoleTableString
-        let m = if minMax then "Min/Max" else "All Values"
+        // Build the (expensive) console table lazily: toConsoleTableString drives
+        // List.sortBy / ConsoleTables / Wcwidth / heavy allocation, so it runs
+        // only when the logger would actually consume an informative message.
+        Logging.logInfoLazy
+            logger
+            (fun () ->
+                let s = ord |> toConsoleTableString
+                let m = if minMax then "Min/Max" else "All Values"
 
-        $"""
+                $"""
 == {msg} {m} ==
 {s}
 == End of Table ==
 """
-        |> Events.OrderScenario
-        |> Logging.logInfo logger
+                |> Events.OrderScenario
+            )
 
 
     /// <summary>

--- a/src/Informedica.GenORDER.Lib/OrderLogging.fs
+++ b/src/Informedica.GenORDER.Lib/OrderLogging.fs
@@ -244,6 +244,7 @@ messages: {msgs.Value.Count}
                     |> fun s ->
                         if not (String.IsNullOrEmpty s) then
                             f s
+            Enabled = fun _ -> true
         }
 
 

--- a/src/Informedica.GenORDER.Lib/OrderProcessor.fs
+++ b/src/Informedica.GenORDER.Lib/OrderProcessor.fs
@@ -318,7 +318,10 @@ module OrderProcessor =
 
         let logUnmatched (kind: string) =
             $"===> no match for {kind} cleared " |> writeWarningMessage
-            ord |> toConsoleTableString |> Events.OrderScenario |> Logging.logWarning logger
+
+            // FLAG: expensive message build (toConsoleTableString renders a full
+            // console table) — kept lazy so it is skipped when logging is off.
+            Logging.logWarningLazy logger (fun () -> ord |> toConsoleTableString |> Events.OrderScenario)
 
         match (ord |> inf).Schedule with
         | Continuous _ ->
@@ -503,7 +506,10 @@ module OrderProcessor =
         let setCalculatedConstraintsStep =
             setCalculatedConstraints
             >> fun ord ->
-                ord |> toConsoleTableString |> Events.OrderScenario |> Logging.logInfo logger
+                // FLAG: expensive message build (toConsoleTableString) — kept lazy
+                // so it is skipped when the logger is off.
+                Logging.logInfoLazy logger (fun () -> ord |> toConsoleTableString |> Events.OrderScenario)
+
                 ord
             >> Ok
 
@@ -531,7 +537,10 @@ module OrderProcessor =
             ord
             |> applyConstraints
             |> fun ord ->
-                ord |> toConsoleTableString |> Events.OrderScenario |> Logging.logInfo logger
+                // FLAG: expensive message build (toConsoleTableString) — kept lazy
+                // so it is skipped when the logger is off.
+                Logging.logInfoLazy logger (fun () -> ord |> toConsoleTableString |> Events.OrderScenario)
+
                 ord
             |> Ok
 

--- a/src/Informedica.GenORDER.Lib/OrderVariable.fs
+++ b/src/Informedica.GenORDER.Lib/OrderVariable.fs
@@ -6,7 +6,7 @@ namespace Informedica.GenOrder.Lib
 /// `Informedica.GenUnits.Lib`
 module ValueUnit =
 
-    open MathNet.Numerics
+    open Informedica.Utils.Lib.BCL
     open Informedica.GenUnits.Lib
     open ValueUnit
 
@@ -174,10 +174,9 @@ module Variable =
 module OrderVariable =
 
 
-    open MathNet.Numerics
+    open Informedica.Utils.Lib.BCL
 
     open Informedica.Utils.Lib
-    open Informedica.Utils.Lib.BCL
     open ConsoleWriter.NewLineNoTime
     open Informedica.GenCore.Lib.Ranges
     open Informedica.GenSolver.Lib

--- a/src/Informedica.GenORDER.Lib/Types.fs
+++ b/src/Informedica.GenORDER.Lib/Types.fs
@@ -6,7 +6,7 @@ module Types =
 
 
     open System
-    open MathNet.Numerics
+    open Informedica.Utils.Lib.BCL
 
     open Informedica.GenUnits.Lib
     open Informedica.GenSolver.Lib.Types

--- a/src/Informedica.GenSOLVER.Lib/Equation.fs
+++ b/src/Informedica.GenSOLVER.Lib/Equation.fs
@@ -434,15 +434,15 @@ module Equation =
         match calcVars log op1 op2 vars with
         | None -> acc, vars
         | Some var ->
+            // No re-sort here: the top of the next loop iteration re-sorts by
+            // Variable.count (sum) before calcVars runs, so any ordering applied
+            // here is immediately overwritten and never reaches calcVars. The
+            // loop's final vars list is consumed by index (List.find (fst = 0)),
+            // so its order is irrelevant. Dropping this sort removed ~half the
+            // per-iteration List.sortBy cost with no behavioural change.
             let vars =
                 vars
                 |> List.map (fun (i, xs) -> i, xs |> List.replace (Variable.eqName var) var)
-                |> fun vars ->
-                    if onlyMinIncrMax then
-                        vars
-                    else
-                        vars
-                        |> List.sortBy (fun (_, xs) -> xs |> List.tail |> List.map Variable.count |> List.reduce (*))
 
             let acc = acc |> List.replaceOrAdd (Variable.eqName var) var
 

--- a/src/Informedica.GenSOLVER.Lib/SolverLogging.fs
+++ b/src/Informedica.GenSOLVER.Lib/SolverLogging.fs
@@ -213,6 +213,7 @@ module SolverLogging =
                     |> fun s ->
                         if not (String.IsNullOrEmpty s) then
                             f s
+            Enabled = fun _ -> true
         }
 
     /// Ignore logger for backward compatibility

--- a/src/Informedica.GenSOLVER.Lib/Utils.fs
+++ b/src/Informedica.GenSOLVER.Lib/Utils.fs
@@ -5,7 +5,7 @@ namespace Informedica.GenSolver.Lib
 module Utils =
 
     open System
-    open MathNet.Numerics
+    open Informedica.Utils.Lib.BCL
 
 
     module Parallel =
@@ -37,8 +37,6 @@ module Utils =
 
 
     module ValueUnit =
-
-        open Informedica.Utils.Lib.BCL
 
         open Informedica.GenUnits.Lib
         open ValueUnit
@@ -140,7 +138,7 @@ module Utils =
             let (|Mul|Div|Add|Sub|) op =
                 // Bridge the ValueUnit op to a BigRational op using dimensionless units (Count.times)
                 let toBrOp (o: ValueUnit -> ValueUnit -> ValueUnit) =
-                    fun (a: MathNet.Numerics.BigRational) (b: MathNet.Numerics.BigRational) ->
+                    fun (a: BigRational) (b: BigRational) ->
                         let va = [| a |] |> create Units.Count.times
                         let vb = [| b |] |> create Units.Count.times
                         let vr = o va vb

--- a/src/Informedica.GenSOLVER.Lib/Variable.fs
+++ b/src/Informedica.GenSOLVER.Lib/Variable.fs
@@ -4,9 +4,8 @@ namespace Informedica.GenSolver.Lib
 module Variable =
 
     open System
-    open MathNet.Numerics
-
     open Informedica.Utils.Lib.BCL
+
     open Informedica.Utils.Lib.ConsoleWriter.NewLineNoTime
     open Informedica.GenUnits.Lib
 

--- a/src/Informedica.GenUNITS.Lib/Core.fs
+++ b/src/Informedica.GenUNITS.Lib/Core.fs
@@ -1,6 +1,6 @@
 namespace Informedica.GenUnits.Lib
 
-open MathNet.Numerics
+open Informedica.Utils.Lib.BCL
 open Informedica.GenUnits.Lib.Types
 
 module Core =

--- a/src/Informedica.GenUNITS.Lib/Group.fs
+++ b/src/Informedica.GenUNITS.Lib/Group.fs
@@ -1,6 +1,6 @@
 namespace Informedica.GenUnits.Lib
 
-open MathNet.Numerics
+open Informedica.Utils.Lib.BCL
 open Informedica.GenUnits.Lib.Types
 
 open Informedica.Utils.Lib

--- a/src/Informedica.GenUNITS.Lib/Parser.fs
+++ b/src/Informedica.GenUNITS.Lib/Parser.fs
@@ -1,6 +1,6 @@
 namespace Informedica.GenUnits.Lib
 
-open MathNet.Numerics
+open Informedica.Utils.Lib.BCL
 open Informedica.Utils.Lib.BCL
 
 

--- a/src/Informedica.GenUNITS.Lib/Types.fs
+++ b/src/Informedica.GenUNITS.Lib/Types.fs
@@ -1,6 +1,6 @@
 namespace Informedica.GenUnits.Lib
 
-open MathNet.Numerics
+open Informedica.Utils.Lib.BCL
 
 
 // Foundational unit types.

--- a/src/Informedica.GenUNITS.Lib/Units.fs
+++ b/src/Informedica.GenUNITS.Lib/Units.fs
@@ -1,6 +1,6 @@
 namespace Informedica.GenUnits.Lib
 
-open MathNet.Numerics
+open Informedica.Utils.Lib.BCL
 open Informedica.GenUnits.Lib.Types
 
 open Informedica.Utils.Lib.BCL

--- a/src/Informedica.GenUNITS.Lib/Utils.fs
+++ b/src/Informedica.GenUNITS.Lib/Utils.fs
@@ -4,7 +4,7 @@ namespace Informedica.GenUnits.Lib
 module Array =
 
     open Informedica.Utils.Lib.BCL
-    open MathNet.Numerics
+    open Informedica.Utils.Lib.BCL
 
     /// <summary>
     /// Remove all BigRationals that are multiples of the smallest BigRationals in the array.

--- a/src/Informedica.GenUNITS.Lib/ValueUnit.fs
+++ b/src/Informedica.GenUNITS.Lib/ValueUnit.fs
@@ -1,6 +1,6 @@
 namespace Informedica.GenUnits.Lib
 
-open MathNet.Numerics
+open Informedica.Utils.Lib.BCL
 
 open Informedica.Utils.Lib
 open Informedica.Utils.Lib.BCL
@@ -760,7 +760,7 @@ module ValueUnit =
         let v =
             let vs1 = vu1 |> toBaseValue
             let vs2 = vu2 |> toBaseValue
-            BigRational.calcCartesian op vs1 vs2 |> Array.distinct
+            BigRational.calcCartesian op vs1 vs2 |> BigRational.distinct
 
         (*
             Array.allPairs vs1 vs2
@@ -842,9 +842,9 @@ module ValueUnit =
         then
             failwith $"cannot compare {vu1} with {vu2}"
 
-        let vs1 = vu1 |> toBaseValue |> Array.distinct |> Array.sort
+        let vs1 = vu1 |> toBaseValue |> BigRational.distinct |> Array.sort
 
-        let vs2 = vu2 |> toBaseValue |> Array.distinct |> Array.sort
+        let vs2 = vu2 |> toBaseValue |> BigRational.distinct |> Array.sort
 
         vs1 = vs2
 

--- a/src/Informedica.Logging.Lib/Logging.fs
+++ b/src/Informedica.Logging.Lib/Logging.fs
@@ -27,7 +27,14 @@ type Event =
     }
 
 
-type Logger = { Log: Event -> unit }
+type Logger =
+    {
+        Log: Event -> unit
+        /// Whether this logger would consume a message at the given level. Lets
+        /// the lazy log API skip building expensive messages that a logger
+        /// (the no-op logger, or one filtered above a level) would discard.
+        Enabled: Level -> bool
+    }
 
 
 /// General logging module
@@ -48,15 +55,21 @@ module Logging =
         msg |> createMessage level |> logger.Log
 
 
-    /// Log an informative message
+    /// Log an informative message.
+    /// Eager: builds the message at the call site. This is fine because the
+    /// logging agent performs the (potentially expensive) formatting and writing
+    /// asynchronously. Use logInfoLazy only when building the message itself is
+    /// expensive (e.g. rendering a console table).
     let logInfo logger msg = logWith Level.Informative logger msg
 
 
-    /// Log a warning message
+    /// Log a warning message. Eager — see logInfo. Prefer logWarningLazy only
+    /// when building the message itself is expensive.
     let logWarning logger msg = logWith Level.Warning logger msg
 
 
-    /// Log a debug message
+    /// Log a debug message. Eager — see logInfo. Prefer logDebugLazy only
+    /// when building the message itself is expensive.
     let logDebug logger msg = logWith Level.Debug logger msg
 
 
@@ -65,11 +78,37 @@ module Logging =
 
 
     /// A logger that does nothing
-    let noOp: Logger = { Log = ignore }
+    let noOp: Logger =
+        {
+            Log = ignore
+            Enabled = fun _ -> false
+        }
 
 
     /// Create a logger that uses the given function to process messages
-    let create (f: Event -> unit) : Logger = { Log = f }
+    let create (f: Event -> unit) : Logger =
+        {
+            Log = f
+            Enabled = fun _ -> true
+        }
+
+
+    /// Whether the logger would consume a message at the given level.
+    let isEnabled level (logger: Logger) = logger.Enabled level
+
+
+    /// Log a message built lazily: the thunk (and any expensive work inside it,
+    /// e.g. a console table) runs ONLY if the logger would actually consume a
+    /// message at this level. Generalises the noOp fast-path to any logger
+    /// filtered above the given level.
+    let logLazy level (logger: Logger) (mk: unit -> IMessage) =
+        if logger.Enabled level then
+            mk () |> createMessage level |> logger.Log
+
+
+    let logInfoLazy logger mk = logLazy Level.Informative logger mk
+    let logWarningLazy logger mk = logLazy Level.Warning logger mk
+    let logDebugLazy logger mk = logLazy Level.Debug logger mk
 
 
     /// Create a logger that prints to the console using a message formatter
@@ -97,7 +136,9 @@ module Logging =
 
     /// Combine multiple loggers into one
     let combine (loggers: Logger list) : Logger =
-        create (fun msg -> loggers |> List.iter (fun logger -> logger.Log msg))
+        { create (fun msg -> loggers |> List.iter (fun logger -> logger.Log msg)) with
+            Enabled = fun level -> loggers |> List.exists (fun logger -> logger.Enabled level)
+        }
 
 
     let levelValue =
@@ -110,19 +151,23 @@ module Logging =
 
     /// Filter messages by level
     let filterByLevel (minLevel: Level) (logger: Logger) : Logger =
-        create (fun msg ->
-            if levelValue msg.Level >= levelValue minLevel then
-                logger.Log msg
-        )
+        { create (fun msg ->
+              if levelValue msg.Level >= levelValue minLevel then
+                  logger.Log msg
+          ) with
+            Enabled = fun level -> levelValue level >= levelValue minLevel && logger.Enabled level
+        }
 
 
     /// Filter messages by type
     let filterByType<'T when 'T :> IMessage> (logger: Logger) : Logger =
-        create (fun msg ->
-            match msg.Message with
-            | :? 'T -> logger.Log msg
-            | _ -> ()
-        )
+        { create (fun msg ->
+              match msg.Message with
+              | :? 'T -> logger.Log msg
+              | _ -> ()
+          ) with
+            Enabled = logger.Enabled
+        }
 
 
 /// Message formatter module
@@ -618,6 +663,7 @@ module AgentLogging =
                                 with
                                 | :? ObjectDisposedException -> ()
                                 | ex -> eprintfn $"Failed to post log event {ev} with:\n{ex.Message}"
+                    Enabled = fun _ -> true
                 }
 
             ReportAsync =

--- a/src/Informedica.NKF.Lib/Utils.fs
+++ b/src/Informedica.NKF.Lib/Utils.fs
@@ -225,7 +225,7 @@ module Utils =
 
     module ValueUnit =
 
-        open MathNet.Numerics
+        open Informedica.Utils.Lib.BCL
         open Informedica.Utils.Lib.BCL
         open Informedica.GenUnits.Lib
 

--- a/src/Informedica.Utils.Lib/BCL/BigRational.fs
+++ b/src/Informedica.Utils.Lib/BCL/BigRational.fs
@@ -2,11 +2,12 @@ namespace Informedica.Utils.Lib.BCL
 
 
 /// Helper functions for `BigRational`
-[<RequireQualifiedAccess>]
+/// Note: needs the ModuleSuffix to prevent build error with
+/// BigRational type definition
+[<RequireQualifiedAccess; CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module BigRational =
 
     open System
-    open MathNet.Numerics
 
     //----------------------------------------------------------------------------
     // Error management
@@ -170,29 +171,6 @@ module BigRational =
         let den = a.Denominator * b.Denominator
         let num = BigInteger.gcd (a.Numerator * b.Denominator) (b.Numerator * a.Denominator)
         (num |> BigRational.FromBigInt) / (den |> BigRational.FromBigInt)
-
-
-    (*
-    /// Convert `n` to a multiple of `d`.
-    /// Passes an `CannotDivideByZero` message
-    /// to `fail` when `d` is zero.
-    let toMultipleOfCont succ fail d n  =
-        if d = 0N then CannotDivideByZero |> fail
-        else
-            let m = (n / d) |> BigRational.ToBigInt |> BigRational.FromBigInt
-            if m * d < n then (m + 1N) * d else m * d
-            |> succ
-
-
-    /// Convert `n` to a multiple of `d`.
-    /// Raises an `CannotDivideByZero` message
-    /// exception when `d` is zero.
-    let toMultipleOf = toMultipleOfCont id raiseExc
-
-    /// Convert `n` to a multiple of `d`.
-    /// Returns `None` when `d` is zero.
-    let toMultipleOfOpt = toMultipleOfCont Some (fun _ -> None)
-    *)
 
 
     /// Checks whether `v` is a multiple of `incr`
@@ -393,6 +371,26 @@ module BigRational =
                         res[baseIdx + j] <- op v1 vs2[j]
 
                 res
+
+
+    /// Order-preserving distinct over a `BigRational` array using the default
+    /// .NET equality comparer. Because `BigRational` (RationalX) is a struct that
+    /// implements `IEquatable<_>`, this takes the unboxed equality path, avoiding
+    /// the per-element boxing that F#'s structural `Array.distinct` incurs for a
+    /// `[<CustomEquality>]` struct. Behaviour matches `Array.distinct` (keeps the
+    /// first occurrence of each value).
+    let distinct (xs: BigRational[]) : BigRational[] =
+        if xs.Length < 2 then
+            xs
+        else
+            let seen = System.Collections.Generic.HashSet<BigRational> xs.Length
+            let res = ResizeArray<BigRational> xs.Length
+
+            for x in xs do
+                if seen.Add x then
+                    res.Add x
+
+            res.ToArray()
 
 
     /// Calculates the nearest multiple of the given `multiple` based on whether it's required

--- a/src/Informedica.Utils.Lib/BCL/RationalX.fs
+++ b/src/Informedica.Utils.Lib/BCL/RationalX.fs
@@ -1,0 +1,364 @@
+namespace Informedica.Utils.Lib.BCL
+
+open System
+open System.Numerics
+
+
+/// <summary>
+/// Internal spill-tier alias. <c>RationalX</c> keeps exact rationals in an
+/// <c>int64</c> fast path and only falls back to this MathNet
+/// <c>BigRational</c> when an intermediate overflows <c>int64</c>.
+/// </summary>
+type MBR = MathNet.Numerics.BigRational
+
+
+/// <summary>
+/// Heap cell holding a spilled (big) rational. Used as <c>RationalX</c>'s big
+/// tier; its presence (non-null) doubles as the small/big discriminator, which
+/// is what lets <c>RationalX</c> avoid a DU tag word and stay 24 bytes wide.
+/// </summary>
+[<Sealed; AllowNullLiteral>]
+type BigCell(value: MBR) =
+    member _.Value = value
+
+
+[<AutoOpen>]
+module private RationalXHelpers =
+
+    let inline absL (a: int64) = if a < 0L then -a else a
+
+    /// Greatest common divisor of two int64 values (always non-negative).
+    let rec gcd64 (a: int64) (b: int64) : int64 =
+        if b = 0L then absL a else gcd64 b (a % b)
+
+    /// Normalize an int64 fraction: reduce by gcd, force a positive denominator.
+    let normPair (p: int64) (q: int64) : int64 * int64 =
+        if q = 0L then
+            raise (DivideByZeroException())
+
+        let g = gcd64 p q
+        let g = if g = 0L then 1L else g
+        let p, q = p / g, q / g
+        if q < 0L then (-p, -q) else (p, q)
+
+    /// Build an MBR from an int64 pair (MBR normalizes itself).
+    let sToLarge (p: int64) (q: int64) : MBR =
+        MBR.FromBigIntFraction(bigint p, bigint q)
+
+    let minB = BigInteger Int64.MinValue
+    let maxB = BigInteger Int64.MaxValue
+    let inline fitsI64 (b: BigInteger) = b >= minB && b <= maxB
+
+    // branchless overflow detection: no try/with region, no Int128
+
+    /// Multiply with overflow check. Returns the product when it fits int64.
+    let mulFits (a: int64) (b: int64) : int64 voption =
+        let mutable low = 0L
+        let high = Math.BigMul(a, b, &low)
+        if high = (low >>> 63) then ValueSome low else ValueNone
+
+    /// Add with overflow check (sign-bit test).
+    let addFits (a: int64) (b: int64) : int64 voption =
+        let s = a + b
+
+        if ((a ^^^ s) &&& (b ^^^ s)) < 0L then
+            ValueNone
+        else
+            ValueSome s
+
+    /// Subtract with overflow check (sign-bit test).
+    let subFits (a: int64) (b: int64) : int64 voption =
+        let s = a - b
+
+        if ((a ^^^ b) &&& (a ^^^ s)) < 0L then
+            ValueNone
+        else
+            ValueSome s
+
+
+/// <summary>
+/// A two-tier exact rational packed into 24 bytes: two <c>int64</c>s for the
+/// reduced small-tier numerator/denominator, and a nullable <c>BigCell</c>
+/// reference for the rare spill tier. <c>Big = null</c> means small (value
+/// <c>P/Q</c>); a non-null <c>Big</c> means spilled (value <c>Big.Value</c>).
+/// </summary>
+/// <remarks>
+/// Hand-rolled (rather than a struct DU) so the spill reference itself is the
+/// small/big discriminator — no DU tag word, so every value is 24 bytes and the
+/// common small case is still inline and allocation-free. There is duplicate logic
+/// for handling spill/non-spill cases, however, for performance reasons this is
+/// accepted.
+///
+/// Canonical-representation invariant: any value that fits <c>int64</c> is
+/// ALWAYS stored small (<c>Big = null</c>), never spilled. Every constructor and
+/// arithmetic result funnels through <c>OfLarge</c> (which re-narrows) or
+/// <c>normPair</c>. This guarantees a single representation per value, so
+/// equality and hashing are consistent across the two tiers.
+/// </remarks>
+[<Struct; CustomEquality; CustomComparison>]
+type RationalX =
+
+    // small tier: reduced, Q > 0 (the zero-initialized default 0/0 is guarded)
+    val internal P: int64
+    val internal Q: int64
+    // big tier: null => small (use P/Q); non-null => spilled (use Big.Value)
+    val internal Big: BigCell
+
+    internal new(p: int64, q: int64) =
+        {
+            P = p
+            Q = q
+            Big = null
+        }
+
+    internal new(cell: BigCell) =
+        {
+            P = 0L
+            Q = 0L
+            Big = cell
+        }
+
+    member internal this.IsSmall = isNull this.Big
+
+    /// True when the value spilled out of the int64 fast path.
+    member this.IsSpilled = not (isNull this.Big)
+
+    // --- canonical constructors ---------------------------------------------
+
+    /// Re-narrow an MBR to the small tier whenever it fits int64. Linchpin of
+    /// the canonical-representation invariant.
+    static member OfLarge(x: MBR) : RationalX =
+        if fitsI64 x.Numerator && fitsI64 x.Denominator then
+            RationalX(int64 x.Numerator, int64 x.Denominator) // MBR is already reduced, den > 0
+        else
+            RationalX(BigCell x)
+
+    static member OfFraction(n: int64, d: int64) =
+        let n, d = normPair n d in RationalX(n, d)
+
+    static member Zero = RationalX(0L, 1L)
+    static member One = RationalX(1L, 1L)
+
+    // --- conversions (the drop-in surface) ----------------------------------
+
+    static member FromInt(x: int) = RationalX(int64 x, 1L)
+
+    static member FromInt64Fraction(n: int64, d: int64) = RationalX.OfFraction(n, d)
+
+    static member FromIntFraction(n: int, d: int) = RationalX.OfFraction(int64 n, int64 d)
+
+    static member FromBigInt(z: bigint) =
+        if fitsI64 z then
+            RationalX(int64 z, 1L)
+        else
+            RationalX(BigCell(MBR.FromBigInt z))
+
+    static member FromDecimal(d: decimal) = RationalX.OfLarge(MBR.FromDecimal d)
+
+    static member ToDouble(r: RationalX) =
+        if r.IsSmall then
+            float r.P / float r.Q
+        else
+            MBR.ToDouble r.Big.Value
+
+    // delegate to MBR so rounding (floor toward -inf) matches the original exactly
+    static member ToBigInt(r: RationalX) : bigint =
+        if r.IsSmall then
+            MBR.ToBigInt(sToLarge r.P r.Q)
+        else
+            MBR.ToBigInt r.Big.Value
+
+    static member ToInt32(r: RationalX) : int =
+        if r.IsSmall then
+            MBR.ToInt32(sToLarge r.P r.Q)
+        else
+            MBR.ToInt32 r.Big.Value
+
+    static member Abs(r: RationalX) : RationalX =
+        if r.IsSmall then
+            RationalX(absL r.P, r.Q) // Q is already > 0
+        else
+            let v = r.Big.Value
+            if v.Numerator.Sign < 0 then RationalX.OfLarge(-v) else r
+
+    static member Parse(s: string) : RationalX = RationalX.OfLarge(MBR.Parse s)
+
+    // --- numerator / denominator (return bigint, MBR sign convention) --------
+
+    member this.Numerator: bigint =
+        if this.IsSmall then
+            bigint this.P
+        else
+            this.Big.Value.Numerator
+
+    member this.Denominator: bigint =
+        if this.IsSmall then
+            bigint this.Q
+        else
+            this.Big.Value.Denominator
+
+    // --- arithmetic (cross-reduced hot path, spill to MBR) -------------------
+
+    static member (*)(x: RationalX, y: RationalX) : RationalX =
+        if x.IsSmall && y.IsSmall then
+            let a, b, c, d = x.P, x.Q, y.P, y.Q
+            let g1 = let g = gcd64 a d in if g = 0L then 1L else g
+            let g2 = let g = gcd64 c b in if g = 0L then 1L else g
+            let a2, d2 = a / g1, d / g1
+            let c2, b2 = c / g2, b / g2
+
+            match mulFits a2 c2, mulFits b2 d2 with
+            | ValueSome n, ValueSome m -> if m < 0L then RationalX(-n, -m) else RationalX(n, m)
+            | _ -> RationalX.OfLarge(sToLarge a2 b2 * sToLarge c2 d2)
+        elif x.IsSmall then
+            RationalX.OfLarge(sToLarge x.P x.Q * y.Big.Value)
+        elif y.IsSmall then
+            RationalX.OfLarge(x.Big.Value * sToLarge y.P y.Q)
+        else
+            RationalX.OfLarge(x.Big.Value * y.Big.Value)
+
+    static member (/)(x: RationalX, y: RationalX) : RationalX =
+        if x.IsSmall && y.IsSmall then
+            let a, b, c, d = x.P, x.Q, y.P, y.Q
+
+            if c = 0L then
+                raise (DivideByZeroException())
+
+            let g1 = let g = gcd64 a c in if g = 0L then 1L else g
+            let g2 = let g = gcd64 d b in if g = 0L then 1L else g
+            let a2, c2 = a / g1, c / g1
+            let d2, b2 = d / g2, b / g2
+
+            match mulFits a2 d2, mulFits b2 c2 with
+            | ValueSome n, ValueSome m -> if m < 0L then RationalX(-n, -m) else RationalX(n, m)
+            | _ -> RationalX.OfLarge(sToLarge a2 b2 / sToLarge c2 d2)
+        elif x.IsSmall then
+            RationalX.OfLarge(sToLarge x.P x.Q / y.Big.Value)
+        elif y.IsSmall then
+            RationalX.OfLarge(x.Big.Value / sToLarge y.P y.Q)
+        else
+            RationalX.OfLarge(x.Big.Value / y.Big.Value)
+
+    static member (+)(x: RationalX, y: RationalX) : RationalX =
+        if x.IsSmall && y.IsSmall then
+            let a, b, c, d = x.P, x.Q, y.P, y.Q
+            let g = let g = gcd64 b d in if g = 0L then 1L else g
+            let bg, dg = b / g, d / g
+
+            match mulFits a dg, mulFits c bg, mulFits b dg with
+            | ValueSome t1, ValueSome t2, ValueSome den ->
+                match addFits t1 t2 with
+                | ValueSome num -> let n, m = normPair num den in RationalX(n, m)
+                | ValueNone -> RationalX.OfLarge(sToLarge a b + sToLarge c d)
+            | _ -> RationalX.OfLarge(sToLarge a b + sToLarge c d)
+        elif x.IsSmall then
+            RationalX.OfLarge(sToLarge x.P x.Q + y.Big.Value)
+        elif y.IsSmall then
+            RationalX.OfLarge(x.Big.Value + sToLarge y.P y.Q)
+        else
+            RationalX.OfLarge(x.Big.Value + y.Big.Value)
+
+    static member (-)(x: RationalX, y: RationalX) : RationalX =
+        if x.IsSmall && y.IsSmall then
+            let a, b, c, d = x.P, x.Q, y.P, y.Q
+            let g = let g = gcd64 b d in if g = 0L then 1L else g
+            let bg, dg = b / g, d / g
+
+            match mulFits a dg, mulFits c bg, mulFits b dg with
+            | ValueSome t1, ValueSome t2, ValueSome den ->
+                match subFits t1 t2 with
+                | ValueSome num -> let n, m = normPair num den in RationalX(n, m)
+                | ValueNone -> RationalX.OfLarge(sToLarge a b - sToLarge c d)
+            | _ -> RationalX.OfLarge(sToLarge a b - sToLarge c d)
+        elif x.IsSmall then
+            RationalX.OfLarge(sToLarge x.P x.Q - y.Big.Value)
+        elif y.IsSmall then
+            RationalX.OfLarge(x.Big.Value - sToLarge y.P y.Q)
+        else
+            RationalX.OfLarge(x.Big.Value - y.Big.Value)
+
+    static member (~-)(x: RationalX) : RationalX =
+        if x.IsSmall then
+            RationalX(-x.P, x.Q) // Q stays > 0
+        else
+            RationalX(BigCell(-x.Big.Value))
+
+    // --- comparison / equality / hash ---------------------------------------
+
+    /// Small-tier pair with the zero-initialized default (Q = 0) normalized to 0/1.
+    static member inline private SmallPair(r: RationalX) : struct (int64 * int64) =
+        if r.Q = 0L then struct (0L, 1L) else struct (r.P, r.Q)
+
+    static member Compare(x: RationalX, y: RationalX) : int =
+        if x.IsSmall && y.IsSmall then
+            let struct (a, b) = RationalX.SmallPair x
+            let struct (c, d) = RationalX.SmallPair y
+
+            match mulFits a d, mulFits c b with // b, d > 0 so direction is preserved
+            | ValueSome l, ValueSome r -> compare l r
+            | _ -> compare (sToLarge a b) (sToLarge c d)
+        elif x.IsSmall then
+            let struct (a, b) = RationalX.SmallPair x
+            compare (sToLarge a b) y.Big.Value
+        elif y.IsSmall then
+            let struct (c, d) = RationalX.SmallPair y
+            compare x.Big.Value (sToLarge c d)
+        else
+            compare x.Big.Value y.Big.Value
+
+    member this.Equals(r: RationalX) = RationalX.Compare(this, r) = 0
+
+    override this.Equals(o: obj) =
+        match o with
+        | :? RationalX as r -> RationalX.Compare(this, r) = 0
+        | _ -> false
+
+    override this.GetHashCode() =
+        if this.IsSmall then
+            let struct (p, q) = RationalX.SmallPair this
+            if q = 1L then int p else (int p <<< 3) + int q
+        else
+            // spilled values never fit int64, so they cannot collide-by-value with a small one
+            let v = this.Big.Value
+            let n = v.Numerator
+            let d = v.Denominator
+
+            if d.IsOne then
+                n.GetHashCode()
+            else
+                (n.GetHashCode() <<< 3) + d.GetHashCode()
+
+    interface IEquatable<RationalX> with
+        member this.Equals(r: RationalX) = RationalX.Compare(this, r) = 0
+
+    interface IComparable with
+        member this.CompareTo(o: obj) =
+            match o with
+            | :? RationalX as r -> RationalX.Compare(this, r)
+            | _ -> invalidArg "o" "not a RationalX"
+
+    interface System.IComparable<RationalX> with
+        member this.CompareTo(r: RationalX) = RationalX.Compare(this, r)
+
+    override this.ToString() =
+        if this.IsSmall then
+            let struct (p, q) = RationalX.SmallPair this
+            if q = 1L then string p else $"{p}/{q}"
+        else
+            this.Big.Value.ToString()
+
+
+/// Numeric literal support so `0N`, `1N`, `1000N`, ... produce `RationalX`.
+[<AutoOpen>]
+module NumericLiteralN =
+
+    let FromZero () = RationalX.Zero
+    let FromOne () = RationalX.One
+    let FromInt32 (i: int) = RationalX.FromInt i
+    let FromInt64 (i: int64) = RationalX.FromInt64Fraction(i, 1L)
+    let FromString (s: string) = RationalX.Parse s
+
+
+/// Drop-in alias: existing code that refers to the `BigRational` type now uses
+/// the faster two-tier `RationalX`. Coexists with the `BigRational` module.
+type BigRational = RationalX

--- a/src/Informedica.Utils.Lib/BCL/RationalX.fs
+++ b/src/Informedica.Utils.Lib/BCL/RationalX.fs
@@ -27,6 +27,11 @@ module private RationalXHelpers =
 
     let inline absL (a: int64) = if a < 0L then -a else a
 
+    /// Fold an int64 into an int32 hash, mixing the upper 32 bits in (a plain
+    /// <c>int</c> cast would discard them, collapsing values that differ only
+    /// above bit 32 into the same bucket).
+    let inline hash64 (x: int64) = int (x ^^^ (x >>> 32))
+
     /// Greatest common divisor of two int64 values (always non-negative).
     let rec gcd64 (a: int64) (b: int64) : int64 =
         if b = 0L then absL a else gcd64 b (a % b)
@@ -134,7 +139,26 @@ type RationalX =
             RationalX(BigCell x)
 
     static member OfFraction(n: int64, d: int64) =
-        let n, d = normPair n d in RationalX(n, d)
+        // normPair sign-normalizes a negative denominator via (-p, -q); that
+        // negation overflows when n or d is Int64.MinValue (no positive int64
+        // counterpart exists), so route those through the big tier, which
+        // re-narrows if the reduced result happens to fit.
+        if n = Int64.MinValue || d = Int64.MinValue then
+            RationalX.OfLarge(sToLarge n d)
+        else
+            let n, d = normPair n d in RationalX(n, d)
+
+    /// Build a small-tier value from a raw numerator/denominator whose
+    /// denominator may be negative, normalizing the sign. Spills to the big
+    /// tier when sign-flipping would overflow int64 (n or m = Int64.MinValue).
+    static member internal OfSmallSigned(n: int64, m: int64) : RationalX =
+        if m < 0L then
+            if n = Int64.MinValue || m = Int64.MinValue then
+                RationalX.OfLarge(sToLarge n m)
+            else
+                RationalX(-n, -m)
+        else
+            RationalX(n, m)
 
     static member Zero = RationalX(0L, 1L)
     static member One = RationalX(1L, 1L)
@@ -176,7 +200,12 @@ type RationalX =
 
     static member Abs(r: RationalX) : RationalX =
         if r.IsSmall then
-            RationalX(absL r.P, r.Q) // Q is already > 0
+            // absL Int64.MinValue stays Int64.MinValue (still negative); the
+            // positive magnitude does not fit int64, so spill to the big tier.
+            if r.P = Int64.MinValue then
+                RationalX.OfLarge(-(sToLarge r.P r.Q)) // P < 0, so this is |value|
+            else
+                RationalX(absL r.P, r.Q) // Q is already > 0
         else
             let v = r.Big.Value
             if v.Numerator.Sign < 0 then RationalX.OfLarge(-v) else r
@@ -208,7 +237,7 @@ type RationalX =
             let c2, b2 = c / g2, b / g2
 
             match mulFits a2 c2, mulFits b2 d2 with
-            | ValueSome n, ValueSome m -> if m < 0L then RationalX(-n, -m) else RationalX(n, m)
+            | ValueSome n, ValueSome m -> RationalX.OfSmallSigned(n, m)
             | _ -> RationalX.OfLarge(sToLarge a2 b2 * sToLarge c2 d2)
         elif x.IsSmall then
             RationalX.OfLarge(sToLarge x.P x.Q * y.Big.Value)
@@ -230,7 +259,7 @@ type RationalX =
             let d2, b2 = d / g2, b / g2
 
             match mulFits a2 d2, mulFits b2 c2 with
-            | ValueSome n, ValueSome m -> if m < 0L then RationalX(-n, -m) else RationalX(n, m)
+            | ValueSome n, ValueSome m -> RationalX.OfSmallSigned(n, m)
             | _ -> RationalX.OfLarge(sToLarge a2 b2 / sToLarge c2 d2)
         elif x.IsSmall then
             RationalX.OfLarge(sToLarge x.P x.Q / y.Big.Value)
@@ -279,9 +308,17 @@ type RationalX =
 
     static member (~-)(x: RationalX) : RationalX =
         if x.IsSmall then
-            RationalX(-x.P, x.Q) // Q stays > 0
+            // -Int64.MinValue overflows back to Int64.MinValue; its positive
+            // counterpart does not fit int64, so spill to the big tier.
+            if x.P = Int64.MinValue then
+                RationalX.OfLarge(-(sToLarge x.P x.Q))
+            else
+                RationalX(-x.P, x.Q) // Q stays > 0
         else
-            RationalX(BigCell(-x.Big.Value))
+            // negating a spilled value can land back inside int64 (e.g. +2^63 ->
+            // -2^63); funnel through OfLarge so it re-narrows and the canonical
+            // small representation (hence hashing) stays consistent.
+            RationalX.OfLarge(-x.Big.Value)
 
     // --- comparison / equality / hash ---------------------------------------
 
@@ -316,7 +353,9 @@ type RationalX =
     override this.GetHashCode() =
         if this.IsSmall then
             let struct (p, q) = RationalX.SmallPair this
-            if q = 1L then int p else (int p <<< 3) + int q
+            // fold the full int64 in; a plain (int p) cast would drop the upper
+            // 32 bits and collide values that differ only above bit 32
+            if q = 1L then hash64 p else (hash64 p <<< 3) + hash64 q
         else
             // spilled values never fit int64, so they cannot collide-by-value with a small one
             let v = this.Big.Value

--- a/src/Informedica.Utils.Lib/Informedica.Utils.Lib.fsproj
+++ b/src/Informedica.Utils.Lib/Informedica.Utils.Lib.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="BCL\Int32.fs" />
     <Compile Include="BCL\Double.fs" />
     <Compile Include="BCL\BigInteger.fs" />
+    <Compile Include="BCL\RationalX.fs" />
     <Compile Include="BCL\BigRational.fs" />
     <Compile Include="BCL\DateTime.fs" />
     <Compile Include="BCL\Decimal.fs" />

--- a/src/Informedica.Utils.Lib/Json.fs
+++ b/src/Informedica.Utils.Lib/Json.fs
@@ -4,7 +4,6 @@ namespace Informedica.Utils.Lib
 module Json =
 
     open System
-    open MathNet.Numerics
     open Informedica.Utils.Lib.BCL
     open Newtonsoft.Json
     open Newtonsoft.Json.Linq
@@ -19,6 +18,7 @@ module Json =
             let bigRational = value :?> BigRational
             let numerator = bigRational.Numerator
             let denominator = bigRational.Denominator
+
             writer.WriteStartObject()
             writer.WritePropertyName("Numerator")
             writer.WriteValue(numerator.ToString())

--- a/src/Informedica.Utils.Lib/Scripts/RationalXCheck.fsx
+++ b/src/Informedica.Utils.Lib/Scripts/RationalXCheck.fsx
@@ -1,0 +1,76 @@
+#I __SOURCE_DIRECTORY__
+#r "nuget: MathNet.Numerics.FSharp, 5.0.0"
+#r "../bin/Debug/net10.0/Informedica.Utils.Lib.dll"
+
+// Correctness gate: RationalX (via the BigRational alias) must agree with
+// MathNet's BigRational on arithmetic, comparison, and set-distinct behavior.
+
+open Informedica.Utils.Lib.BCL
+
+type RX = Informedica.Utils.Lib.BCL.BigRational      // = RationalX
+type MB = MathNet.Numerics.BigRational
+
+let rnd = System.Random 1234
+
+// random fractions with denominators that are products of small primes,
+// mirroring GenPRES base-unit magnitudes, plus some larger ones
+let denoms = [| 1L; 2L; 3L; 5L; 7L; 10L; 1000L; 86400L; 86400000L; 100000000L |]
+
+let randPair () =
+    let n = int64 (rnd.Next(-100000, 100000))
+    let d = denoms[rnd.Next(denoms.Length)] * int64 (rnd.Next(1, 1000))
+    n, d
+
+let toRX (n: int64, d: int64) = RX.FromInt64Fraction(n, d)
+let toMB (n: int64, d: int64) = MB.FromBigIntFraction(bigint n, bigint d)
+
+let close (a: float) (b: float) =
+    let scale = (abs a + abs b + 1.0)
+    abs (a - b) <= 1e-9 * scale
+
+let mutable failures = 0
+let report name cond detail =
+    if not cond then
+        failures <- failures + 1
+        printfn "FAIL %s: %s" name detail
+
+// 1. arithmetic agreement (+ - * /) via ToDouble
+for _ in 1 .. 20000 do
+    let p1 = randPair ()
+    let p2 = randPair ()
+    let x, y = toRX p1, toRX p2
+    let a, b = toMB p1, toMB p2
+    report "add" (close (RX.ToDouble(x + y)) (MB.ToDouble(a + b))) $"{p1} + {p2}"
+    report "sub" (close (RX.ToDouble(x - y)) (MB.ToDouble(a - b))) $"{p1} - {p2}"
+    report "mul" (close (RX.ToDouble(x * y)) (MB.ToDouble(a * b))) $"{p1} * {p2}"
+    if snd p2 <> 0L && fst p2 <> 0L then
+        report "div" (close (RX.ToDouble(x / y)) (MB.ToDouble(a / b))) $"{p1} / {p2}"
+    // comparison sign must match
+    report "cmp" (sign (compare x y) = sign (compare a b)) $"cmp {p1} {p2}"
+
+// 2. spill correctness: force overflow of int64 then narrow back
+let big = RX.FromBigInt(bigint System.Int64.MaxValue)
+report "spill-mul-eq" (RX.ToDouble(big * big) |> close <| MB.ToDouble(MB.FromBigInt(bigint System.Int64.MaxValue) * MB.FromBigInt(bigint System.Int64.MaxValue))) "maxint^2"
+report "spill-narrow" ((big * big) / big = big) "(max^2)/max = max (re-narrows to SX)"
+
+// 3. equality/hash consistency across tiers: a value built two ways must dedupe
+let half1 = RX.FromInt64Fraction(1L, 2L)
+let half2 = RX.FromInt64Fraction(50L, 100L)         // reduces to 1/2
+let half3 = RX.FromBigInt(1I) / RX.FromBigInt(2I)
+report "eq-reduce" (half1 = half2 && half2 = half3) "1/2 built three ways equal"
+report "hash-reduce" (half1.GetHashCode() = half2.GetHashCode() && half2.GetHashCode() = half3.GetHashCode()) "hash equal"
+let distinctCount = [| half1; half2; half3; RX.One; RX.FromInt 1 |] |> Array.distinct |> Array.length
+report "distinct" (distinctCount = 2) $"expected 2 distinct (1/2 and 1), got {distinctCount}"
+
+// 4. default value behaves as zero (struct zero-init = SX(0,0))
+let dflt = Unchecked.defaultof<RX>
+report "default-zero-eq" (dflt = RX.Zero) "default = 0"
+report "default-zero-cmp" (compare dflt (RX.FromInt 1) < 0) "default < 1"
+
+// 5. round trips used by the codebase
+report "toInt32" (RX.ToInt32(RX.FromInt 42) = 42) "ToInt32 42"
+report "toBigInt-floor" (RX.ToBigInt(RX.FromInt64Fraction(-3L, 2L)) = MB.ToBigInt(MB.FromBigIntFraction(-3I, 2I))) "ToBigInt floor -3/2"
+report "parse" (RX.Parse "3/4" = RX.FromInt64Fraction(3L, 4L)) "parse 3/4"
+report "num/den" ((RX.FromInt64Fraction(6L, 8L)).Numerator = 3I && (RX.FromInt64Fraction(6L, 8L)).Denominator = 4I) "6/8 -> 3/4"
+
+if failures = 0 then printfn "ALL CHECKS PASSED" else printfn "TOTAL FAILURES: %d" failures

--- a/src/Informedica.Utils.Lib/Set.fs
+++ b/src/Informedica.Utils.Lib/Set.fs
@@ -20,7 +20,6 @@ module Set =
 
     module Tests =
 
-        open MathNet.Numerics
         open Swensen.Unquote
 
 

--- a/src/Informedica.ZForm.Lib/DoseRule.fs
+++ b/src/Informedica.ZForm.Lib/DoseRule.fs
@@ -3,13 +3,12 @@
 
 module DoseRule =
 
-    open MathNet.Numerics
+    open Informedica.Utils.Lib.BCL
 
     open Aether
     open Aether.Operators
 
     open Informedica.Utils.Lib
-    open Informedica.Utils.Lib.BCL
     open Informedica.GenCore.Lib.Ranges
     open Informedica.GenUnits.Lib
 

--- a/src/Informedica.ZForm.Lib/GStand.fs
+++ b/src/Informedica.ZForm.Lib/GStand.fs
@@ -3,11 +3,9 @@ namespace Informedica.ZForm.Lib
 
 module GStand =
 
-    open MathNet.Numerics
-
-    open Informedica.Utils.Lib.ConsoleWriter.NewLineNoTime
     open Informedica.Utils.Lib.BCL
 
+    open Informedica.Utils.Lib.ConsoleWriter.NewLineNoTime
     open Aether
     open DoseRule
 

--- a/src/Informedica.ZForm.Lib/Scripts/Scripts.fsx
+++ b/src/Informedica.ZForm.Lib/Scripts/Scripts.fsx
@@ -3,7 +3,6 @@
 #time
 
 open Informedica.Utils.Lib
-open Informedica.ZIndex.Lib
 open Informedica.ZForm.Lib
 
 

--- a/src/Informedica.ZForm.Lib/Types.fs
+++ b/src/Informedica.ZForm.Lib/Types.fs
@@ -4,7 +4,7 @@ namespace Informedica.ZForm.Lib
 [<AutoOpen>]
 module Types =
 
-    open MathNet.Numerics
+    open Informedica.Utils.Lib.BCL
 
     open Informedica.GenUnits.Lib
 

--- a/src/Informedica.ZForm.Lib/Utils.fs
+++ b/src/Informedica.ZForm.Lib/Utils.fs
@@ -3,7 +3,7 @@ namespace Informedica.ZForm.Lib
 
 module MinMax =
 
-    open MathNet.Numerics
+    open Informedica.Utils.Lib.BCL
 
     open Informedica.GenUnits.Lib
     open Informedica.GenCore.Lib.Ranges

--- a/src/Informedica.ZForm.Lib/ValueUnit.fs
+++ b/src/Informedica.ZForm.Lib/ValueUnit.fs
@@ -5,8 +5,6 @@
 /// `Informedica.GenUnits.Lib.ValueUnit` library
 module ValueUnit =
 
-    open MathNet.Numerics
-
     open Informedica.Utils.Lib.BCL
     open Informedica.GenUnits.Lib
 

--- a/tests/Informedica.GenCORE.Tests/Generators.fs
+++ b/tests/Informedica.GenCORE.Tests/Generators.fs
@@ -13,7 +13,7 @@ module Generators =
 
     open Expecto
     open FsCheck
-    open MathNet.Numerics
+    open Informedica.Utils.Lib.BCL
 
 
     let bigRGen (n, d) =

--- a/tests/Informedica.GenCORE.Tests/Tests.fs
+++ b/tests/Informedica.GenCORE.Tests/Tests.fs
@@ -8,7 +8,7 @@ module Tests =
     open Expecto
     open Expecto.Flip
 
-    open MathNet.Numerics
+    open Informedica.Utils.Lib.BCL
 
     open Informedica.GenUnits.Lib
     open Informedica.GenCore.Lib

--- a/tests/Informedica.GenFORM.Tests/FixtureJson.fs
+++ b/tests/Informedica.GenFORM.Tests/FixtureJson.fs
@@ -2,7 +2,7 @@ namespace Informedica.GenForm.Tests
 
 
 open System
-open MathNet.Numerics
+open Informedica.Utils.Lib.BCL
 open Newtonsoft.Json
 
 

--- a/tests/Informedica.GenFORM.Tests/Tests.fs
+++ b/tests/Informedica.GenFORM.Tests/Tests.fs
@@ -7,7 +7,7 @@ module Generators =
 
     open Expecto
     open FsCheck
-    open MathNet.Numerics
+    open Informedica.Utils.Lib.BCL
 
     let bigRGen (n, d) =
         let d = if d = 0 then 1 else d
@@ -130,7 +130,7 @@ module GenericLabelTests =
 module ProductFilterTests =
 
 
-    open MathNet.Numerics
+    open Informedica.Utils.Lib.BCL
     open Informedica.GenUnits.Lib
     open Expecto
     open Expecto.Flip
@@ -334,7 +334,7 @@ module DoseRuleProductTests =
 
     open Expecto
     open Expecto.Flip
-    open MathNet.Numerics
+    open Informedica.Utils.Lib.BCL
     open Informedica.GenForm.Lib
 
 
@@ -966,7 +966,7 @@ module DoseRuleRoundtripTests =
 
     open System
     open System.IO
-    open MathNet.Numerics
+    open Informedica.Utils.Lib.BCL
     open Expecto
     open Expecto.Flip
     open Informedica.Utils.Lib.BCL
@@ -1212,7 +1212,7 @@ module DoseRuleRoundtripTests =
 module Tests =
 
 
-    open MathNet.Numerics
+    open Informedica.Utils.Lib.BCL
     open Expecto
     open Expecto.Flip
 

--- a/tests/Informedica.GenORDER.Tests/Scenarios.fs
+++ b/tests/Informedica.GenORDER.Tests/Scenarios.fs
@@ -2,7 +2,7 @@
 /// testing purposes
 module Scenarios
 
-open MathNet.Numerics
+open Informedica.Utils.Lib.BCL
 open Informedica.Utils.Lib.BCL
 open Informedica.GenCore.Lib.Ranges
 open Informedica.GenForm.Lib

--- a/tests/Informedica.GenORDER.Tests/Tests.fs
+++ b/tests/Informedica.GenORDER.Tests/Tests.fs
@@ -1,6 +1,6 @@
 module Tests
 
-open MathNet.Numerics
+open Informedica.Utils.Lib.BCL
 open Expecto
 open Expecto.Flip
 

--- a/tests/Informedica.GenSOLVER.Tests/Tests.fs
+++ b/tests/Informedica.GenSOLVER.Tests/Tests.fs
@@ -13,7 +13,7 @@ module Generators =
 
     open Expecto
     open FsCheck
-    open MathNet.Numerics
+    open Informedica.Utils.Lib.BCL
 
     let bigRGen (n, d) =
         let d = if d = 0 then 1 else d
@@ -203,11 +203,10 @@ module TestSolver =
 module Tests =
 
 
-    open MathNet.Numerics
+    open Informedica.Utils.Lib.BCL
     open Expecto
     open Expecto.Flip
 
-    open Informedica.Utils.Lib.BCL
     open Informedica.GenUnits.Lib
     open Informedica.GenSolver.Lib
 

--- a/tests/Informedica.GenUNITS.Tests/Tests.fs
+++ b/tests/Informedica.GenUNITS.Tests/Tests.fs
@@ -5,7 +5,7 @@ module Unquote =
 
 
     open Swensen.Unquote
-    open MathNet.Numerics
+    open Informedica.Utils.Lib.BCL
     //open Informedica.GenUnits.Lib
     open Informedica.GenUnits.Lib
     open Informedica.GenUnits.Lib.ValueUnit
@@ -181,7 +181,6 @@ module Tests =
     open Expecto
     open Expecto.Flip
 
-    open MathNet.Numerics
     open Informedica.Utils.Lib.BCL
     //open Informedica.GenUnits.Lib
 

--- a/tests/Informedica.Logging.Tests/Tests.fs
+++ b/tests/Informedica.Logging.Tests/Tests.fs
@@ -93,7 +93,13 @@ module Tests =
 
                     test "logWith should create and send event to logger" {
                         let mutable capturedEvent = None
-                        let logger = { Log = fun e -> capturedEvent <- Some e }
+
+                        let logger =
+                            {
+                                Log = (fun e -> capturedEvent <- Some e)
+                                Enabled = fun _ -> true
+                            }
+
                         let msg = createTestMessage "test message"
 
                         Logging.logWith Level.Error logger msg
@@ -107,7 +113,13 @@ module Tests =
 
                     test "convenience functions should use correct levels" {
                         let mutable levels = []
-                        let logger = { Log = fun e -> levels <- e.Level :: levels }
+
+                        let logger =
+                            {
+                                Log = (fun e -> levels <- e.Level :: levels)
+                                Enabled = fun _ -> true
+                            }
+
                         let msg = createTestMessage "test"
 
                         Logging.logInfo logger msg
@@ -170,8 +182,18 @@ module Tests =
                     test "combine should send to all loggers" {
                         let mutable events1 = []
                         let mutable events2 = []
-                        let logger1 = { Log = fun e -> events1 <- e :: events1 }
-                        let logger2 = { Log = fun e -> events2 <- e :: events2 }
+
+                        let logger1 =
+                            {
+                                Log = (fun e -> events1 <- e :: events1)
+                                Enabled = fun _ -> true
+                            }
+
+                        let logger2 =
+                            {
+                                Log = (fun e -> events2 <- e :: events2)
+                                Enabled = fun _ -> true
+                            }
 
                         let combined = Logging.combine [ logger1; logger2 ]
                         let msg = createTestMessage "combined test"
@@ -184,7 +206,13 @@ module Tests =
 
                     test "filterByLevel should only pass appropriate messages" {
                         let mutable events = []
-                        let baseLogger = { Log = fun e -> events <- e :: events }
+
+                        let baseLogger =
+                            {
+                                Log = (fun e -> events <- e :: events)
+                                Enabled = fun _ -> true
+                            }
+
                         let filteredLogger = Logging.filterByLevel Level.Warning baseLogger
 
                         let msg = createTestMessage "test"
@@ -201,7 +229,13 @@ module Tests =
 
                     test "filterByType should only pass specific message types" {
                         let mutable events = []
-                        let baseLogger = { Log = fun e -> events <- e :: events }
+
+                        let baseLogger =
+                            {
+                                Log = (fun e -> events <- e :: events)
+                                Enabled = fun _ -> true
+                            }
+
                         let filteredLogger = Logging.filterByType<TestMessage> baseLogger
 
                         let testMsg = createTestMessage "test"

--- a/tests/Informedica.Utils.Tests/Generators.fs
+++ b/tests/Informedica.Utils.Tests/Generators.fs
@@ -13,7 +13,7 @@ module Generators =
 
     open Expecto
     open FsCheck
-    open MathNet.Numerics
+    open Informedica.Utils.Lib.BCL
 
 
     let bigRGen (n, d) =

--- a/tests/Informedica.Utils.Tests/Tests.fs
+++ b/tests/Informedica.Utils.Tests/Tests.fs
@@ -284,8 +284,6 @@ module Tests =
 
     module Double =
 
-        open MathNet.Numerics
-
         [<Tests>]
         let tests =
 
@@ -424,8 +422,6 @@ module Tests =
 
 
     module BigRational =
-
-        open MathNet.Numerics
 
         // Test calcCartesian function
         let testCalcCartesian () =

--- a/tests/Informedica.Utils.Tests/Tests.fs
+++ b/tests/Informedica.Utils.Tests/Tests.fs
@@ -660,6 +660,91 @@ module Tests =
                 ]
 
 
+        [<Tests>]
+        let edgeCaseTests =
+            // 9223372036854775808 = 2^63: the positive counterpart of Int64.MinValue,
+            // which does NOT fit int64 and therefore must spill to the big tier.
+            let twoPow63 = -(bigint Int64.MinValue)
+
+            let minV () =
+                BigRational.FromInt64Fraction(Int64.MinValue, 1L)
+
+            testList
+                "RationalX edge cases"
+                [
+
+                    test "negating Int64.MinValue spills with the correct positive value" {
+                        let neg = -(minV ())
+
+                        Expect.isTrue neg.IsSpilled "negation of Int64.MinValue must spill"
+                        Expect.equal neg.Numerator twoPow63 "numerator is +2^63"
+                        Expect.equal neg.Denominator 1I "denominator is 1"
+                    }
+
+                    test "Abs of Int64.MinValue spills with the correct positive value" {
+                        let a = BigRational.Abs(minV ())
+
+                        Expect.isTrue a.IsSpilled "abs of Int64.MinValue must spill"
+                        Expect.equal a.Numerator twoPow63 "numerator is +2^63"
+                    }
+
+                    test "double negation of Int64.MinValue round-trips to the canonical small value" {
+                        let v = minV ()
+                        let back = -(-v)
+
+                        Expect.equal back v "value round-trips"
+                        Expect.isFalse back.IsSpilled "re-narrows to the small tier"
+                        Expect.equal (back.GetHashCode()) (v.GetHashCode()) "hash matches the canonical representation"
+                    }
+
+                    test "fraction with Int64.MinValue denominator normalizes sign without overflow" {
+                        // 1 / Int64.MinValue : the positive magnitude of the
+                        // denominator does not fit int64, so the value must spill
+                        let v = BigRational.FromInt64Fraction(1L, Int64.MinValue)
+
+                        Expect.isTrue v.IsSpilled "must spill"
+                        Expect.equal v.Numerator -1I "numerator is -1"
+                        Expect.equal v.Denominator twoPow63 "denominator is +2^63"
+                    }
+
+                    test "negative-denominator fraction of small values normalizes to a positive denominator" {
+                        let v = BigRational.FromInt64Fraction(3L, -4L)
+
+                        Expect.equal v.Numerator -3I "numerator is -3"
+                        Expect.equal v.Denominator 4I "denominator is +4"
+                    }
+
+                    test "GetHashCode mixes the upper 32 bits (no truncation collision)" {
+                        // 1/1 and (2^32 + 1)/1 differ only above bit 32; a plain
+                        // int32 cast would collapse them into the same hash bucket
+                        let a = BigRational.FromInt 1
+                        let b = BigRational.FromBigInt 4294967297I // 2^32 + 1
+
+                        Expect.isFalse (a = b) "values differ"
+                        Expect.isFalse (a.GetHashCode() = b.GetHashCode()) "hashes must differ"
+                    }
+
+                    test "equal values produce equal hash codes across construction paths" {
+                        let a = BigRational.FromInt 5
+                        let b = BigRational.FromInt64Fraction(10L, 2L)
+
+                        Expect.isTrue (a = b) "values are equal"
+                        Expect.equal (a.GetHashCode()) (b.GetHashCode()) "hash codes are equal"
+                    }
+
+                    test "distinct deduplicates equal large-numerator values" {
+                        let a = BigRational.FromBigInt 4294967297I
+                        let b = BigRational.FromInt64Fraction(4294967297L, 1L)
+                        let c = BigRational.FromInt 1
+
+                        [| a; b; c; a |]
+                        |> BigRational.distinct
+                        |> Array.length
+                        |> fun n -> Expect.equal n 2 "two distinct values remain"
+                    }
+                ]
+
+
     module DateTime =
 
         let tests =

--- a/tests/Informedica.ZForm.Tests/Tests.fs
+++ b/tests/Informedica.ZForm.Tests/Tests.fs
@@ -3,9 +3,8 @@ namespace Informedica.ZForm.Tests
 
 open Expecto
 open Expecto.Flip
-open MathNet.Numerics
-
 open Informedica.Utils.Lib.BCL
+
 open Informedica.GenCore.Lib.Ranges
 open Informedica.ZForm.Lib
 

--- a/tests/Informedica.ZIndex.Tests/Generators.fs
+++ b/tests/Informedica.ZIndex.Tests/Generators.fs
@@ -13,7 +13,7 @@ module Generators =
 
     open Expecto
     open FsCheck
-    open MathNet.Numerics
+    open Informedica.Utils.Lib.BCL
 
 
     let bigRGen (n, d) =


### PR DESCRIPTION
### Summary

  Replaces the rational-number backing of all dosing math — `MathNet.Numerics.BigRational`
  (a reference type; every operation allocates and routes through `BigInteger`) — with a
  faster two-tier struct, `RationalX`, exposed under the existing `BigRational` name so the
  ~47 consuming files compile unchanged. Along the way this fixes the real end-to-end
  bottleneck (eager logging) and lands a proper lazy-logging API.

  **Net vs. `master`: −24% time, −36% allocation on the GenORDER scenario solve, zero
  correctness cost** — per-scenario result hashes are bit-identical and the full suite is
  green (5526 passed, 0 failed, 2 skipped).

  ### What changed

  **1. `RationalX` type + global drop-in alias**
  - New `src/Informedica.Utils.Lib/BCL/RationalX.fs`: a `[<Struct; CustomEquality; CustomComparison>]`
    two-tier rational. Small tier = reduced `int64` numerator/denominator (the common,
    allocation-free path) with cross-reduction + branchless overflow detection
    (`Math.BigMul`, sign-bit tests); spill tier wraps the existing MathNet `BigRational`
    only on int64 overflow.
  - Full MathNet API parity (`FromInt/FromBigInt/FromDecimal/ToDouble/ToInt32/ToBigInt/Abs/
    Parse/Numerator/Denominator/+ - * / ~-`), `NumericLiteralN` (so `0N`…`1000N` work),
    `IEquatable<RationalX>`, and `type BigRational = RationalX`.
  - **Canonical-representation invariant**: any value that fits int64 is always stored small,
    guaranteeing one representation per value so equality/hashing stay consistent for
    `Array.distinct`, `Set`, and `Map` keys.
  - Migration: removed `open MathNet.Numerics` from ~31 src + ~13 test files (replaced with
    `open Informedica.Utils.Lib.BCL`). `BCL/BigRational.fs` gains the `ModuleSuffix`
    representation so the `BigRational` module and the new `BigRational` type coexist.

  **2. Struct shrink — 32 B → 24 B**
  - Replaced the struct DU (8 B tag) with a hand-rolled struct `(int64 P, int64 Q, BigCell Big)`
    where `Big = null` is the small/big discriminator. Small case stays inline and alloc-free.

  **3. Unboxed dedup in `ValueUnit.calc`**
  - Added `BigRational.distinct` (order-preserving `HashSet<BigRational>` using the default
    `EqualityComparer`, hitting the unboxed `IEquatable` path) and switched `ValueUnit.calc`
    to it. F#'s structural `Array.distinct` boxes every `[<CustomEquality>]` struct; this
    avoids it.

  **4. Lazy / eager-logging guards**
  - `Logger` gains an `Enabled: Level -> bool` field (`noOp` → `false`, real loggers → `true`);
    `filterByLevel`/`combine` propagate it. New thunk-based `logLazy`/`logInfoLazy` build the
    message only when `Enabled level`. `Logging.isActive` is redefined via `Enabled Informative`,
    so guards generalise beyond `noOp` to any logger filtered above informative.
  - Guarded every eager *build-then-log* site in the solve path (`Order.logOrder`,
    `OrderProcessor.setCalculatedConstraintsStep`/`applyConstraintsStep`/`logUnmatched`) so the
    expensive console table / constraint dump is built **only when a logger will consume it**.

  **5. Dead-code removal in the solver**
  - `GenSOLVER/Equation.fs`: removed a provably-dead per-iteration `List.sortBy`
    (behaviour-preserving, perf-neutral).

  ### Benchmark results

  A/B method: same harness built + run on this branch (RationalX) vs. `master` (BigRational);
  BenchmarkDotNet means. Harnesses live in `benchmark/{RationalXBench,ValueUnitBench,ScenarioBench}`
  (gitignored under the opt-in policy).

  **Raw arithmetic `(a*b)/c`:** 71.8 µs / 156 KB → **16.6 µs (≈4.3×) / 0 B**, 0 spills.

  **`ValueUnit.calc` cartesian (mul, 160k):** 75.6 ms / 57.2 MB → **20.1 ms (3.8×) / 21.1 MB (−63%)**.

  **End-to-end GenORDER scenario solve (8 scenarios):**

  | Variant | Time | Allocated |
  |---|---|---|
  | BigRational baseline (`master`) | 153.9 ms | 301.8 MB |
  | RationalX (24 B + unboxed distinct) | 148.2 ms | 263.7 MB |
  | **+ eager-logging guards** | **117.4 ms** | **192.4 MB** |

  ### Key findings

  1. RationalX wins where work is **arithmetic-bound** (2–4×, less memory) and is
     correctness-neutral everywhere.
  2. **Amdahl in action:** speedup shrinks up the stack (raw 4.3× → `ValueUnit.calc` 2–4× →
     full solve ~1.04×) — the solve is *not* bottlenecked on rational arithmetic.
  3. **The biggest end-to-end win was logging, not the type.** `logOrder` built a full console
     table on every solve step and handed it to a `noOp` logger that discarded it. Guarding it
     cut ~21% off the already-optimized solve.
  4. Struct width matters for store-heavy paths (24 B beats 32 B); a `[<CustomEquality>]` struct
     must avoid boxing in `Array.distinct`.
  5. Sampling-profiler self-time ≠ wall-clock under heavy GC: a profiler attributed ~34% to
     `List.sortBy`, but a controlled A/B showed it costs ≈0 — the real solver cost is broad
     allocation pressure (`PollGC` ~51% of samples), not any single line.

  ### Files

  - **New:** `BCL/RationalX.fs`, `Scripts/RationalXCheck.fsx` (FSI correctness gate),
    `docs/code-reviews/rational-x-perf-investigation.md` (full write-up),
    benchmark harnesses (gitignored).
  - **Modified:** 36 tracked `.fs` source files (mostly 1-line `open MathNet` migrations) +
    test files; logging API in `Logging.Lib`, `Order.fs`, `OrderProcessor.fs`; dead-sort
    removal in `GenSOLVER/Equation.fs`.

  ### Follow-up (out of scope)

  The solver's remaining cost is broad allocation/GC in `Equation.loop` (it rebuilds immutable
  `vars` lists every propagation step). A careful array-based / in-place refactor is the next
  perf project — high validation cost, scoped separately.

  ### Testing

  - Full suite green: **5526 passed, 0 failed, 2 skipped**.
  - Per-scenario result hashes bit-identical between BigRational and RationalX.
  - `RationalXCheck.fsx` FSI gate covers arithmetic correctness incl. overflow/spill cases.