### PR TITLE
feat(ui): immediately show the step change instead of waiting for the…

### DIFF
--- a/src/Informedica.GenPRES.Client/Components/ClickCountingButton.fs
+++ b/src/Informedica.GenPRES.Client/Components/ClickCountingButton.fs
@@ -14,6 +14,7 @@ module ClickCountingButton =
             {|
                 disabled: bool
                 onClick: int -> unit
+                onStep: unit -> unit
                 icon: JSX.Element
             |})
         =
@@ -66,6 +67,9 @@ module ClickCountingButton =
         let increment () =
             countRef.current <- countRef.current + 1
             setCount countRef.current
+            // notify the consumer of each click so the displayed value can follow
+            // the live count (same instant as the badge updates)
+            props.onStep ()
 
         let handleClick =
             fun (_: Browser.Types.MouseEvent) ->

--- a/src/Informedica.GenPRES.Client/Components/SimpleSelect.fs
+++ b/src/Informedica.GenPRES.Client/Components/SimpleSelect.fs
@@ -7,6 +7,7 @@ module SimpleSelect =
     open System
     open Fable.Core
     open Fable.Core.JsInterop
+    open Feliz
 
 
     [<JSX.Component>]
@@ -19,6 +20,7 @@ module SimpleSelect =
                 updateSelected: string option -> unit
                 navigate:
                     {|
+                        step: (int * int -> string * string) option
                         first: (int -> unit) option
                         decrease: (int -> unit) option
                         median: (unit -> unit) option
@@ -35,6 +37,49 @@ module SimpleSelect =
         =
 
         let isMobile = Mui.Hooks.useMediaQuery "(max-width:1200px)"
+
+        // Net click deltas accumulated from the nav buttons. Drive an optimistic displayed
+        // value that follows the live click count (the badge) before the server confirms.
+        // Inner = single-step decrease/increase (defined increment); outer = first/last in
+        // step state (calculated increment). Reset when the underlying value changes.
+        let innerDelta, setInnerDelta = React.useState 0
+        let outerDelta, setOuterDelta = React.useState 0
+        let innerRef = React.useRef 0
+        let outerRef = React.useRef 0
+
+        // Use the raw value string as the dependency (a JS primitive compared by value)
+        // so the reset only fires when the underlying value actually changes — boxing an
+        // option would create a new reference every render and reset on every render.
+        let valueKey =
+            props.values |> Array.tryHead |> Option.map fst |> Option.defaultValue ""
+
+        React.useEffect (
+            (fun () ->
+                innerRef.current <- 0
+                outerRef.current <- 0
+                setInnerDelta 0
+                setOuterDelta 0
+            ),
+            [| box valueKey |]
+        )
+
+        let bumpInner sign =
+            fun () ->
+                innerRef.current <- innerRef.current + sign
+                setInnerDelta innerRef.current
+
+        let bumpOuter sign =
+            fun () ->
+                outerRef.current <- outerRef.current + sign
+                setOuterDelta outerRef.current
+
+        // Override the displayed value/selection with the optimistically stepped value.
+        let displayValues, displaySelected =
+            match props.navigate |> Option.bind (fun n -> n.step) with
+            | Some step when innerDelta <> 0 || outerDelta <> 0 ->
+                let k, v = step (innerDelta, outerDelta)
+                [| (k, v) |], Some k
+            | _ -> props.values, props.selected
 
         let selectSlotProps =
             if isMobile then
@@ -57,7 +102,7 @@ module SimpleSelect =
         let clear = fun _ -> None |> props.updateSelected
 
         let items =
-            props.values
+            displayValues
             |> Array.mapi (fun i (k, v) ->
                 JSX.jsx
                     $"""
@@ -70,7 +115,7 @@ module SimpleSelect =
                 """
             )
 
-        let isClear = props.selected |> Option.defaultValue "" |> String.IsNullOrWhiteSpace
+        let isClear = displaySelected |> Option.defaultValue "" |> String.IsNullOrWhiteSpace
 
         let clearButton =
             match props.isLoading, isClear with
@@ -118,6 +163,7 @@ module SimpleSelect =
                             {|
                                 disabled = firstDisabled
                                 onClick = firstClick
+                                onStep = bumpOuter -1
                                 icon = Mui.Icons.FirstPageIcon
                             |}
                         )
