### PR TITLE
fix(genorder): collect value units with same unit group instead of ex…

### DIFF
--- a/src/Informedica.GenORDER.Lib/OrderVariable.fs
+++ b/src/Informedica.GenORDER.Lib/OrderVariable.fs
@@ -61,10 +61,8 @@ module ValueUnit =
         | None -> None
         | Some vu ->
             let u = vu |> getUnit
-            // TODO: investigate whether this is too strict and should
-            // be relaxed to equal unit group, but then needs to converted
-            // to same unit base case
-            if vus |> Array.forall (getUnit >> Units.eqsUnit u) |> not then
+
+            if vus |> Array.forall (getUnit >> Group.eqsGroup u) |> not then
                 let details =
                     vus
                     |> Array.map (fun vu ->

--- a/tests/Informedica.GenORDER.Tests/Tests.fs
+++ b/tests/Informedica.GenORDER.Tests/Tests.fs
@@ -1179,6 +1179,70 @@ module MedicationParserTests =
             ]
 
 
+module OrderVariableTests =
+
+    // Hermetic tests for ValueUnit.collect — no resources are loaded. All
+    // ValueUnits are built inline. The headline case uses the real DIGOXINE
+    // TABLET strengths from the Z-index: three GPKs of the same substance
+    // expressed in mixed mass units (milligram and microgram), which share a
+    // unit group but not a unit. collect must merge them into a single
+    // ValueUnit, converting the microgram value into the head unit (mg).
+    let tests =
+        testList
+            "ValueUnit.collect"
+            [
+                // DIGOXINE TABLET: GPK 16721 = 0,25 mg, GPK 16772 = 62,5 microg,
+                // GPK 38857 = 0,125 mg. 62,5 microg = 1/16 mg, so the collected
+                // result is [| 1/4; 1/16; 1/8 |] mg in input order.
+                test "collect merges mixed mass units (digoxin mg + microgram)" {
+                    let vus =
+                        [|
+                            ValueUnit.create Units.Mass.milliGram [| 1N / 4N |] // 0,25 mg
+                            ValueUnit.create Units.Mass.microGram [| 125N / 2N |] // 62,5 microg
+                            ValueUnit.create Units.Mass.milliGram [| 1N / 8N |] // 0,125 mg
+                        |]
+
+                    let exp =
+                        ValueUnit.create Units.Mass.milliGram [| 1N / 4N; 1N / 16N; 1N / 8N |] |> Some
+
+                    vus
+                    |> ValueUnit.collect
+                    |> Expect.equal "should merge into a single mg ValueUnit" exp
+                }
+
+                // Same unit throughout: identity round-trip of the values.
+                test "collect keeps values when all units are equal" {
+                    let vus =
+                        [|
+                            ValueUnit.create Units.Mass.milliGram [| 1N / 4N |]
+                            ValueUnit.create Units.Mass.milliGram [| 1N / 8N |]
+                        |]
+
+                    let exp = ValueUnit.create Units.Mass.milliGram [| 1N / 4N; 1N / 8N |] |> Some
+
+                    vus
+                    |> ValueUnit.collect
+                    |> Expect.equal "should concatenate without conversion" exp
+                }
+
+                test "collect returns None for an empty array" {
+                    [||] |> ValueUnit.collect |> Expect.isNone "empty input should give None"
+                }
+
+                // Different unit groups (mass vs volume) cannot be collected.
+                test "collect fails for incompatible unit groups" {
+                    let vus =
+                        [|
+                            ValueUnit.create Units.Mass.milliGram [| 1N / 4N |]
+                            ValueUnit.create Units.Volume.milliLiter [| 1N |]
+                        |]
+
+                    (fun () -> vus |> ValueUnit.collect |> ignore)
+                    |> Expect.throws "mixing mass and volume should throw"
+                }
+            ]
+
+
 module EquationsTests =
 
     // Golden reference: the full "Equations" sheet. Each entry is the equation
@@ -1296,4 +1360,5 @@ let tests =
             DosePrintoutTests.tests
             PatientConstructorTests.tests
             MedicationParserTests.tests
+            OrderVariableTests.tests
         ]


### PR DESCRIPTION
## Summary

Relax `ValueUnit.collect` (in `OrderVariable.fs`) so it merges a `ValueUnit[]`
whose elements share a **unit group** rather than requiring an identical
**unit**, and add a hermetic test covering the behaviour.

Previously `collect` guarded with `Units.eqsUnit` (exact unit equality) and
`failwith`'d on any mismatch. But every call site in `Medication.createComponents`
pre-filters its input with `filterByUnitGroup`, which only guarantees a common
*group* (e.g. Mass), not a common *unit* (mg vs microgram). An array of
same-group / different-unit values therefore passed the upstream filter and then
crashed in `collect` — a latent exception in the dose-calculation path.

The fix changes the guard to `Group.eqsGroup`. No conversion code is needed:
`collect` already normalises each element to the group base via
`toBase >> getValue` and re-expresses the pooled values in the head unit through
`withUnit u |> toUnit`, so mixed units within a group convert correctly.

## Why it matters (real data)

This is not theoretical. Scanning the Z-index, **19 GenPresProducts** carry one
substance expressed in mixed mass units across their GPKs. Example — `DIGOXINE`
`TABLET`:

| GPK    | Strength | Unit      |
|--------|----------|-----------|
| 16721  | 0,25     | MILLIGRAM |
| 16772  | 62,5     | MICROGRAM |
| 38857  | 0,125    | MILLIGRAM |

Old behaviour: `failwith "Cannot collect the ValueUnit array..."`.
New behaviour: `[| 1/4; 1/16; 1/8 |] mg` (62,5 microg → 1/16 mg, exact via
`BigRational`/`RationalX`, input order preserved).

## Changes

- `src/Informedica.GenORDER.Lib/OrderVariable.fs` — `collect` group-equality guard
  (single-function change).
- `tests/Informedica.GenORDER.Tests/Tests.fs` — new `OrderVariableTests` module
  (`testList "ValueUnit.collect"`), registered in the `GenOrder Tests` aggregate.

## Tests

Hermetic — no resources / Google Sheets loaded, all `ValueUnit`s built inline:

- merges mixed mass units (digoxin mg + microgram)
- keeps values unchanged when all units are equal
- returns `None` for an empty array
- throws for incompatible unit groups (mass + volume)

The digoxin test passes only with the relaxed guard, so it pins the fix.

Passed!  - Failed: 0, Passed: 4, Skipped: 0, Total: 4

## Notes

- Cross-group inputs still throw, so genuinely incompatible merges remain rejected.
- The `failwith` branch is now effectively unreachable from the known call sites
  (they pre-filter to one group) and is retained as a defensive guard.