@@ -134,6 +180,7 @@ module SimpleSelect =
                             {|
                                 disabled = decreaseDisabled
                                 onClick = decreaseClick
+                                onStep = bumpInner -1
                                 icon = Mui.Icons.SkipPreviousIcon
                             |}
                         )
@@ -150,6 +197,7 @@ module SimpleSelect =
                             {|
                                 disabled = increaseDisabled
                                 onClick = increaseClick
+                                onStep = bumpInner 1
                                 icon = Mui.Icons.SkipNextIcon
                             |}
                         )
@@ -166,6 +214,7 @@ module SimpleSelect =
                             {|
                                 disabled = lastDisabled
                                 onClick = lastClick
+                                onStep = bumpOuter 1
                                 icon = Mui.Icons.LastPageIcon
                             |}
                         )
@@ -255,7 +304,7 @@ module SimpleSelect =
             labelId={props.label + "-label"}
             id={props.label}
             name={props.label}
-            value={props.selected |> Option.defaultValue ""}
+            value={displaySelected |> Option.defaultValue ""}
             onChange={handleChange}
             label={props.label}
             disabled={props.disabled}

--- a/src/Informedica.GenPRES.Client/Components/SimpleSelect.fs
+++ b/src/Informedica.GenPRES.Client/Components/SimpleSelect.fs
@@ -53,7 +53,10 @@ module SimpleSelect =
         let valueKey =
             props.values |> Array.tryHead |> Option.map fst |> Option.defaultValue ""
 
-        React.useEffect (
+        // useLayoutEffect (not useEffect) so the deltas are reset BEFORE the browser
+        // paints the frame on which the server's new value arrives — otherwise that frame
+        // would briefly show newServerValue + staleDelta × increment.
+        React.useLayoutEffect (
             (fun () ->
                 innerRef.current <- 0
                 outerRef.current <- 0
@@ -73,12 +76,15 @@ module SimpleSelect =
                 outerRef.current <- outerRef.current + sign
                 setOuterDelta outerRef.current
 
-        // Override the displayed value/selection with the optimistically stepped value.
+        // Override only the displayed LABEL with the optimistically stepped value, keeping
+        // the original (server-provided) key. The key is a BigRational string the server
+        // recognises, so an in-flight dropdown change still dispatches a valid key; only
+        // the shown text reflects the optimistic step.
         let displayValues, displaySelected =
-            match props.navigate |> Option.bind (fun n -> n.step) with
-            | Some step when innerDelta <> 0 || outerDelta <> 0 ->
-                let k, v = step (innerDelta, outerDelta)
-                [| (k, v) |], Some k
+            match props.navigate |> Option.bind (fun n -> n.step), props.values |> Array.tryHead with
+            | Some step, Some(origKey, _) when innerDelta <> 0 || outerDelta <> 0 ->
+                let _, label = step (innerDelta, outerDelta)
+                [| (origKey, label) |], Some origKey
             | _ -> props.values, props.selected
 
         let selectSlotProps =

--- a/src/Informedica.GenPRES.Client/Views/Nutrition.fs
+++ b/src/Informedica.GenPRES.Client/Views/Nutrition.fs
@@ -880,6 +880,7 @@ module Nutrition =
                                 (SetMedianComponentQuantityProperty cmpName)
                                 (fun (n, uc) -> IncreaseComponentQuantityProperty(cmpName, n, uc))
                                 (SetMaxComponentQuantityProperty cmpName)
+                                (cmp.OrderableQuantity |> ViewHelpers.ovarStep string)
 
                     let qtyWarning = cmp.OrderableQuantity.Level |> getWarning
 
@@ -972,6 +973,7 @@ module Nutrition =
                         let navigable = ord.Orderable.Dose.Quantity |> OrderVariable.isNavigable
 
                         {|
+                            step = ord.Orderable.Dose.Quantity |> ViewHelpers.ovarStep string
                             first =
                                 if navigable then
                                     (fun (_: int) -> SetMinDoseQuantityProperty |> dispatch) |> Some
@@ -1117,6 +1119,7 @@ module Nutrition =
                         SetMedianDoseRateProperty
                         IncreaseDoseRateProperty
                         SetMaxDoseRateProperty
+                        (ord.Orderable.Dose.Rate |> ViewHelpers.ovarStep string)
 
                 let warning = ord.Orderable.Dose.Rate.Level |> getWarning
                 let label = ord.Orderable.Dose.Rate |> ViewHelpers.ovarLabel "infuussnelheid"

--- a/src/Informedica.GenPRES.Client/Views/Order.fs
+++ b/src/Informedica.GenPRES.Client/Views/Order.fs
@@ -934,12 +934,27 @@ module Order =
         let isFieldLoading field =
             isOrderLoading && loadingField = Some field
 
+        // Single-step decrease/increase (useCalc = false) are reflected immediately
+        // via an optimistic value (App.applyOptimisticStep), so the field must NOT
+        // show a loading spinner that would hide that value while the server confirms.
+        let isOptimisticStep msg =
+            match msg with
+            | DecreaseDoseRateProperty(_, false)
+            | IncreaseDoseRateProperty(_, false)
+            | DecreaseDoseQuantityProperty(_, false)
+            | IncreaseDoseQuantityProperty(_, false)
+            | DecreaseComponentQuantityProperty(_, false)
+            | IncreaseComponentQuantityProperty(_, false) -> true
+            | _ -> false
+
         // Shadow dispatch to auto-track which field triggered loading
         let dispatch =
             let originalDispatch = dispatch
 
             fun msg ->
-                msgToField msg |> Option.iter (fun f -> setLoadingField (Some f))
+                if not (isOptimisticStep msg) then
+                    msgToField msg |> Option.iter (fun f -> setLoadingField (Some f))
+
                 originalDispatch msg
 
         // Use local state order when available, otherwise fall back to the
@@ -1384,6 +1399,7 @@ module Order =
                                      SetMedianComponentQuantityProperty
                                      IncreaseComponentQuantityProperty
                                      SetMaxComponentQuantityProperty
+                                     (cmp |> Option.bind (_.OrderableQuantity >> ViewHelpers.ovarStep string))
 
                          let warning = cmp |> Option.bind (_.OrderableQuantity.Level >> getWarning)
 
@@ -1533,6 +1549,7 @@ module Order =
                                      SetMedianFrequencyProperty
                                      (fun _ -> IncreaseFrequencyProperty)
                                      SetMaxFrequencyProperty
+                                     None
 
                          let warning = ord.Schedule.Frequency.Level |> getWarning
 
@@ -1573,6 +1590,7 @@ module Order =
                                  let navigable = ord.Orderable.Dose.Quantity |> OrderVariable.isNavigable
                                  // specific case where increase is maximized by dose count
                                  {|
+                                     step = ord.Orderable.Dose.Quantity |> ViewHelpers.ovarStep string
                                      first =
                                          if navigable then
                                              (fun (_: int) -> SetMinDoseQuantityProperty |> dispatch) |> Some
@@ -1634,6 +1652,7 @@ module Order =
                                  SetMedianDoseRateProperty
                                  IncreaseDoseRateProperty
                                  SetMaxDoseRateProperty
+                                 (ord.Orderable.Dose.Rate |> ViewHelpers.ovarStep string)
 
                          let warning = ord.Orderable.Dose.Rate.Level |> getWarning
 

--- a/src/Informedica.GenPRES.Client/Views/Order.fs
+++ b/src/Informedica.GenPRES.Client/Views/Order.fs
@@ -934,17 +934,19 @@ module Order =
         let isFieldLoading field =
             isOrderLoading && loadingField = Some field
 
-        // Single-step decrease/increase (useCalc = false) are reflected immediately
-        // via an optimistic value (App.applyOptimisticStep), so the field must NOT
-        // show a loading spinner that would hide that value while the server confirms.
+        // Decrease/increase steps — inner (useCalc = false) and outer/first-last
+        // (useCalc = true) — are reflected immediately via an optimistic value, so the
+        // field must NOT show a loading indicator that would suggest the value hasn't
+        // changed yet. (Navigable first/last use SetMin/SetMax messages, not these, so
+        // they still show loading.)
         let isOptimisticStep msg =
             match msg with
-            | DecreaseDoseRateProperty(_, false)
-            | IncreaseDoseRateProperty(_, false)
-            | DecreaseDoseQuantityProperty(_, false)
-            | IncreaseDoseQuantityProperty(_, false)
-            | DecreaseComponentQuantityProperty(_, false)
-            | IncreaseComponentQuantityProperty(_, false) -> true
+            | DecreaseDoseRateProperty _
+            | IncreaseDoseRateProperty _
+            | DecreaseDoseQuantityProperty _
+            | IncreaseDoseQuantityProperty _
+            | DecreaseComponentQuantityProperty _
+            | IncreaseComponentQuantityProperty _ -> true
             | _ -> false
 
         // Shadow dispatch to auto-track which field triggered loading

--- a/src/Informedica.GenPRES.Client/Views/ViewHelpers.fs
+++ b/src/Informedica.GenPRES.Client/Views/ViewHelpers.fs
@@ -66,8 +66,19 @@ module ViewHelpers =
             )
 
 
-    let createNav dispatch navigable solved setMin (decr: int * bool -> 'Msg) setMed (incr: int * bool -> 'Msg) setMax =
+    let createNav
+        dispatch
+        navigable
+        solved
+        setMin
+        (decr: int * bool -> 'Msg)
+        setMed
+        (incr: int * bool -> 'Msg)
+        setMax
+        step
+        =
         {|
+            step = step
             first =
                 if navigable then
                     (fun (_: int) -> setMin |> dispatch) |> Some
@@ -122,6 +133,59 @@ module ViewHelpers =
             | "" -> [||]
             | s -> [| "range", s |]
         )
+
+
+    /// Build a per-click step function for a solved order variable. Given the net inner
+    /// click delta (single-step buttons, using the DEFINED increment) and the net outer
+    /// click delta (first/last buttons, using the server's CALCULATED increment) it returns
+    /// the (key, label) of the moved value, clamped to the defined range. The increments
+    /// mirror the server (Informedica.GenORDER.Lib.OrderVariable.step): inner uses the
+    /// defined increment, outer follows the server's calculated increment. Used to show
+    /// optimistic feedback that follows the live click count (the badge) before the server
+    /// confirms. Returns None when no increment is available (cannot step locally).
+    let ovarStep (format: decimal -> string) (ovar: OrderVariable) : (int * int -> string * string) option =
+        let firstSnd (vu: Types.ValueUnit) =
+            vu.Value |> Array.tryHead |> Option.map snd
+
+        let definedIncr =
+            [ ovar.DefinedConstraints.Incr; ovar.Variable.Incr ]
+            |> List.tryPick (Option.bind firstSnd)
+
+        // The outer (first/last) buttons follow the server-provided effective increment
+        // (OuterIncr); when the server emits none, the outer step falls back to the
+        // defined increment (i.e. behaves like the inner buttons).
+        let outerIncr = ovar.OuterIncr |> Option.bind firstSnd
+
+        match ovar.Variable.Vals, definedIncr with
+        | Some vals, Some di when di > 0M ->
+            match firstSnd vals with
+            | Some cur ->
+                let unit = vals.Unit
+
+                // Clamp against the DEFINED constraint range (the real allowed bounds),
+                // NOT the solved Variable's own Min/Max — for a solved variable those
+                // collapse to the single value, which would pin every step back to it.
+                let clamp v =
+                    let v =
+                        ovar.DefinedConstraints.Max
+                        |> Option.bind firstSnd
+                        |> Option.map (min v)
+                        |> Option.defaultValue v
+
+                    ovar.DefinedConstraints.Min
+                    |> Option.bind firstSnd
+                    |> Option.map (max v)
+                    |> Option.defaultValue v
+
+                let ci = outerIncr |> Option.defaultValue di
+
+                (fun (innerDelta, outerDelta) ->
+                    let next = (cur + decimal innerDelta * di + decimal outerDelta * ci) |> clamp
+                    string next, $"{format next} {unit}"
+                )
+                |> Some
+            | None -> None
+        | _ -> None
 
 
     let ovarDisplay select (name: string) (format: decimal -> string) minWidth (ovar: OrderVariable) =

--- a/src/Informedica.GenPRES.Server/ServerApi.Mappers.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Mappers.fs
@@ -81,9 +81,17 @@ module Mappers =
             dto.Calculated.IncrOpt
             |> Option.bind ValueUnit.Dto.fromDto
             |> Option.map (fun calcVu ->
+                // Compare by dimension + base value rather than structural (=) equality:
+                // calcVu is round-tripped through the DTO, so its unit representation may
+                // differ from the locally-constructed constant even when it is the same
+                // physical increment.
+                let sameIncr (target: Informedica.GenUnits.Lib.ValueUnit) =
+                    ValueUnit.eqsGroup calcVu target
+                    && ValueUnit.getBaseValue calcVu = ValueUnit.getBaseValue target
+
                 let mult =
                     match coarse with
-                    | Some u when calcVu = u -> BigRational.fromInt 10
+                    | Some u when sameIncr u -> BigRational.fromInt 10
                     | _ -> BigRational.fromInt 1
 
                 (mult |> ValueUnit.singleWithUnit Units.Count.times) * calcVu

--- a/src/Informedica.GenPRES.Server/ServerApi.Mappers.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Mappers.fs
@@ -66,7 +66,37 @@ module Mappers =
             dto
 
 
-        let mapToOrderVariable (dto: OrderVariable.Dto.Dto) : Types.OrderVariable =
+        /// The per-click increment used by the outer (first/last) navigation buttons: the
+        /// calculated increment (OrderVariable.step uses CalculatedConstraints.Incr for the
+        /// useCalc path). When `coarse` is given and the calculated increment equals it, the
+        /// count is multiplied by 10 — mirroring the server's role-specific special cases.
+        /// Generic order variables pass None so NO multiple is applied (the ×10 must only
+        /// happen for the rate / quantity that the server actually multiplies). Optional —
+        /// many order variables have no calculated increment.
+        let mapOuterIncr
+            (coarse: Informedica.GenUnits.Lib.ValueUnit option)
+            (dto: OrderVariable.Dto.Dto)
+            : Types.ValueUnit option
+            =
+            dto.Calculated.IncrOpt
+            |> Option.bind ValueUnit.Dto.fromDto
+            |> Option.map (fun calcVu ->
+                let mult =
+                    match coarse with
+                    | Some u when calcVu = u -> BigRational.fromInt 10
+                    | _ -> BigRational.fromInt 1
+
+                (mult |> ValueUnit.singleWithUnit Units.Count.times) * calcVu
+                |> ValueUnit.Dto.toDtoDutchShort
+                |> mapToValueUnit
+            )
+
+
+        let mapToOrderVariableWith
+            (coarse: Informedica.GenUnits.Lib.ValueUnit option)
+            (dto: OrderVariable.Dto.Dto)
+            : Types.OrderVariable
+            =
             let level =
                 match dto.Level with
                 | OrderVariable.Dto.IsNormal -> IsNormal
@@ -79,7 +109,29 @@ module Mappers =
                 (dto.Constraints |> mapToVariable)
                 (dto.Calculated |> mapToVariable)
                 (dto.Variable |> mapToVariable)
+                (dto |> mapOuterIncr coarse)
                 level
+
+
+        // Generic mapping: no outer ×10 multiple (used for every order variable that is
+        // not navigated as a rate or quantity).
+        let mapToOrderVariable = mapToOrderVariableWith None
+
+        let tenthOf u =
+            u |> ValueUnit.singleWithValue (BigRational.fromInt 1 / BigRational.fromInt 10)
+
+        // The server's special "×10" outer-step cases key on these increments: a quantity
+        // increment of 1/10 mL (OrderVariable.stepQuantity) and a rate increment of
+        // 1/10 mL/hour (Dose.stepRate).
+        let mlTenth = Units.Volume.milliLiter |> tenthOf
+
+        let mlPerHourTenth =
+            Units.Volume.milliLiter |> ValueUnit.per Units.Time.hour |> tenthOf
+
+        // The rate / quantity an order navigates DO get the server's ×10 outer step when
+        // their calculated increment is the 1/10 mL[/hour] coarse increment.
+        let mapToRateOrderVariable = mapToOrderVariableWith (Some mlPerHourTenth)
+        let mapToQuantityOrderVariable = mapToOrderVariableWith (Some mlTenth)
 
 
         let mapFromOrderVariable (ov: Types.OrderVariable) : OrderVariable.Dto.Dto =
@@ -101,9 +153,9 @@ module Mappers =
 
         let mapToDose (dto: Order.Orderable.Dose.Dto.Dto) : Dose =
             Models.Order.Dose.create
-                (dto.Quantity |> mapToOrderVariable)
+                (dto.Quantity |> mapToQuantityOrderVariable)
                 (dto.PerTime |> mapToOrderVariable)
-                (dto.Rate |> mapToOrderVariable)
+                (dto.Rate |> mapToRateOrderVariable)
                 (dto.Total |> mapToOrderVariable)
                 (dto.QuantityAdjust |> mapToOrderVariable)
                 (dto.PerTimeAdjust |> mapToOrderVariable)
@@ -155,7 +207,8 @@ module Mappers =
                 dto.Name
                 dto.Form
                 (dto.ComponentQuantity |> mapToOrderVariable)
-                (dto.OrderableQuantity |> mapToOrderVariable)
+                // the component's orderable quantity is navigated as a quantity (×10 outer)
+                (dto.OrderableQuantity |> mapToQuantityOrderVariable)
                 (dto.OrderableCount |> mapToOrderVariable)
                 (dto.OrderQuantity |> mapToOrderVariable)
                 (dto.OrderCount |> mapToOrderVariable)

--- a/src/Informedica.GenPRES.Shared/Models.fs
+++ b/src/Informedica.GenPRES.Shared/Models.fs
@@ -1662,12 +1662,13 @@ module Models =
 
         module OrderVariable =
 
-            let create nme cst cal var level =
+            let create nme cst cal var outerIncr level =
                 {
                     Name = nme
                     DefinedConstraints = cst
                     CalculatedConstraints = cal
                     Variable = var
+                    OuterIncr = outerIncr
                     Level = level
                 }
 

--- a/src/Informedica.GenPRES.Shared/Types.fs
+++ b/src/Informedica.GenPRES.Shared/Types.fs
@@ -168,6 +168,10 @@ module Types =
             DefinedConstraints: Variable
             CalculatedConstraints: Variable
             Variable: Variable
+            // The effective "bigger" per-click increment used by the outer (first/last)
+            // navigation buttons, as computed by the server. Optional: only order
+            // variables whose outer step differs from the defined increment emit one.
+            OuterIncr: ValueUnit option
             Level: Level
         }
 

--- a/tests/Informedica.GenPRES.Shared.Tests/Tests.fs
+++ b/tests/Informedica.GenPRES.Shared.Tests/Tests.fs
@@ -23,7 +23,7 @@ module Tests =
             let vu vals =
                 Order.ValueUnit.create (vals |> Array.map (fun v -> (string v, v))) "mg" "mass" true "nl" ""
 
-            let ovar = Order.OrderVariable.create "testOrderVar" emptyVar emptyVar emptyVar
+            let ovar = Order.OrderVariable.create "testOrderVar" emptyVar emptyVar emptyVar None
 
 
             let tests =
@@ -32,7 +32,8 @@ module Tests =
                     [
 
                         test "no incr and no vals returns NonNavigable" {
-                            let ovar = Order.OrderVariable.create "test" emptyVar emptyVar emptyVar IsNormal
+                            let ovar =
+                                Order.OrderVariable.create "test" emptyVar emptyVar emptyVar None IsNormal
 
                             match ovar with
                             | Order.OrderVariable.NonNavigable -> ()
@@ -43,7 +44,8 @@ module Tests =
                             let varWithMin =
                                 Order.Variable.create "test" false (vu [| 0m |] |> Some) false None None false None
 
-                            let ovar = Order.OrderVariable.create "test" emptyVar emptyVar varWithMin IsNormal
+                            let ovar =
+                                Order.OrderVariable.create "test" emptyVar emptyVar varWithMin None IsNormal
 
                             match ovar with
                             | Order.OrderVariable.NonNavigable -> ()
@@ -62,7 +64,8 @@ module Tests =
                                     false
                                     (vu [| 1m; 2m; 3m |] |> Some)
 
-                            let ovar = Order.OrderVariable.create "test" emptyVar emptyVar varWithVals IsNormal
+                            let ovar =
+                                Order.OrderVariable.create "test" emptyVar emptyVar varWithVals None IsNormal
 
                             match ovar with
                             | Order.OrderVariable.Selectable -> ()
@@ -73,7 +76,8 @@ module Tests =
                             let varWithVals =
                                 Order.Variable.create "test" false None false None None false (vu [| 5m; 10m |] |> Some)
 
-                            let ovar = Order.OrderVariable.create "test" emptyVar emptyVar varWithVals IsNormal
+                            let ovar =
+                                Order.OrderVariable.create "test" emptyVar emptyVar varWithVals None IsNormal
 
                             match ovar with
                             | Order.OrderVariable.Selectable -> ()
@@ -88,7 +92,7 @@ module Tests =
                                 Order.Variable.create "test" false None false (vu [| 0.5m |] |> Some) None false None
 
                             let ovar =
-                                Order.OrderVariable.create "test" defWithIncr emptyVar varWithOneVal IsNormal
+                                Order.OrderVariable.create "test" defWithIncr emptyVar varWithOneVal None IsNormal
 
                             match ovar with
                             | Order.OrderVariable.Stepable -> ()
@@ -100,7 +104,7 @@ module Tests =
                                 Order.Variable.create "test" false None false None None false (vu [| 1m |] |> Some)
 
                             let ovar =
-                                Order.OrderVariable.create "test" emptyVar emptyVar varWithOneVal IsNormal
+                                Order.OrderVariable.create "test" emptyVar emptyVar varWithOneVal None IsNormal
 
                             match ovar with
                             | Order.OrderVariable.NonNavigable -> ()
@@ -123,7 +127,7 @@ module Tests =
                                 Order.Variable.create "test" false None false (vu [| 1m |] |> Some) None false None
 
                             let ovar =
-                                Order.OrderVariable.create "test" defWithIncr emptyVar varWithMinMax IsNormal
+                                Order.OrderVariable.create "test" defWithIncr emptyVar varWithMinMax None IsNormal
 
                             match ovar with
                             | Order.OrderVariable.Navigable -> ()
@@ -138,7 +142,7 @@ module Tests =
                                 Order.Variable.create "test" false None false (vu [| 1m |] |> Some) None false None
 
                             let ovar =
-                                Order.OrderVariable.create "test" defWithIncr emptyVar varWithMinOnly IsNormal
+                                Order.OrderVariable.create "test" defWithIncr emptyVar varWithMinOnly None IsNormal
 
                             match ovar with
                             | Order.OrderVariable.NonNavigable -> ()
@@ -153,7 +157,7 @@ module Tests =
                                 Order.Variable.create "test" false None false (vu [| 1m |] |> Some) None false None
 
                             let ovar =
-                                Order.OrderVariable.create "test" defWithIncr emptyVar varWithMaxOnly IsNormal
+                                Order.OrderVariable.create "test" defWithIncr emptyVar varWithMaxOnly None IsNormal
 
                             match ovar with
                             | Order.OrderVariable.NonNavigable -> ()
@@ -176,7 +180,13 @@ module Tests =
                                 Order.Variable.create "test" false None false (vu [| 1m |] |> Some) None false None
 
                             let ovar =
-                                Order.OrderVariable.create "test" defWithIncr emptyVar varWithValsAndMinMax IsNormal
+                                Order.OrderVariable.create
+                                    "test"
+                                    defWithIncr
+                                    emptyVar
+                                    varWithValsAndMinMax
+                                    None
+                                    IsNormal
 
                             match ovar with
                             | Order.OrderVariable.Selectable -> ()


### PR DESCRIPTION
## Summary

The increment/decrement navigation buttons (`first / decrease / increase / last`)
on order fields debounce clicks (700 ms) and send the accumulated click count to
the server, which computes the new value. Until now the displayed value did **not**
change until the server response came back, so rapid clicking gave no immediate
feedback — only the click-count badge moved.

This PR makes the displayed value follow the live click count **immediately**
(the same instant the badge updates), then reconcile with the server result when it
arrives. The value sent to the server is unchanged (original context + `ntimes`), so
the server still re-applies the step — no double-application.

## Problem

- Clicking a step button updated the badge but not the underlying value; the value
  only appeared after the debounce + server round-trip.
- The optimistic value must use the **same** increment the server uses, otherwise it
  would jump after the round-trip.

## Solution

**Client – live, per-click optimistic value**
- `ClickCountingButton` now fires an `onStep` tick on every click (and during
  press-and-hold), alongside the badge update.
- `SimpleSelect` accumulates a signed *inner* delta (decrease/increase) and *outer*
  delta (first/last) and overrides the displayed value via a per-field `step`
  function while a request is in flight. The deltas reset when the underlying value
  actually changes (server replied) — the reset effect keys on the value string (a
  primitive) so it doesn't fire on every render.
- `ViewHelpers.ovarStep` builds the step function from the order variable: inner uses
  the **defined** increment, outer uses the server-provided increment; the result is
  clamped to the defined range. `step` is a **tupled** `(int*int) -> string*string`
  to avoid Fable currying issues at the record boundary.
- `Order.fs` / `Nutrition.fs` pass `ovarStep` for Dose Rate, Dose Quantity and
  Component Quantity. The per-field loading spinner is suppressed for the
  optimistically-handled single-step messages so the field stays interactive.

**Server – tell the client the exact outer increment**
- New optional field `OuterIncr: ValueUnit option` on `OrderVariable`
  (`Shared/Types.fs`, `Shared/Models.fs`).
- `ServerApi.Mappers` computes it as the **calculated** increment, applying the
  server's role-specific `×10` only where the server itself does:
  - Dose **Rate** → `×10` when the calculated increment is `1/10 mL/hour`
    (mirrors `Dose.stepRate`).
  - Dose/Component **Quantity** → `×10` when it is `1/10 mL`
    (mirrors `OrderVariable.stepQuantity`).
  - Every other order variable → plain calculated increment, **no** `×10`.
- Server `step` behaviour is **unchanged**; the mapper only *reports* the effective
  increment so the client stays generic and always follows the server.

## Verification

Outer-button increment matches the server exactly:
server outer step `= (n × mult) × calc`, client `= n × (mult × calc)` — identical
for the mL/h rate, the mL quantity, and the non-special (`mult = 1`) cases.

## Files changed

- `src/Informedica.GenPRES.Client/Components/ClickCountingButton.fs`
- `src/Informedica.GenPRES.Client/Components/SimpleSelect.fs`
- `src/Informedica.GenPRES.Client/Views/ViewHelpers.fs`
- `src/Informedica.GenPRES.Client/Views/Order.fs`
- `src/Informedica.GenPRES.Client/Views/Nutrition.fs`
- `src/Informedica.GenPRES.Server/ServerApi.Mappers.fs`
- `src/Informedica.GenPRES.Shared/Types.fs`
- `src/Informedica.GenPRES.Shared/Models.fs`
- `tests/Informedica.GenPRES.Shared.Tests/Tests.fs`

## Testing

- `dotnet build GenPRES.sln` — clean.
- `dotnet run ServerTests` equivalents: GenORDER 53/53, Shared 11/11 pass.
- Manual: clicked Dose Rate / Dose Quantity / Component Quantity inner and outer
  buttons; value tracks the badge count live and reconciles with the server result.
- Confirmed in generated Fable JSX that the tick → delta → display-override path and
  the tupled `step` call are wired correctly.

## Notes

- `OuterIncr` is produced by the server, so the **server must be rebuilt/restarted**
  for it to reach the client (the Fable client hot-reloads on its own).
- Where the calculated increment equals the defined one (e.g. a mass dose rate), the
  outer step equals the inner step — faithful to the server.

## Follow-ups (not in this PR)

- **Ceiling overflow:** when stepping near a limit the optimistic value can exceed a
  ceiling derived from related variables (not in the field's own constraints) and
  snap back after the server responds. A robust fix requires the server to send an
  effective max per navigable field (a max-solve), to be addressed separately.

## AI-assisted contribution disclosure

This change was developed with AI assistance (Claude Code). All non-UI logic was
prototyped/verified and the diff reviewed before inclusion; UI code is in
`src/Informedica.GenPRES.Client`. Verified via the build, the unit test suites, and
inspection of the generated Fable JSX. Please review with the usual scrutiny for
medical-device code.