### PR TITLE
Fix/UI navigation overflow

### DIFF
--- a/.claude/docs/session-decisions.md
+++ b/.claude/docs/session-decisions.md
@@ -24,3 +24,87 @@
 ### Deferred: UI Select Boxes
 - When multiple `DoseTypes` are available, the nutrition UI will need select boxes.
 - Pattern to follow: `Prescribe.fs` filter selects using `SimpleSelect` component.
+
+---
+
+# Session Decisions - 2026-06-27
+
+Three client-UI features this session. All changes are in `src/Informedica.GenPRES.Client/`
+(the only `.fs` area the script-only policy permits direct edits). Builds clean via
+`dotnet build src/Informedica.GenPRES.Client/Informedica.GenPRES.Client.fsproj`.
+
+## 1. Patient view auto-close should not strand open dropdowns
+
+- **File**: `Views/Patient.fs` (the 5s inactivity timer that collapses the patient accordion).
+- **Problem**: collapsing the accordion reflows the whole page (it's the first child of the
+  page Stack in `Pages/GenPres.fs`), detaching any open MUI dropdown popup (its own selects
+  **or** a sibling child view's DataGrid COLUMNS/FILTERS popup) from its anchor → dangling list.
+- **Decision**: gate the timer on a DOM check at fire time and **re-arm a fresh 5s** while any
+  overlay is open (full-grace, user-chosen), rather than collapsing.
+  - `anyOverlayOpen ()` = `document.querySelectorAll(".MuiModal-root:not(.MuiModal-hidden), .MuiPopper-root").length > 0`.
+  - **Critical**: must exclude `.MuiModal-hidden`. The language menu (`Components/Localization.fs`)
+    uses `keepMounted`, so its closed Popover/Modal root stays in the DOM permanently; without
+    the `:not(.MuiModal-hidden)` the timer never fired (regression we hit and fixed).
+  - Do NOT use an `[aria-expanded="true"]` selector — the accordion summary itself has it.
+- DOM check chosen over open/close callbacks because MUI's own DataGrid toolbar popups can't be
+  hooked; one DOM query covers patient selects + child-view popups + future popups.
+
+## 2. Optimistic step value not reset when server returns the SAME value
+
+- **Files**: `Views/Order.fs`, `Views/Nutrition.fs` (compute `revision`); `Views/ViewHelpers.fs`
+  (`createNav` carries it); `Components/SimpleSelect.fs` (consumes it).
+- **Problem (PR #372 follow-up)**: `SimpleSelect` reset its optimistic step delta only when the
+  displayed `valueKey` changed. When a step overflowed and the server returned the *same* value,
+  `valueKey` didn't change → the stale optimistic value stuck in the OrderView (background
+  Prescribe view showed the correct value).
+- **Decision**: add a monotonic `revision` counter, bumped on every new `Resolved` orderContext
+  (Order.fs) / new `ctx` reference (Nutrition.fs), computed **during render via a ref compare**
+  (`obj.ReferenceEquals`) so the new value is present on the response frame (no one-frame flash).
+  Threaded through the `navigate` record (only stepping selects need it; `navigate=None` callers
+  untouched). `SimpleSelect` adds `box revision` to its reset `useLayoutEffect` deps.
+- **Note**: `navigate` records are built in 3+ places — `ViewHelpers.createNav` and **inline**
+  records in Order.fs *and* Nutrition.fs (the `doseQtyNav`). All must carry every field or the
+  structural anon-record type fails to compile. Easy to miss the inline Nutrition one.
+
+## 3. Multi-component dose quantity: feasibility ceiling + saturate at max
+
+- **Scope (important, narrowed twice with the user)**: applies ONLY to `orderable.dose.quantity`,
+  and ONLY for **multi-component** orderables. Single component → orderable quantity follows the
+  dose, no ceiling. The existing `canIncr` (`Components.Length = 1 || all DoseCount > 1`) and the
+  "totale hoeveelheid" field being gated on `Components.Length > 1` both already encode this.
+- **Server semantics (confirmed, drove terminology)**:
+  - `OrderVariable.step` (`OrderVariable.fs:980`) moves **freely** along the increment grid with
+    NO upper bound (comment: "may fall outside min/max … intentional"), then the order re-solves.
+  - The downward correction on overflow is the **constraint re-solve being infeasible**, then
+    `Api.fs:856` `Result.defaultValue sc.Order` **reverts to the previous order**. NOT a clamp.
+  - Therefore "clamp" was the wrong word and the client should NOT bound the optimistic value to
+    `DefinedConstraints.Max/Min` (that makes it *undershoot* the server). Only genuine bound =
+    the structural feasibility ceiling.
+- **Decisions / implementation** (all in `ViewHelpers.fs` + the two views):
+  - `ovarStepTo (ceiling: decimal option) format ovar` — free stepping; applies only the
+    feasibility `ceiling` + a one-increment floor (mirrors server non-zero-positive). `ovarStep`
+    is the no-ceiling delegate. Replaced the old `DefinedConstraints`-range "clamp".
+  - `orderableDoseQuantityCeiling ord` → `Some (max OrderableQuantity vals)` when `Components > 1`,
+    else `None`. (For multi-component, max dose qty = orderable qty because `DoseCount_min = 1`,
+    set by `setToMinIsOne` in `OrderProcessor.fs:93`.)
+  - `incrementStepsToCeiling ceiling ovar` → how many defined-increment steps fit below the
+    ceiling. Used by `saturateInc n` (in both views' dose-qty `increase` callback) to cap the
+    DISPATCHED step count so an overflow **lands on the max** (feasible → no revert) instead of
+    overshooting and reverting.
+  - **Delta-saturation fix** (`SimpleSelect.fs`): `bumpInner`/`bumpOuter` now only accumulate a
+    click if it actually changes the predicted value (`changesValue` compares step output
+    before/after). Without this the raw delta grew past the visible ceiling, so reversing had a
+    "dead zone" until the delta unwound below the max. General fix (also helps the floor).
+- **Terminology retired**: "clamp" → "feasibility ceiling" / "saturate" / "revert" / "free
+  stepping". `clampInc` renamed `saturateInc`. Swept all comments (Order/Nutrition revision
+  comments, SimpleSelect, ViewHelpers) for residual "clamp"/"clamped back" wording.
+
+### Open / deferred
+- The outer `last` button (solved branch) dispatches `IncreaseDoseQuantityProperty(n, true)`
+  **uncapped** — saturation only applied to the inner `increase`. Outer uses the calculated
+  increment × server multiplier (`stepQuantity`), trickier to mirror client-side. Left as-is.
+- A fully general server-side fix (saturate on infeasible step instead of `Result.defaultValue`
+  revert at `Api.fs:856`) would cover fields where the client can't know the true max — but
+  that's `.fs` server code → would need the `.fsx` prototype-and-migrate workflow, not done.
+- Unit assumption in the ceiling `min`: dose qty and orderable qty share a unit (mL volume);
+  holds for the orderable dose quantity, would be wrong if ever different-unit.

--- a/src/Informedica.GenPRES.Client/Components/SimpleSelect.fs
+++ b/src/Informedica.GenPRES.Client/Components/SimpleSelect.fs
@@ -27,6 +27,7 @@ module SimpleSelect =
                         increase: (int -> unit) option
                         last: (int -> unit) option
                         useDebounce: bool
+                        revision: int
                     |} option
                 isLoading: bool
                 disabled: bool
@@ -53,6 +54,13 @@ module SimpleSelect =
         let valueKey =
             props.values |> Array.tryHead |> Option.map fst |> Option.defaultValue ""
 
+        // A monotonic counter the parent bumps on every server response. It also resets
+        // the optimistic deltas when the server returns the SAME value as before — e.g.
+        // stepping past the maximum is clamped back to the current value, so valueKey
+        // never changes and would otherwise leave the stale optimistic value displayed.
+        let revision =
+            props.navigate |> Option.map (fun n -> n.revision) |> Option.defaultValue 0
+
         // useLayoutEffect (not useEffect) so the deltas are reset BEFORE the browser
         // paints the frame on which the server's new value arrives — otherwise that frame
         // would briefly show newServerValue + staleDelta × increment.
@@ -63,7 +71,7 @@ module SimpleSelect =
                 setInnerDelta 0
                 setOuterDelta 0
             ),
-            [| box valueKey |]
+            [| box valueKey; box revision |]
         )
 
         let bumpInner sign =

--- a/src/Informedica.GenPRES.Client/Components/SimpleSelect.fs
+++ b/src/Informedica.GenPRES.Client/Components/SimpleSelect.fs
@@ -42,7 +42,8 @@ module SimpleSelect =
         // Net click deltas accumulated from the nav buttons. Drive an optimistic displayed
         // value that follows the live click count (the badge) before the server confirms.
         // Inner = single-step decrease/increase (defined increment); outer = first/last in
-        // step state (calculated increment). Reset when the underlying value changes.
+        // step state (calculated increment). Reset when the underlying value or the server
+        // revision changes.
         let innerDelta, setInnerDelta = React.useState 0
         let outerDelta, setOuterDelta = React.useState 0
         let innerRef = React.useRef 0
@@ -55,9 +56,9 @@ module SimpleSelect =
             props.values |> Array.tryHead |> Option.map fst |> Option.defaultValue ""
 
         // A monotonic counter the parent bumps on every server response. It also resets
-        // the optimistic deltas when the server returns the SAME value as before — e.g.
-        // stepping past the maximum is clamped back to the current value, so valueKey
-        // never changes and would otherwise leave the stale optimistic value displayed.
+        // the optimistic deltas when the server returns the SAME value as before — e.g. a
+        // no-op step (already at the maximum) leaves the current value unchanged, so
+        // valueKey never changes and would otherwise leave a stale optimistic value shown.
         let revision =
             props.navigate |> Option.map (fun n -> n.revision) |> Option.defaultValue 0
 
@@ -74,22 +75,39 @@ module SimpleSelect =
             [| box valueKey; box revision |]
         )
 
+        let stepFn = props.navigate |> Option.bind (fun n -> n.step)
+
+        // Only accumulate a click that actually moves the predicted value. When the step
+        // has saturated at a bound (the feasibility ceiling or the increment floor) the
+        // value stops changing; continuing to grow the delta would store invisible
+        // "overflow" that a reversal must first unwind before the value moves again.
+        let changesValue inner outer =
+            match stepFn with
+            | Some f -> f (inner, outer) <> f (innerRef.current, outerRef.current)
+            | None -> true
+
         let bumpInner sign =
             fun () ->
-                innerRef.current <- innerRef.current + sign
-                setInnerDelta innerRef.current
+                let next = innerRef.current + sign
+
+                if changesValue next outerRef.current then
+                    innerRef.current <- next
+                    setInnerDelta next
 
         let bumpOuter sign =
             fun () ->
-                outerRef.current <- outerRef.current + sign
-                setOuterDelta outerRef.current
+                let next = outerRef.current + sign
+
+                if changesValue innerRef.current next then
+                    outerRef.current <- next
+                    setOuterDelta next
 
         // Override only the displayed LABEL with the optimistically stepped value, keeping
         // the original (server-provided) key. The key is a BigRational string the server
         // recognises, so an in-flight dropdown change still dispatches a valid key; only
         // the shown text reflects the optimistic step.
         let displayValues, displaySelected =
-            match props.navigate |> Option.bind (fun n -> n.step), props.values |> Array.tryHead with
+            match stepFn, props.values |> Array.tryHead with
             | Some step, Some(origKey, _) when innerDelta <> 0 || outerDelta <> 0 ->
                 let _, label = step (innerDelta, outerDelta)
                 [| (origKey, label) |], Some origKey

--- a/src/Informedica.GenPRES.Client/Components/SimpleSelect.fs
+++ b/src/Informedica.GenPRES.Client/Components/SimpleSelect.fs
@@ -41,13 +41,13 @@ module SimpleSelect =
 
         // Net click deltas accumulated from the nav buttons. Drive an optimistic displayed
         // value that follows the live click count (the badge) before the server confirms.
-        // Inner = single-step decrease/increase (defined increment); outer = first/last in
-        // step state (calculated increment). Reset when the underlying value or the server
-        // revision changes.
-        let innerDelta, setInnerDelta = React.useState 0
-        let outerDelta, setOuterDelta = React.useState 0
-        let innerRef = React.useRef 0
-        let outerRef = React.useRef 0
+        // Small = single-step decrease/increase (the defined increment); Large = jump
+        // decrease/increase (the server's larger calculated increment). Reset when the
+        // underlying value or the server revision changes.
+        let smallDelta, setSmallDelta = React.useState 0
+        let largeDelta, setLargeDelta = React.useState 0
+        let smallRef = React.useRef 0
+        let largeRef = React.useRef 0
 
         // Use the raw value string as the dependency (a JS primitive compared by value)
         // so the reset only fires when the underlying value actually changes — boxing an
@@ -67,10 +67,10 @@ module SimpleSelect =
         // would briefly show newServerValue + staleDelta × increment.
         React.useLayoutEffect (
             (fun () ->
-                innerRef.current <- 0
-                outerRef.current <- 0
-                setInnerDelta 0
-                setOuterDelta 0
+                smallRef.current <- 0
+                largeRef.current <- 0
+                setSmallDelta 0
+                setLargeDelta 0
             ),
             [| box valueKey; box revision |]
         )
@@ -81,26 +81,26 @@ module SimpleSelect =
         // has saturated at a bound (the feasibility ceiling or the increment floor) the
         // value stops changing; continuing to grow the delta would store invisible
         // "overflow" that a reversal must first unwind before the value moves again.
-        let changesValue inner outer =
+        let changesValue small large =
             match stepFn with
-            | Some f -> f (inner, outer) <> f (innerRef.current, outerRef.current)
+            | Some f -> f (small, large) <> f (smallRef.current, largeRef.current)
             | None -> true
 
-        let bumpInner sign =
+        let bumpSmall sign =
             fun () ->
-                let next = innerRef.current + sign
+                let next = smallRef.current + sign
 
-                if changesValue next outerRef.current then
-                    innerRef.current <- next
-                    setInnerDelta next
+                if changesValue next largeRef.current then
+                    smallRef.current <- next
+                    setSmallDelta next
 
-        let bumpOuter sign =
+        let bumpLarge sign =
             fun () ->
-                let next = outerRef.current + sign
+                let next = largeRef.current + sign
 
-                if changesValue innerRef.current next then
-                    outerRef.current <- next
-                    setOuterDelta next
+                if changesValue smallRef.current next then
+                    largeRef.current <- next
+                    setLargeDelta next
 
         // Override only the displayed LABEL with the optimistically stepped value, keeping
         // the original (server-provided) key. The key is a BigRational string the server
@@ -108,8 +108,8 @@ module SimpleSelect =
         // the shown text reflects the optimistic step.
         let displayValues, displaySelected =
             match stepFn, props.values |> Array.tryHead with
-            | Some step, Some(origKey, _) when innerDelta <> 0 || outerDelta <> 0 ->
-                let _, label = step (innerDelta, outerDelta)
+            | Some step, Some(origKey, _) when smallDelta <> 0 || largeDelta <> 0 ->
+                let _, label = step (smallDelta, largeDelta)
                 [| (origKey, label) |], Some origKey
             | _ -> props.values, props.selected
 
@@ -195,7 +195,7 @@ module SimpleSelect =
                             {|
                                 disabled = firstDisabled
                                 onClick = firstClick
-                                onStep = bumpOuter -1
+                                onStep = bumpLarge -1
                                 icon = Mui.Icons.FirstPageIcon
                             |}
                         )
@@ -212,7 +212,7 @@ module SimpleSelect =
                             {|
                                 disabled = decreaseDisabled
                                 onClick = decreaseClick
-                                onStep = bumpInner -1
+                                onStep = bumpSmall -1
                                 icon = Mui.Icons.SkipPreviousIcon
                             |}
                         )
@@ -229,7 +229,7 @@ module SimpleSelect =
                             {|
                                 disabled = increaseDisabled
                                 onClick = increaseClick
-                                onStep = bumpInner 1
+                                onStep = bumpSmall 1
                                 icon = Mui.Icons.SkipNextIcon
                             |}
                         )
@@ -246,7 +246,7 @@ module SimpleSelect =
                             {|
                                 disabled = lastDisabled
                                 onClick = lastClick
-                                onStep = bumpOuter 1
+                                onStep = bumpLarge 1
                                 icon = Mui.Icons.LastPageIcon
                             |}
                         )

--- a/src/Informedica.GenPRES.Client/Views/Nutrition.fs
+++ b/src/Informedica.GenPRES.Client/Views/Nutrition.fs
@@ -633,9 +633,9 @@ module Nutrition =
 
         // Monotonic counter bumped whenever a new server response replaces the order
         // context. Passed into stepped selects so they reset their optimistic step value
-        // even when the server clamps back to the SAME value (e.g. stepping past the
-        // maximum), where the displayed value never changes and the value-based reset
-        // alone would leave the stale optimistic value on screen.
+        // even when the server returns the SAME value as before (e.g. a no-op step when
+        // already at the maximum), where the displayed value never changes and the
+        // value-based reset alone would leave the stale optimistic value on screen.
         let revisionRef = React.useRef 0
         let prevCtxRef = React.useRef ctx
 
@@ -987,8 +987,22 @@ module Nutrition =
                         let solved = ord |> isSolved
                         let navigable = ord.Orderable.Dose.Quantity |> OrderVariable.isNavigable
 
+                        // For a multi-component orderable the dose quantity cannot exceed the
+                        // prepared orderable quantity. Use it as a feasibility ceiling: the
+                        // optimistic value stays within it, and an overflowing increase is
+                        // saturated at the max (saturateInc) instead of overshooting, which the
+                        // solver would reject — reverting the value. Single component: orderable
+                        // quantity follows the dose, so no ceiling.
+                        let doseQtyCeiling = ord |> ViewHelpers.orderableDoseQuantityCeiling
+
+                        let saturateInc n =
+                            ord.Orderable.Dose.Quantity
+                            |> ViewHelpers.incrementStepsToCeiling doseQtyCeiling
+                            |> Option.map (min n)
+                            |> Option.defaultValue n
+
                         {|
-                            step = ord.Orderable.Dose.Quantity |> ViewHelpers.ovarStep string
+                            step = ord.Orderable.Dose.Quantity |> ViewHelpers.ovarStepTo doseQtyCeiling string
                             first =
                                 if navigable then
                                     (fun (_: int) -> SetMinDoseQuantityProperty |> dispatch) |> Some
@@ -1008,7 +1022,8 @@ module Nutrition =
                                     None
                             increase =
                                 if solved && canIncr then
-                                    (fun n -> (n, false) |> IncreaseDoseQuantityProperty |> dispatch) |> Some
+                                    (fun n -> (saturateInc n, false) |> IncreaseDoseQuantityProperty |> dispatch)
+                                    |> Some
                                 else
                                     None
                             last =

--- a/src/Informedica.GenPRES.Client/Views/Nutrition.fs
+++ b/src/Informedica.GenPRES.Client/Views/Nutrition.fs
@@ -966,77 +966,16 @@ module Nutrition =
 
                 let vals = ord.Orderable.Dose.Quantity |> ViewHelpers.ovarValsWithRange string 3
 
-                let showNav =
-                    ord.Orderable.Components
-                    |> Array.forall (fun cmp ->
-                        cmp.OrderableQuantity.Variable.Vals
-                        |> Option.map (fun vu -> vu.Value |> Array.length = 1)
-                        |> Option.defaultValue false
-                    )
-
                 let doseQtyNav =
-                    if not showNav then
-                        None
-                    else
-                        let canIncr =
-                            ord.Orderable.Components |> Array.length = 1
-                            || ord.Orderable.DoseCount.Variable.Vals
-                               |> Option.map (fun vu -> vu.Value |> Array.map snd |> Array.forall (fun v -> v > 1m))
-                               |> Option.defaultValue false
-
-                        let solved = ord |> isSolved
-                        let navigable = ord.Orderable.Dose.Quantity |> OrderVariable.isNavigable
-
-                        // For a multi-component orderable the dose quantity cannot exceed the
-                        // prepared orderable quantity. Use it as a feasibility ceiling: the
-                        // optimistic value stays within it, and an overflowing increase is
-                        // saturated at the max (saturateInc) instead of overshooting, which the
-                        // solver would reject — reverting the value. Single component: orderable
-                        // quantity follows the dose, so no ceiling.
-                        let doseQtyCeiling = ord |> ViewHelpers.orderableDoseQuantityCeiling
-
-                        let saturateInc n =
-                            ord.Orderable.Dose.Quantity
-                            |> ViewHelpers.incrementStepsToCeiling doseQtyCeiling
-                            |> Option.map (min n)
-                            |> Option.defaultValue n
-
-                        {|
-                            step = ord.Orderable.Dose.Quantity |> ViewHelpers.ovarStepTo doseQtyCeiling string
-                            first =
-                                if navigable then
-                                    (fun (_: int) -> SetMinDoseQuantityProperty |> dispatch) |> Some
-                                elif solved then
-                                    (fun n -> (n, true) |> DecreaseDoseQuantityProperty |> dispatch) |> Some
-                                else
-                                    None
-                            decrease =
-                                if solved then
-                                    (fun n -> (n, false) |> DecreaseDoseQuantityProperty |> dispatch) |> Some
-                                else
-                                    None
-                            median =
-                                if navigable then
-                                    (fun () -> SetMedianDoseQuantityProperty |> dispatch) |> Some
-                                else
-                                    None
-                            increase =
-                                if solved && canIncr then
-                                    (fun n -> (saturateInc n, false) |> IncreaseDoseQuantityProperty |> dispatch)
-                                    |> Some
-                                else
-                                    None
-                            last =
-                                if navigable then
-                                    (fun (_: int) -> SetMaxDoseQuantityProperty |> dispatch) |> Some
-                                elif solved && canIncr then
-                                    (fun n -> (n, true) |> IncreaseDoseQuantityProperty |> dispatch) |> Some
-                                else
-                                    None
-                            useDebounce = not navigable && solved
-                            revision = revision
-                        |}
-                        |> Some
+                    ViewHelpers.createDoseQtyNav
+                        dispatch
+                        revision
+                        ord
+                        SetMinDoseQuantityProperty
+                        DecreaseDoseQuantityProperty
+                        SetMedianDoseQuantityProperty
+                        IncreaseDoseQuantityProperty
+                        SetMaxDoseQuantityProperty
 
                 select
                     isLoading

--- a/src/Informedica.GenPRES.Client/Views/Nutrition.fs
+++ b/src/Informedica.GenPRES.Client/Views/Nutrition.fs
@@ -631,6 +631,20 @@ module Nutrition =
         let ctx = props.nutritionContext.OrderContext
         let ncId = props.nutritionContext.Id
 
+        // Monotonic counter bumped whenever a new server response replaces the order
+        // context. Passed into stepped selects so they reset their optimistic step value
+        // even when the server clamps back to the SAME value (e.g. stepping past the
+        // maximum), where the displayed value never changes and the value-based reset
+        // alone would leave the stale optimistic value on screen.
+        let revisionRef = React.useRef 0
+        let prevCtxRef = React.useRef ctx
+
+        if not (obj.ReferenceEquals(prevCtxRef.current, ctx)) then
+            prevCtxRef.current <- ctx
+            revisionRef.current <- revisionRef.current + 1
+
+        let revision = revisionRef.current
+
         let label =
             match props.nutritionContext.Category with
             | NutritionCategory.EnteralFeeding ->
@@ -873,6 +887,7 @@ module Nutrition =
 
                             ViewHelpers.createNav
                                 dispatch
+                                revision
                                 navigable
                                 solved
                                 (SetMinComponentQuantityProperty cmpName)
@@ -1004,6 +1019,7 @@ module Nutrition =
                                 else
                                     None
                             useDebounce = not navigable && solved
+                            revision = revision
                         |}
                         |> Some
 
@@ -1112,6 +1128,7 @@ module Nutrition =
                 let nav =
                     ViewHelpers.createNav
                         dispatch
+                        revision
                         navigable
                         solved
                         SetMinDoseRateProperty

--- a/src/Informedica.GenPRES.Client/Views/Order.fs
+++ b/src/Informedica.GenPRES.Client/Views/Order.fs
@@ -936,8 +936,8 @@ module Order =
 
         // Monotonic counter bumped on every new server response (a fresh Resolved
         // orderContext). Passed into stepped selects so they reset their optimistic
-        // step value even when the server clamps back to the SAME value (e.g. stepping
-        // past the maximum) — in that case the displayed value never changes, so the
+        // step value even when the server returns the SAME value as before (e.g. a no-op
+        // step when already at the maximum) — in that case the displayed value never changes, so the
         // value-based reset alone would leave the stale optimistic value on screen.
         let revisionRef = React.useRef 0
         let prevCtxRef = React.useRef props.orderContext
@@ -1607,9 +1607,54 @@ module Order =
 
                                  let solved = ord |> isSolved
                                  let navigable = ord.Orderable.Dose.Quantity |> OrderVariable.isNavigable
-                                 // specific case where increase is maximized by dose count
+                                 // For a multi-component orderable the dose quantity cannot
+                                 // exceed the prepared orderable quantity. Use it as a feasibility
+                                 // ceiling: the optimistic value stays within it, and an overflowing
+                                 // increase is saturated at the max (saturateInc) instead of overshooting,
+                                 // which the solver would reject — reverting the value. Single
+                                 // component: orderable quantity follows the dose, so no ceiling.
+                                 let doseQtyCeiling = ord |> ViewHelpers.orderableDoseQuantityCeiling
+
+                                 let saturateInc n =
+                                     ord.Orderable.Dose.Quantity
+                                     |> ViewHelpers.incrementStepsToCeiling doseQtyCeiling
+                                     |> Option.map (min n)
+                                     |> Option.defaultValue n
+
+                                 // Outer (first/last) counterpart of saturateInc: clamp the dispatched
+                                 // outer steps so the larger outer increment lands on the last grid
+                                 // point at or below the ceiling instead of overshooting and being
+                                 // reverted by the solver.
+                                 let saturateOuter n =
+                                     ord.Orderable.Dose.Quantity
+                                     |> ViewHelpers.outerIncrementStepsToCeiling doseQtyCeiling
+                                     |> Option.map (min n)
+                                     |> Option.defaultValue n
+
+                                 // Whether a full defined-increment step still fits below the
+                                 // feasibility ceiling. The increment grid cannot generally land
+                                 // exactly on the ceiling, so the server value settles just below it
+                                 // while the optimistic display clamps to the ceiling — leaving
+                                 // DoseCount > 1 (so canIncr stays true) and the increase buttons
+                                 // permanently active despite the field showing the max. Gating on
+                                 // remaining ceiling room disables them once no further step fits.
+                                 let canStepUp =
+                                     ord.Orderable.Dose.Quantity
+                                     |> ViewHelpers.incrementStepsToCeiling doseQtyCeiling
+                                     |> Option.map (fun steps -> steps > 0)
+                                     |> Option.defaultValue true
+
+                                 // Outer counterpart of canStepUp, measured against the outer
+                                 // increment so the last button disables exactly when no further
+                                 // outer step fits below the ceiling.
+                                 let canStepUpOuter =
+                                     ord.Orderable.Dose.Quantity
+                                     |> ViewHelpers.outerIncrementStepsToCeiling doseQtyCeiling
+                                     |> Option.map (fun steps -> steps > 0)
+                                     |> Option.defaultValue true
+
                                  {|
-                                     step = ord.Orderable.Dose.Quantity |> ViewHelpers.ovarStep string
+                                     step = ord.Orderable.Dose.Quantity |> ViewHelpers.ovarStepTo doseQtyCeiling string
                                      first =
                                          if navigable then
                                              (fun (_: int) -> SetMinDoseQuantityProperty |> dispatch) |> Some
@@ -1628,15 +1673,17 @@ module Order =
                                          else
                                              None
                                      increase =
-                                         if solved && canIncr then
-                                             (fun n -> (n, false) |> IncreaseDoseQuantityProperty |> dispatch) |> Some
+                                         if solved && canIncr && canStepUp then
+                                             (fun n -> (saturateInc n, false) |> IncreaseDoseQuantityProperty |> dispatch)
+                                             |> Some
                                          else
                                              None
                                      last =
                                          if navigable then
                                              (fun (_: int) -> SetMaxDoseQuantityProperty |> dispatch) |> Some
-                                         elif solved && canIncr then
-                                             (fun n -> (n, true) |> IncreaseDoseQuantityProperty |> dispatch) |> Some
+                                         elif solved && canIncr && canStepUpOuter then
+                                             (fun n -> (saturateOuter n, true) |> IncreaseDoseQuantityProperty |> dispatch)
+                                             |> Some
                                          else
                                              None
                                      useDebounce = not navigable && solved

--- a/src/Informedica.GenPRES.Client/Views/Order.fs
+++ b/src/Informedica.GenPRES.Client/Views/Order.fs
@@ -198,17 +198,14 @@ module Order =
                 | Some ord ->
                     let msg =
                         { ord with
-                            Orderable =
-                                { ord.Orderable with
-                                    Components =
-                                        ord.Orderable.Components
-                                        |> Array.map (fun cmp ->
-                                            match state.SelectedComponent with
-                                            | Some c when cmp.Name = c ->
-                                                { cmp with OrderableQuantity = cmp.OrderableQuantity |> setOvar s }
-                                            | _ -> cmp
-                                        )
-                                }
+                            Order.Orderable.Components =
+                                ord.Orderable.Components
+                                |> Array.map (fun cmp ->
+                                    match state.SelectedComponent with
+                                    | Some c when cmp.Name = c ->
+                                        { cmp with OrderableQuantity = cmp.OrderableQuantity |> setOvar s }
+                                    | _ -> cmp
+                                )
                         }
                         |> UpdateOrderScenario
 
@@ -245,29 +242,25 @@ module Order =
                 | Some ord ->
                     let msg =
                         { ord with
-                            Orderable =
-                                { ord.Orderable with
-                                    Components =
-                                        ord.Orderable.Components
-                                        |> Array.mapi (fun i cmp ->
-                                            if i > 0 then
-                                                cmp
-                                            else
-                                                { cmp with
-                                                    Items =
-                                                        cmp.Items
-                                                        |> Array.map (fun itm ->
-                                                            match state.SelectedItem with
-                                                            | Some subst when subst = itm.Name ->
-                                                                { itm with
-                                                                    Item.Dose.Quantity =
-                                                                        itm.Dose.Quantity |> setOvar s
-                                                                }
-                                                            | _ -> itm
-                                                        )
-                                                }
-                                        )
-                                }
+                            Order.Orderable.Components =
+                                ord.Orderable.Components
+                                |> Array.mapi (fun i cmp ->
+                                    if i > 0 then
+                                        cmp
+                                    else
+                                        { cmp with
+                                            Items =
+                                                cmp.Items
+                                                |> Array.map (fun itm ->
+                                                    match state.SelectedItem with
+                                                    | Some subst when subst = itm.Name ->
+                                                        { itm with
+                                                            Item.Dose.Quantity = itm.Dose.Quantity |> setOvar s
+                                                        }
+                                                    | _ -> itm
+                                                )
+                                        }
+                                )
                         }
                         |> UpdateOrderScenario
 
@@ -279,32 +272,26 @@ module Order =
                 | Some ord ->
                     let msg =
                         { ord with
-                            Orderable =
-                                { ord.Orderable with
-                                    Components =
-                                        ord.Orderable.Components
-                                        |> Array.mapi (fun i cmp ->
-                                            if i > 0 then
-                                                cmp
-                                            else
-                                                { cmp with
-                                                    Items =
-                                                        cmp.Items
-                                                        |> Array.map (fun itm ->
-                                                            match state.SelectedItem with
-                                                            | Some subst when subst = itm.Name ->
-                                                                { itm with
-                                                                    Dose =
-                                                                        { itm.Dose with
-                                                                            QuantityAdjust =
-                                                                                itm.Dose.QuantityAdjust |> setOvar s
-                                                                        }
-                                                                }
-                                                            | _ -> itm
-                                                        )
-                                                }
-                                        )
-                                }
+                            Order.Orderable.Components =
+                                ord.Orderable.Components
+                                |> Array.mapi (fun i cmp ->
+                                    if i > 0 then
+                                        cmp
+                                    else
+                                        { cmp with
+                                            Items =
+                                                cmp.Items
+                                                |> Array.map (fun itm ->
+                                                    match state.SelectedItem with
+                                                    | Some subst when subst = itm.Name ->
+                                                        { itm with
+                                                            Item.Dose.QuantityAdjust =
+                                                                itm.Dose.QuantityAdjust |> setOvar s
+                                                        }
+                                                    | _ -> itm
+                                                )
+                                        }
+                                )
                         }
                         |> UpdateOrderScenario
 
@@ -316,28 +303,23 @@ module Order =
                 | Some ord ->
                     let msg =
                         { ord with
-                            Orderable =
-                                { ord.Orderable with
-                                    Components =
-                                        ord.Orderable.Components
-                                        |> Array.mapi (fun i cmp ->
-                                            if i > 0 then
-                                                cmp
-                                            else
-                                                { cmp with
-                                                    Items =
-                                                        cmp.Items
-                                                        |> Array.map (fun itm ->
-                                                            match state.SelectedItem with
-                                                            | Some subst when subst = itm.Name ->
-                                                                { itm with
-                                                                    Item.Dose.PerTime = itm.Dose.PerTime |> setOvar s
-                                                                }
-                                                            | _ -> itm
-                                                        )
-                                                }
-                                        )
-                                }
+                            Order.Orderable.Components =
+                                ord.Orderable.Components
+                                |> Array.mapi (fun i cmp ->
+                                    if i > 0 then
+                                        cmp
+                                    else
+                                        { cmp with
+                                            Items =
+                                                cmp.Items
+                                                |> Array.map (fun itm ->
+                                                    match state.SelectedItem with
+                                                    | Some subst when subst = itm.Name ->
+                                                        { itm with Item.Dose.PerTime = itm.Dose.PerTime |> setOvar s }
+                                                    | _ -> itm
+                                                )
+                                        }
+                                )
 
                         }
                         |> UpdateOrderScenario
@@ -350,32 +332,26 @@ module Order =
                 | Some ord ->
                     let msg =
                         { ord with
-                            Orderable =
-                                { ord.Orderable with
-                                    Components =
-                                        ord.Orderable.Components
-                                        |> Array.mapi (fun i cmp ->
-                                            if i > 0 then
-                                                cmp
-                                            else
-                                                { cmp with
-                                                    Items =
-                                                        cmp.Items
-                                                        |> Array.map (fun itm ->
-                                                            match state.SelectedItem with
-                                                            | Some subst when subst = itm.Name ->
-                                                                { itm with
-                                                                    Dose =
-                                                                        { itm.Dose with
-                                                                            PerTimeAdjust =
-                                                                                itm.Dose.PerTimeAdjust |> setOvar s
-                                                                        }
-                                                                }
-                                                            | _ -> itm
-                                                        )
-                                                }
-                                        )
-                                }
+                            Order.Orderable.Components =
+                                ord.Orderable.Components
+                                |> Array.mapi (fun i cmp ->
+                                    if i > 0 then
+                                        cmp
+                                    else
+                                        { cmp with
+                                            Items =
+                                                cmp.Items
+                                                |> Array.map (fun itm ->
+                                                    match state.SelectedItem with
+                                                    | Some subst when subst = itm.Name ->
+                                                        { itm with
+                                                            Item.Dose.PerTimeAdjust =
+                                                                itm.Dose.PerTimeAdjust |> setOvar s
+                                                        }
+                                                    | _ -> itm
+                                                )
+                                        }
+                                )
 
                         }
                         |> UpdateOrderScenario
@@ -388,28 +364,23 @@ module Order =
                 | Some ord ->
                     let msg =
                         { ord with
-                            Orderable =
-                                { ord.Orderable with
-                                    Components =
-                                        ord.Orderable.Components
-                                        |> Array.mapi (fun i cmp ->
-                                            if i > 0 then
-                                                cmp
-                                            else
-                                                { cmp with
-                                                    Items =
-                                                        cmp.Items
-                                                        |> Array.map (fun itm ->
-                                                            match state.SelectedItem with
-                                                            | Some subst when subst = itm.Name ->
-                                                                { itm with
-                                                                    Item.Dose.Rate = itm.Dose.Rate |> setOvar s
-                                                                }
-                                                            | _ -> itm
-                                                        )
-                                                }
-                                        )
-                                }
+                            Order.Orderable.Components =
+                                ord.Orderable.Components
+                                |> Array.mapi (fun i cmp ->
+                                    if i > 0 then
+                                        cmp
+                                    else
+                                        { cmp with
+                                            Items =
+                                                cmp.Items
+                                                |> Array.map (fun itm ->
+                                                    match state.SelectedItem with
+                                                    | Some subst when subst = itm.Name ->
+                                                        { itm with Item.Dose.Rate = itm.Dose.Rate |> setOvar s }
+                                                    | _ -> itm
+                                                )
+                                        }
+                                )
 
                         }
                         |> UpdateOrderScenario
@@ -422,32 +393,25 @@ module Order =
                 | Some ord ->
                     let msg =
                         { ord with
-                            Orderable =
-                                { ord.Orderable with
-                                    Components =
-                                        ord.Orderable.Components
-                                        |> Array.mapi (fun i cmp ->
-                                            if i > 0 then
-                                                cmp
-                                            else
-                                                { cmp with
-                                                    Items =
-                                                        cmp.Items
-                                                        |> Array.map (fun itm ->
-                                                            match state.SelectedItem with
-                                                            | Some subst when subst = itm.Name ->
-                                                                { itm with
-                                                                    Dose =
-                                                                        { itm.Dose with
-                                                                            RateAdjust =
-                                                                                itm.Dose.RateAdjust |> setOvar s
-                                                                        }
-                                                                }
-                                                            | _ -> itm
-                                                        )
-                                                }
-                                        )
-                                }
+                            Order.Orderable.Components =
+                                ord.Orderable.Components
+                                |> Array.mapi (fun i cmp ->
+                                    if i > 0 then
+                                        cmp
+                                    else
+                                        { cmp with
+                                            Items =
+                                                cmp.Items
+                                                |> Array.map (fun itm ->
+                                                    match state.SelectedItem with
+                                                    | Some subst when subst = itm.Name ->
+                                                        { itm with
+                                                            Item.Dose.RateAdjust = itm.Dose.RateAdjust |> setOvar s
+                                                        }
+                                                    | _ -> itm
+                                                )
+                                        }
+                                )
 
                         }
                         |> UpdateOrderScenario
@@ -460,37 +424,34 @@ module Order =
                 | Some ord ->
                     let msg =
                         { ord with
-                            Orderable =
-                                { ord.Orderable with
-                                    Components =
-                                        ord.Orderable.Components
-                                        |> Array.mapi (fun i cmp ->
-                                            if i > 0 && cmp.Name <> cname then
-                                                cmp
-                                            else
-                                                { cmp with
-                                                    Items =
-                                                        cmp.Items
-                                                        |> Array.map (fun itm ->
-                                                            match state.SelectedItem with
-                                                            | Some subst when subst = itm.Name ->
-                                                                { itm with
-                                                                    ComponentConcentration =
-                                                                        itm.ComponentConcentration |> setOvar s
-                                                                }
-                                                            | _ ->
-                                                                if itm.Name <> iname then
-                                                                    itm
-                                                                else
-                                                                    { itm with
-                                                                        ComponentConcentration =
-                                                                            itm.ComponentConcentration |> setOvar s
-                                                                    }
+                            Order.Orderable.Components =
+                                ord.Orderable.Components
+                                |> Array.mapi (fun i cmp ->
+                                    if i > 0 && cmp.Name <> cname then
+                                        cmp
+                                    else
+                                        { cmp with
+                                            Items =
+                                                cmp.Items
+                                                |> Array.map (fun itm ->
+                                                    match state.SelectedItem with
+                                                    | Some subst when subst = itm.Name ->
+                                                        { itm with
+                                                            ComponentConcentration =
+                                                                itm.ComponentConcentration |> setOvar s
+                                                        }
+                                                    | _ ->
+                                                        if itm.Name <> iname then
+                                                            itm
+                                                        else
+                                                            { itm with
+                                                                ComponentConcentration =
+                                                                    itm.ComponentConcentration |> setOvar s
+                                                            }
 
-                                                        )
-                                                }
-                                        )
-                                }
+                                                )
+                                        }
+                                )
 
                         }
                         |> UpdateOrderScenario
@@ -503,29 +464,26 @@ module Order =
                 | Some ord ->
                     let msg =
                         { ord with
-                            Orderable =
-                                { ord.Orderable with
-                                    Components =
-                                        ord.Orderable.Components
-                                        |> Array.mapi (fun i cmp ->
-                                            if i > 0 then
-                                                cmp
-                                            else
-                                                { cmp with
-                                                    Items =
-                                                        cmp.Items
-                                                        |> Array.map (fun itm ->
-                                                            match state.SelectedItem with
-                                                            | Some subst when subst = itm.Name ->
-                                                                { itm with
-                                                                    OrderableConcentration =
-                                                                        itm.OrderableConcentration |> setOvar s
-                                                                }
-                                                            | _ -> itm
-                                                        )
-                                                }
-                                        )
-                                }
+                            Order.Orderable.Components =
+                                ord.Orderable.Components
+                                |> Array.mapi (fun i cmp ->
+                                    if i > 0 then
+                                        cmp
+                                    else
+                                        { cmp with
+                                            Items =
+                                                cmp.Items
+                                                |> Array.map (fun itm ->
+                                                    match state.SelectedItem with
+                                                    | Some subst when subst = itm.Name ->
+                                                        { itm with
+                                                            OrderableConcentration =
+                                                                itm.OrderableConcentration |> setOvar s
+                                                        }
+                                                    | _ -> itm
+                                                )
+                                        }
+                                )
 
                         }
                         |> UpdateOrderScenario
@@ -538,29 +496,25 @@ module Order =
                 | Some ord ->
                     let msg =
                         { ord with
-                            Orderable =
-                                { ord.Orderable with
-                                    Components =
-                                        ord.Orderable.Components
-                                        |> Array.mapi (fun i cmp ->
-                                            if i > 0 then
-                                                cmp
-                                            else
-                                                { cmp with
-                                                    Items =
-                                                        cmp.Items
-                                                        |> Array.map (fun itm ->
-                                                            match state.SelectedItem with
-                                                            | Some subst when subst = itm.Name ->
-                                                                { itm with
-                                                                    OrderableQuantity =
-                                                                        itm.OrderableQuantity |> setOvar s
-                                                                }
-                                                            | _ -> itm
-                                                        )
-                                                }
-                                        )
-                                }
+                            Order.Orderable.Components =
+                                ord.Orderable.Components
+                                |> Array.mapi (fun i cmp ->
+                                    if i > 0 then
+                                        cmp
+                                    else
+                                        { cmp with
+                                            Items =
+                                                cmp.Items
+                                                |> Array.map (fun itm ->
+                                                    match state.SelectedItem with
+                                                    | Some subst when subst = itm.Name ->
+                                                        { itm with
+                                                            OrderableQuantity = itm.OrderableQuantity |> setOvar s
+                                                        }
+                                                    | _ -> itm
+                                                )
+                                        }
+                                )
 
                         }
                         |> UpdateOrderScenario
@@ -1216,6 +1170,475 @@ module Order =
                     paddingY = (if isMobile then 1 else 2)
                 |}
 
+            let componentSelect =
+                match displayOrder with
+                | Some ord ->
+                    if ord.Orderable.Components |> Array.length <= 1 then
+                        null
+                    else
+                        ord.Orderable.Components
+                        |> Array.map _.Name
+                        |> Array.map (fun s -> s, s)
+                        |> select
+                            false
+                            "componenten"
+                            state.SelectedComponent
+                            (ChangeComponent >> dispatch)
+                            None
+                            false
+                            None
+                            None
+                | _ -> null
+
+            let itemSelect =
+                match displayOrder with
+                | Some ord ->
+                    if ord.Orderable.Components |> Array.isEmpty || itms |> Array.length <= 1 then
+                        null
+                    else
+                        itms
+                        |> Array.map _.Name
+                        |> Array.map (fun s -> s, s)
+                        |> select false "stoffen" state.SelectedItem (ChangeItem >> dispatch) None false None None
+                | _ -> null
+
+            let substDoseQtySelect =
+                match substIndx, displayOrder with
+                | Some i, Some ord when ord.Schedule.IsContinuous |> not && itms |> Array.length > 0 ->
+                    let label, vals =
+                        itms[i].Dose.Quantity.Variable.Vals
+                        |> Option.map (fun v ->
+                            (Terms.``Order Dose`` |> getTerm "keer dosis" |> (fun s -> $"{s} ({v.Unit})")),
+                            v.Value
+                            |> Array.map (fun (s, d) -> s, $"{d |> fixPrecision 3} {v.Unit}")
+                            |> Array.distinctBy snd
+                        )
+                        |> Option.defaultValue ("", [||])
+
+                    let warning = itms[i].Dose.Quantity.Level |> getWarning
+
+                    vals
+                    |> select
+                        (isFieldLoading "substDoseQty")
+                        label
+                        None
+                        (ChangeSubstanceDoseQuantity >> dispatch)
+                        None
+                        false
+                        warning
+                        None
+                | _ -> null
+
+            let substDoseQtyAdjSelect =
+                match substIndx, displayOrder with
+                | Some i, Some ord when
+                    (ord.Schedule.IsOnce || ord.Schedule.IsOnceTimed)
+                    && itms |> Array.length > 0
+                    && useAdjust
+                    ->
+                    let label, vals =
+                        itms[i].Dose.QuantityAdjust.Variable.Vals
+                        |> Option.map (fun v ->
+                            (Terms.``Order Adjusted dose``
+                             |> getTerm "keer dosis"
+                             |> fun s -> $"{s} ({v.Unit})"),
+                            v.Value
+                            |> Array.map (fun (s, d) -> s, $"{d |> fixPrecision 3} {v.Unit}")
+                            |> Array.distinctBy snd
+                        )
+                        |> Option.defaultValue ("", [||])
+
+                    let warning = itms[i].Dose.QuantityAdjust.Level |> getWarning
+
+                    vals
+                    |> select
+                        (isFieldLoading "substDoseQtyAdj")
+                        label
+                        None
+                        (ChangeSubstanceDoseQuantityAdjust >> dispatch)
+                        None
+                        true
+                        warning
+                        None
+                | _ -> null
+
+            let substPerTimeSelect =
+                match substIndx, displayOrder with
+                | Some i, Some ord when ord.Schedule.IsContinuous |> not && itms |> Array.length > 0 ->
+                    let dispatch =
+                        if useAdjust then
+                            ChangeSubstancePerTimeAdjust >> dispatch
+                        else
+                            ChangeSubstancePerTime >> dispatch
+
+                    let label, vals =
+                        if useAdjust then
+                            itms[i].Dose.PerTimeAdjust.Variable.Vals
+                        else
+                            itms[i].Dose.PerTime.Variable.Vals
+                        |> Option.map (fun v ->
+                            (Terms.``Order Adjusted dose``
+                             |> getTerm "dosering"
+                             |> fun s -> $"{s} ({v.Unit})"),
+                            v.Value
+                            |> Array.map (fun (s, d) -> s, $"{d |> fixPrecision 3} {v.Unit}")
+                            |> Array.distinctBy snd
+                        )
+                        |> Option.defaultValue ("", [||])
+
+                    let warning =
+                        if useAdjust then
+                            itms[i].Dose.PerTimeAdjust.Level |> getWarning
+                        else
+                            itms[i].Dose.PerTime.Level |> getWarning
+
+                    vals
+                    |> select (isFieldLoading "substPerTime") label None dispatch None true warning None
+                | _ -> null
+
+            let substRateSelect =
+                let navigate = None
+
+                match substIndx, displayOrder with
+                | Some i, Some ord when ord.Schedule.IsContinuous && itms |> Array.length > 0 ->
+                    let dispatch =
+                        if useAdjust then
+                            ChangeSubstanceRateAdjust >> dispatch
+                        else
+                            ChangeSubstanceRate >> dispatch
+
+                    let warning =
+                        if useAdjust then
+                            itms[i].Dose.RateAdjust.Level |> getWarning
+                        else
+                            itms[i].Dose.Rate.Level |> getWarning
+
+                    let ovar =
+                        if useAdjust then
+                            itms[i].Dose.RateAdjust
+                        else
+                            itms[i].Dose.Rate
+
+                    ovar
+                    |> ViewHelpers.ovarVals (fixPrecision 3)
+                    |> Array.distinctBy snd
+                    |> select
+                        (isFieldLoading "substRate")
+                        (Terms.``Order Adjusted dose`` |> getTerm "dosering")
+                        None
+                        dispatch
+                        navigate
+                        true
+                        warning
+                        None
+                | _ -> null
+
+            let compOrdQtySelect =
+                match displayOrder with
+                | Some ord when ord.Orderable.Components |> Array.length > 1 ->
+                    let cmp =
+                        ord.Orderable.Components
+                        |> Array.tryFind (fun c ->
+                            state.SelectedComponent.IsNone || c.Name = state.SelectedComponent.Value
+                        )
+
+                    let vals =
+                        cmp
+                        |> Option.map (_.OrderableQuantity >> ViewHelpers.ovarValsWithRange string 3)
+                        |> Option.defaultValue [||]
+
+                    let navigate =
+                        let c = vals |> Array.length
+
+                        let show =
+                            match cmp with
+                            | None -> false
+                            | Some cmp ->
+                                cmp.OrderableQuantity.Variable.Min.IsSome
+                                && cmp.OrderableQuantity.Variable.Incr.IsSome
+                                && cmp.OrderableQuantity.Variable.Max.IsSome
+                                || c >= 1
+
+                        if not show then
+                            None
+                        else
+                            let solved = ord |> isSolved
+
+                            let navigable =
+                                cmp
+                                |> Option.map (_.OrderableQuantity >> OrderVariable.isNavigable)
+                                |> Option.defaultValue false
+
+                            createNav
+                                navigable
+                                solved
+                                SetMinComponentQuantityProperty
+                                DecreaseComponentQuantityProperty
+                                SetMedianComponentQuantityProperty
+                                IncreaseComponentQuantityProperty
+                                SetMaxComponentQuantityProperty
+                                (cmp |> Option.bind (_.OrderableQuantity >> ViewHelpers.ovarStep string))
+
+                    let warning = cmp |> Option.bind (_.OrderableQuantity.Level >> getWarning)
+
+                    vals
+                    |> select
+                        (isFieldLoading "compOrdQty")
+                        "bereiding hoeveelheid"
+                        None
+                        (ChangeComponentOrderableQuantity >> dispatch)
+                        navigate
+                        false
+                        warning
+                        None
+                | _ -> null
+
+            let substCompConcSelect =
+                match substIndx, displayOrder with
+                | Some i, Some ord ->
+                    match itms |> Array.tryItem i with
+                    | Some itm ->
+                        let cname, iname =
+                            ord.Orderable.Components
+                            |> Array.tryHead
+                            |> Option.map _.Name
+                            |> Option.defaultValue "",
+                            itm.Name
+
+                        let change = fun s -> (cname, iname, s) |> ChangeSubstanceComponentConcentration
+
+                        if
+                            itm.ComponentConcentration.DefinedConstraints.Vals
+                            |> Option.map (fun vu -> vu.Value |> Array.length > 1)
+                            |> Option.defaultValue false
+                        then
+                            itm.ComponentConcentration
+                            |> ViewHelpers.ovarVals (fixPrecision 3)
+                            |> select
+                                (isFieldLoading "substCompConc")
+                                "product sterkte"
+                                None
+                                (change >> dispatch)
+                                None
+                                false
+                                None
+                                None
+                        else
+                            null
+                    | None ->
+                        match
+                            ord.Orderable.Components
+                            |> Array.tryFind (fun c ->
+                                state.SelectedComponent.IsNone || c.Name = state.SelectedComponent.Value
+                            )
+                        with
+                        | Some cmp ->
+                            match cmp.Items |> Array.tryFind (fun i -> i.Name = cmp.Name) with
+                            | Some itm ->
+                                let change =
+                                    fun s -> (cmp.Name, itm.Name, s) |> ChangeSubstanceComponentConcentration
+
+                                if
+                                    itm.ComponentConcentration.DefinedConstraints.Vals
+                                    |> Option.map (fun vu -> vu.Value |> Array.length > 1)
+                                    |> Option.defaultValue false
+                                then
+                                    itm.ComponentConcentration
+                                    |> ViewHelpers.ovarVals string
+                                    |> select
+                                        (isFieldLoading "substCompConc")
+                                        "product sterkte"
+                                        None
+                                        (change >> dispatch)
+                                        None
+                                        false
+                                        None
+                                        None
+                                else
+                                    null
+
+                            | None -> null
+                        | None -> null
+                | _ -> null
+
+            let substOrdQtySelect =
+                match substIndx, displayOrder with
+                | Some i, Some ord when
+                    ord.Schedule.IsContinuous
+                    && itms |> Array.length > 0
+                    && ord.Orderable.Components |> Array.length > 1
+                    ->
+                    let warning = itms[i].OrderableQuantity.Level |> getWarning
+
+                    itms[i].OrderableQuantity
+                    |> ViewHelpers.ovarVals (fixPrecision 3)
+                    |> select
+                        (isFieldLoading "substOrdQty")
+                        $"{itms[i].Name} hoeveelheid"
+                        None
+                        (ChangeSubstanceOrderableQuantity >> dispatch)
+                        None
+                        false
+                        warning
+                        None
+                | _ -> null
+
+            let substOrdConcSelect =
+                match substIndx, displayOrder with
+                | Some i, Some ord when
+                    ord.Schedule.IsContinuous |> not
+                    && itms |> Array.length > 0
+                    && ord.Orderable.Components |> Array.length > 1
+                    ->
+                    let warning = itms[i].OrderableConcentration.Level |> getWarning
+
+                    itms[i].OrderableConcentration
+                    |> ViewHelpers.ovarVals (fixPrecision 3)
+                    |> select
+                        (isFieldLoading "substOrdConc")
+                        $"{itms[i].Name} concentratie"
+                        None
+                        (ChangeSubstanceOrderableConcentration >> dispatch)
+                        None
+                        false
+                        warning
+                        None
+                | _ -> null
+
+            let ordQtySelect =
+                match displayOrder with
+                | Some ord when ord.Orderable.Components |> Array.length > 1 ->
+                    let warning = ord.Orderable.OrderableQuantity.Level |> getWarning
+
+                    ord.Orderable.OrderableQuantity
+                    |> ViewHelpers.ovarVals string
+                    |> select
+                        (isFieldLoading "ordQty")
+                        "totale hoeveelheid"
+                        None
+                        (ChangeOrderableQuantity >> dispatch)
+                        None
+                        false
+                        warning
+                        None
+                | _ -> null
+
+            let frequencySelect =
+                match displayOrder with
+                | Some ord when ord.Schedule.IsDiscontinuous || ord.Schedule.IsTimed ->
+                    let xs = ord.Schedule.Frequency |> ViewHelpers.ovarVals string
+
+                    let navigate =
+                        if xs |> Array.length <> 1 then
+                            None
+                        else
+                            let solved = ord |> isSolved
+                            let navigable = false
+
+                            createNav
+                                navigable
+                                solved
+                                SetMinFrequencyProperty
+                                (fun _ -> DecreaseFrequencyProperty)
+                                SetMedianFrequencyProperty
+                                (fun _ -> IncreaseFrequencyProperty)
+                                SetMaxFrequencyProperty
+                                None
+
+                    let warning = ord.Schedule.Frequency.Level |> getWarning
+
+                    select
+                        (isFieldLoading "frequency")
+                        (Terms.``Order Frequency`` |> getTerm "frequentie")
+                        None
+                        (ChangeFrequency >> dispatch)
+                        navigate
+                        false
+                        warning
+                        None
+                        xs
+                | _ -> null
+
+            let ordDoseQtySelect =
+                match displayOrder with
+                | Some ord when ord.Schedule.IsContinuous |> not ->
+                    let navigate =
+                        ViewHelpers.createDoseQtyNav
+                            dispatch
+                            revision
+                            ord
+                            SetMinDoseQuantityProperty
+                            DecreaseDoseQuantityProperty
+                            SetMedianDoseQuantityProperty
+                            IncreaseDoseQuantityProperty
+                            SetMaxDoseQuantityProperty
+
+                    let warning = ord.Orderable.Dose.Quantity.Level |> getWarning
+
+                    ord.Orderable.Dose.Quantity
+                    |> ViewHelpers.ovarValsWithRange string 3
+                    |> select
+                        (isFieldLoading "ordDoseQty")
+                        "toedien hoeveelheid"
+                        None
+                        (ChangeOrderableDoseQuantity >> dispatch)
+                        navigate
+                        false
+                        warning
+                        None
+                | _ -> null
+
+            let ordDoseRateSelect =
+                match displayOrder with
+                | Some ord when ord.Schedule.IsContinuous || ord.Schedule.IsTimed || ord.Schedule.IsOnceTimed ->
+                    let solved = ord |> isSolved
+                    let navigable = ord.Orderable.Dose.Rate |> OrderVariable.isNavigable
+
+                    let navigate =
+                        createNav
+                            navigable
+                            solved
+                            SetMinDoseRateProperty
+                            DecreaseDoseRateProperty
+                            SetMedianDoseRateProperty
+                            IncreaseDoseRateProperty
+                            SetMaxDoseRateProperty
+                            (ord.Orderable.Dose.Rate |> ViewHelpers.ovarStep string)
+
+                    let warning = ord.Orderable.Dose.Rate.Level |> getWarning
+
+                    ord.Orderable.Dose.Rate
+                    |> ViewHelpers.ovarValsWithRange string 3
+                    |> select
+                        (isFieldLoading "ordDoseRate")
+                        (Terms.``Order Drip rate`` |> getTerm "inloop snelheid")
+                        None
+                        (ChangeOrderableDoseRate >> dispatch)
+                        navigate
+                        false
+                        warning
+                        None
+                | _ -> null
+
+            let timeSelect =
+                match displayOrder with
+                | Some ord ->
+                    let warning = ord.Schedule.Time.Level |> getWarning
+
+                    ord.Schedule.Time
+                    |> ViewHelpers.ovarVals (fixPrecision 2)
+                    |> Array.distinctBy snd
+                    |> select
+                        (isFieldLoading "time")
+                        (Terms.``Order Administration time`` |> getTerm "inloop tijd")
+                        None
+                        (ChangeTime >> dispatch)
+                        None
+                        true
+                        warning
+                        None
+                | _ -> null
+
             JSX.jsx
                 $"""
             import CardHeader from '@mui/material/CardHeader';
@@ -1232,526 +1655,24 @@ module Order =
             ></CardHeader>
             <CardContent sx={contentSx}>
                 <Stack direction={"column"} spacing={if isMobile then 1.5 else 3} >
-                    {match displayOrder with
-                     | Some ord ->
-                         if ord.Orderable.Components |> Array.length <= 1 then
-                             null
-                         else
-                             ord.Orderable.Components
-                             |> Array.map _.Name
-                             |> Array.map (fun s -> s, s)
-                             |> select false "componenten" state.SelectedComponent (ChangeComponent >> dispatch) None false None None
-                     | _ -> null}
-                    {match displayOrder with
-                     | Some ord ->
-                         if ord.Orderable.Components |> Array.isEmpty || itms |> Array.length <= 1 then
-                             null
-                         else
-                             itms
-                             |> Array.map _.Name
-                             |> Array.map (fun s -> s, s)
-                             |> select false "stoffen" state.SelectedItem (ChangeItem >> dispatch) None false None None
-                     | _ -> null}
+                    {componentSelect}
+                    {itemSelect}
                     {dosingDivider}
-                    {match substIndx, displayOrder with
-                     | Some i, Some ord when ord.Schedule.IsContinuous |> not && itms |> Array.length > 0 ->
-                         let label, vals =
-                             itms[i].Dose.Quantity.Variable.Vals
-                             |> Option.map (fun v ->
-                                 (Terms.``Order Dose`` |> getTerm "keer dosis" |> (fun s -> $"{s} ({v.Unit})")),
-                                 v.Value
-                                 |> Array.map (fun (s, d) -> s, $"{d |> fixPrecision 3} {v.Unit}")
-                                 |> Array.distinctBy snd
-                             )
-                             |> Option.defaultValue ("", [||])
-
-                         let warning = itms[i].Dose.Quantity.Level |> getWarning
-
-                         vals
-                         |> select
-                             (isFieldLoading "substDoseQty")
-                             label
-                             None
-                             (ChangeSubstanceDoseQuantity >> dispatch)
-                             None
-                             false
-                             warning
-                             None
-                     | _ -> null}
-                    {match substIndx, displayOrder with
-                     | Some i, Some ord when
-                         (ord.Schedule.IsOnce || ord.Schedule.IsOnceTimed)
-                         && itms |> Array.length > 0
-                         && useAdjust
-                         ->
-                         let label, vals =
-                             itms[i].Dose.QuantityAdjust.Variable.Vals
-                             |> Option.map (fun v ->
-                                 (Terms.``Order Adjusted dose``
-                                  |> getTerm "keer dosis"
-                                  |> fun s -> $"{s} ({v.Unit})"),
-                                 v.Value
-                                 |> Array.map (fun (s, d) -> s, $"{d |> fixPrecision 3} {v.Unit}")
-                                 |> Array.distinctBy snd
-                             )
-                             |> Option.defaultValue ("", [||])
-
-                         let warning = itms[i].Dose.QuantityAdjust.Level |> getWarning
-
-                         vals
-                         |> select
-                             (isFieldLoading "substDoseQtyAdj")
-                             label
-                             None
-                             (ChangeSubstanceDoseQuantityAdjust >> dispatch)
-                             None
-                             true
-                             warning
-                             None
-                     | _ -> null}
-                    {match substIndx, displayOrder with
-                     | Some i, Some ord when ord.Schedule.IsContinuous |> not && itms |> Array.length > 0 ->
-                         let dispatch =
-                             if useAdjust then
-                                 ChangeSubstancePerTimeAdjust >> dispatch
-                             else
-                                 ChangeSubstancePerTime >> dispatch
-
-                         let label, vals =
-                             if useAdjust then
-                                 itms[i].Dose.PerTimeAdjust.Variable.Vals
-                             else
-                                 itms[i].Dose.PerTime.Variable.Vals
-                             |> Option.map (fun v ->
-                                 (Terms.``Order Adjusted dose``
-                                  |> getTerm "dosering"
-                                  |> fun s -> $"{s} ({v.Unit})"),
-                                 v.Value
-                                 |> Array.map (fun (s, d) -> s, $"{d |> fixPrecision 3} {v.Unit}")
-                                 |> Array.distinctBy snd
-                             )
-                             |> Option.defaultValue ("", [||])
-
-                         let warning =
-                             if useAdjust then
-                                 itms[i].Dose.PerTimeAdjust.Level |> getWarning
-                             else
-                                 itms[i].Dose.PerTime.Level |> getWarning
-
-                         vals
-                         |> select (isFieldLoading "substPerTime") label None dispatch None true warning None
-                     | _ -> null}
-                    {let navigate = None
-
-                     match substIndx, displayOrder with
-                     | Some i, Some ord when ord.Schedule.IsContinuous && itms |> Array.length > 0 ->
-                         let dispatch =
-                             if useAdjust then
-                                 ChangeSubstanceRateAdjust >> dispatch
-                             else
-                                 ChangeSubstanceRate >> dispatch
-
-                         let warning =
-                             if useAdjust then
-                                 itms[i].Dose.RateAdjust.Level |> getWarning
-                             else
-                                 itms[i].Dose.Rate.Level |> getWarning
-
-                         let ovar =
-                             if useAdjust then
-                                 itms[i].Dose.RateAdjust
-                             else
-                                 itms[i].Dose.Rate
-
-                         ovar
-                         |> ViewHelpers.ovarVals (fixPrecision 3)
-                         |> Array.distinctBy snd
-                         |> select
-                             (isFieldLoading "substRate")
-                             (Terms.``Order Adjusted dose`` |> getTerm "dosering")
-                             None
-                             dispatch
-                             navigate
-                             true
-                             warning
-                             None
-                     | _ -> null}
+                    {substDoseQtySelect}
+                    {substDoseQtyAdjSelect}
+                    {substPerTimeSelect}
+                    {substRateSelect}
                     {preparationDivider}
-                    {match displayOrder with
-                     | Some ord when ord.Orderable.Components |> Array.length > 1 ->
-                         let cmp =
-                             ord.Orderable.Components
-                             |> Array.tryFind (fun c -> state.SelectedComponent.IsNone || c.Name = state.SelectedComponent.Value)
-
-                         let vals =
-                             cmp
-                             |> Option.map (_.OrderableQuantity >> ViewHelpers.ovarValsWithRange string 3)
-                             |> Option.defaultValue [||]
-
-                         let navigate =
-                             let c = vals |> Array.length
-
-                             let show =
-                                 match cmp with
-                                 | None -> false
-                                 | Some cmp ->
-                                     cmp.OrderableQuantity.Variable.Min.IsSome
-                                     && cmp.OrderableQuantity.Variable.Incr.IsSome
-                                     && cmp.OrderableQuantity.Variable.Max.IsSome
-                                     || c >= 1
-
-                             if not show then
-                                 None
-                             else
-                                 let solved = ord |> isSolved
-
-                                 let navigable =
-                                     cmp
-                                     |> Option.map (_.OrderableQuantity >> OrderVariable.isNavigable)
-                                     |> Option.defaultValue false
-
-                                 createNav
-                                     navigable
-                                     solved
-                                     SetMinComponentQuantityProperty
-                                     DecreaseComponentQuantityProperty
-                                     SetMedianComponentQuantityProperty
-                                     IncreaseComponentQuantityProperty
-                                     SetMaxComponentQuantityProperty
-                                     (cmp |> Option.bind (_.OrderableQuantity >> ViewHelpers.ovarStep string))
-
-                         let warning = cmp |> Option.bind (_.OrderableQuantity.Level >> getWarning)
-
-                         vals
-                         |> select
-                             (isFieldLoading "compOrdQty")
-                             "bereiding hoeveelheid"
-                             None
-                             (ChangeComponentOrderableQuantity >> dispatch)
-                             navigate
-                             false
-                             warning
-                             None
-                     | _ -> null}
-                    {match substIndx, displayOrder with
-                     | Some i, Some ord ->
-                         match itms |> Array.tryItem i with
-                         | Some itm ->
-                             let cname, iname =
-                                 ord.Orderable.Components
-                                 |> Array.tryHead
-                                 |> Option.map _.Name
-                                 |> Option.defaultValue "",
-                                 itm.Name
-
-                             let change = fun s -> (cname, iname, s) |> ChangeSubstanceComponentConcentration
-
-                             if
-                                 itm.ComponentConcentration.DefinedConstraints.Vals
-                                 |> Option.map (fun vu -> vu.Value |> Array.length > 1)
-                                 |> Option.defaultValue false
-                             then
-                                 itm.ComponentConcentration
-                                 |> ViewHelpers.ovarVals (fixPrecision 3)
-                                 |> select (isFieldLoading "substCompConc") "product sterkte" None (change >> dispatch) None false None None
-                             else
-                                 null
-                         | None ->
-                             match
-                                 ord.Orderable.Components
-                                 |> Array.tryFind (fun c -> state.SelectedComponent.IsNone || c.Name = state.SelectedComponent.Value)
-                             with
-                             | Some cmp ->
-                                 match cmp.Items |> Array.tryFind (fun i -> i.Name = cmp.Name) with
-                                 | Some itm ->
-                                     let change =
-                                         fun s -> (cmp.Name, itm.Name, s) |> ChangeSubstanceComponentConcentration
-
-                                     if
-                                         itm.ComponentConcentration.DefinedConstraints.Vals
-                                         |> Option.map (fun vu -> vu.Value |> Array.length > 1)
-                                         |> Option.defaultValue false
-                                     then
-                                         itm.ComponentConcentration
-                                         |> ViewHelpers.ovarVals string
-                                         |> select
-                                             (isFieldLoading "substCompConc")
-                                             "product sterkte"
-                                             None
-                                             (change >> dispatch)
-                                             None
-                                             false
-                                             None
-                                             None
-                                     else
-                                         null
-
-                                 | None -> null
-                             | None -> null
-
-                     | _ -> null
-
-                }
-                    {match substIndx, displayOrder with
-                     | Some i, Some ord when
-                         ord.Schedule.IsContinuous
-                         && itms |> Array.length > 0
-                         && ord.Orderable.Components |> Array.length > 1
-                         ->
-                         let warning = itms[i].OrderableQuantity.Level |> getWarning
-
-                         itms[i].OrderableQuantity
-                         |> ViewHelpers.ovarVals (fixPrecision 3)
-                         |> select
-                             (isFieldLoading "substOrdQty")
-                             $"{itms[i].Name} hoeveelheid"
-                             None
-                             (ChangeSubstanceOrderableQuantity >> dispatch)
-                             None
-                             false
-                             warning
-                             None
-                     | _ -> null}
-                    {match substIndx, displayOrder with
-                     | Some i, Some ord when
-                         ord.Schedule.IsContinuous |> not
-                         && itms |> Array.length > 0
-                         && ord.Orderable.Components |> Array.length > 1
-                         ->
-                         let warning = itms[i].OrderableConcentration.Level |> getWarning
-
-                         itms[i].OrderableConcentration
-                         |> ViewHelpers.ovarVals (fixPrecision 3)
-                         |> select
-                             (isFieldLoading "substOrdConc")
-                             $"{itms[i].Name} concentratie"
-                             None
-                             (ChangeSubstanceOrderableConcentration >> dispatch)
-                             None
-                             false
-                             warning
-                             None
-                     | _ -> null}
-                    {match displayOrder with
-                     | Some ord when ord.Orderable.Components |> Array.length > 1 ->
-                         let warning = ord.Orderable.OrderableQuantity.Level |> getWarning
-
-                         ord.Orderable.OrderableQuantity
-                         |> ViewHelpers.ovarVals string
-                         |> select
-                             (isFieldLoading "ordQty")
-                             "totale hoeveelheid"
-                             None
-                             (ChangeOrderableQuantity >> dispatch)
-                             None
-                             false
-                             warning
-                             None
-                     | _ -> null}
+                    {compOrdQtySelect}
+                    {substCompConcSelect}
+                    {substOrdQtySelect}
+                    {substOrdConcSelect}
+                    {ordQtySelect}
                     {administrationDivider}
-                    {match displayOrder with
-                     | Some ord when ord.Schedule.IsDiscontinuous || ord.Schedule.IsTimed ->
-                         let xs = ord.Schedule.Frequency |> ViewHelpers.ovarVals string
-
-                         let navigate =
-                             if xs |> Array.length <> 1 then
-                                 None
-                             else
-                                 let solved = ord |> isSolved
-                                 let navigable = false
-
-                                 createNav
-                                     navigable
-                                     solved
-                                     SetMinFrequencyProperty
-                                     (fun _ -> DecreaseFrequencyProperty)
-                                     SetMedianFrequencyProperty
-                                     (fun _ -> IncreaseFrequencyProperty)
-                                     SetMaxFrequencyProperty
-                                     None
-
-                         let warning = ord.Schedule.Frequency.Level |> getWarning
-
-                         select
-                             (isFieldLoading "frequency")
-                             (Terms.``Order Frequency`` |> getTerm "frequentie")
-                             None
-                             (ChangeFrequency >> dispatch)
-                             navigate
-                             false
-                             warning
-                             None
-                             xs
-                     | _ -> null}
-                    {match displayOrder with
-                     | Some ord when ord.Schedule.IsContinuous |> not ->
-                         // only show nav if all components have
-                         // a distinct orderable quantity
-                         let showNav =
-                             ord.Orderable.Components
-                             |> Array.forall (fun cmp ->
-                                 cmp.OrderableQuantity.Variable.Vals
-                                 |> Option.map (fun vu -> vu.Value |> Array.length = 1)
-                                 |> Option.defaultValue false
-                             )
-
-                         let navigate =
-                             if not showNav then
-                                 None
-                             else
-                                 let canIncr =
-                                     ord.Orderable.Components |> Array.length = 1
-                                     || ord.Orderable.DoseCount.Variable.Vals
-                                        |> Option.map (fun vu -> vu.Value |> Array.map snd |> Array.forall (fun v -> v > 1m))
-                                        |> Option.defaultValue false
-
-                                 let solved = ord |> isSolved
-                                 let navigable = ord.Orderable.Dose.Quantity |> OrderVariable.isNavigable
-                                 // For a multi-component orderable the dose quantity cannot
-                                 // exceed the prepared orderable quantity. Use it as a feasibility
-                                 // ceiling: the optimistic value stays within it, and an overflowing
-                                 // increase is saturated at the max (saturateInc) instead of overshooting,
-                                 // which the solver would reject — reverting the value. Single
-                                 // component: orderable quantity follows the dose, so no ceiling.
-                                 let doseQtyCeiling = ord |> ViewHelpers.orderableDoseQuantityCeiling
-
-                                 let saturateInc n =
-                                     ord.Orderable.Dose.Quantity
-                                     |> ViewHelpers.incrementStepsToCeiling doseQtyCeiling
-                                     |> Option.map (min n)
-                                     |> Option.defaultValue n
-
-                                 // Outer (first/last) counterpart of saturateInc: clamp the dispatched
-                                 // outer steps so the larger outer increment lands on the last grid
-                                 // point at or below the ceiling instead of overshooting and being
-                                 // reverted by the solver.
-                                 let saturateOuter n =
-                                     ord.Orderable.Dose.Quantity
-                                     |> ViewHelpers.outerIncrementStepsToCeiling doseQtyCeiling
-                                     |> Option.map (min n)
-                                     |> Option.defaultValue n
-
-                                 // Whether a full defined-increment step still fits below the
-                                 // feasibility ceiling. The increment grid cannot generally land
-                                 // exactly on the ceiling, so the server value settles just below it
-                                 // while the optimistic display clamps to the ceiling — leaving
-                                 // DoseCount > 1 (so canIncr stays true) and the increase buttons
-                                 // permanently active despite the field showing the max. Gating on
-                                 // remaining ceiling room disables them once no further step fits.
-                                 let canStepUp =
-                                     ord.Orderable.Dose.Quantity
-                                     |> ViewHelpers.incrementStepsToCeiling doseQtyCeiling
-                                     |> Option.map (fun steps -> steps > 0)
-                                     |> Option.defaultValue true
-
-                                 // Outer counterpart of canStepUp, measured against the outer
-                                 // increment so the last button disables exactly when no further
-                                 // outer step fits below the ceiling.
-                                 let canStepUpOuter =
-                                     ord.Orderable.Dose.Quantity
-                                     |> ViewHelpers.outerIncrementStepsToCeiling doseQtyCeiling
-                                     |> Option.map (fun steps -> steps > 0)
-                                     |> Option.defaultValue true
-
-                                 {|
-                                     step = ord.Orderable.Dose.Quantity |> ViewHelpers.ovarStepTo doseQtyCeiling string
-                                     first =
-                                         if navigable then
-                                             (fun (_: int) -> SetMinDoseQuantityProperty |> dispatch) |> Some
-                                         elif solved then
-                                             (fun n -> (n, true) |> DecreaseDoseQuantityProperty |> dispatch) |> Some
-                                         else
-                                             None
-                                     decrease =
-                                         if solved then
-                                             (fun n -> (n, false) |> DecreaseDoseQuantityProperty |> dispatch) |> Some
-                                         else
-                                             None
-                                     median =
-                                         if navigable then
-                                             (fun () -> SetMedianDoseQuantityProperty |> dispatch) |> Some
-                                         else
-                                             None
-                                     increase =
-                                         if solved && canIncr && canStepUp then
-                                             (fun n -> (saturateInc n, false) |> IncreaseDoseQuantityProperty |> dispatch)
-                                             |> Some
-                                         else
-                                             None
-                                     last =
-                                         if navigable then
-                                             (fun (_: int) -> SetMaxDoseQuantityProperty |> dispatch) |> Some
-                                         elif solved && canIncr && canStepUpOuter then
-                                             (fun n -> (saturateOuter n, true) |> IncreaseDoseQuantityProperty |> dispatch)
-                                             |> Some
-                                         else
-                                             None
-                                     useDebounce = not navigable && solved
-                                     revision = revision
-                                 |}
-                                 |> Some
-
-                         let warning = ord.Orderable.Dose.Quantity.Level |> getWarning
-
-                         ord.Orderable.Dose.Quantity
-                         |> ViewHelpers.ovarValsWithRange string 3
-                         |> select
-                             (isFieldLoading "ordDoseQty")
-                             "toedien hoeveelheid"
-                             None
-                             (ChangeOrderableDoseQuantity >> dispatch)
-                             navigate
-                             false
-                             warning
-                             None
-                     | _ -> null}
-                    {match displayOrder with
-                     | Some ord when ord.Schedule.IsContinuous || ord.Schedule.IsTimed || ord.Schedule.IsOnceTimed ->
-                         let solved = ord |> isSolved
-                         let navigable = ord.Orderable.Dose.Rate |> OrderVariable.isNavigable
-
-                         let navigate =
-                             createNav
-                                 navigable
-                                 solved
-                                 SetMinDoseRateProperty
-                                 DecreaseDoseRateProperty
-                                 SetMedianDoseRateProperty
-                                 IncreaseDoseRateProperty
-                                 SetMaxDoseRateProperty
-                                 (ord.Orderable.Dose.Rate |> ViewHelpers.ovarStep string)
-
-                         let warning = ord.Orderable.Dose.Rate.Level |> getWarning
-
-                         ord.Orderable.Dose.Rate
-                         |> ViewHelpers.ovarValsWithRange string 3
-                         |> select
-                             (isFieldLoading "ordDoseRate")
-                             (Terms.``Order Drip rate`` |> getTerm "inloop snelheid")
-                             None
-                             (ChangeOrderableDoseRate >> dispatch)
-                             navigate
-                             false
-                             warning
-                             None
-                     | _ -> null}
-                    {match displayOrder with
-                     | Some ord ->
-                         let warning = ord.Schedule.Time.Level |> getWarning
-
-                         ord.Schedule.Time
-                         |> ViewHelpers.ovarVals (fixPrecision 2)
-                         |> Array.distinctBy snd
-                         |> select
-                             (isFieldLoading "time")
-                             (Terms.``Order Administration time`` |> getTerm "inloop tijd")
-                             None
-                             (ChangeTime >> dispatch)
-                             None
-                             true
-                             warning
-                             None
-                     | _ -> null}
+                    {frequencySelect}
+                    {ordDoseQtySelect}
+                    {ordDoseRateSelect}
+                    {timeSelect}
                 </Stack>
                 {loadingIndicator}
             </CardContent>

--- a/src/Informedica.GenPRES.Client/Views/Order.fs
+++ b/src/Informedica.GenPRES.Client/Views/Order.fs
@@ -934,6 +934,23 @@ module Order =
         let isFieldLoading field =
             isOrderLoading && loadingField = Some field
 
+        // Monotonic counter bumped on every new server response (a fresh Resolved
+        // orderContext). Passed into stepped selects so they reset their optimistic
+        // step value even when the server clamps back to the SAME value (e.g. stepping
+        // past the maximum) — in that case the displayed value never changes, so the
+        // value-based reset alone would leave the stale optimistic value on screen.
+        let revisionRef = React.useRef 0
+        let prevCtxRef = React.useRef props.orderContext
+
+        if not (obj.ReferenceEquals(prevCtxRef.current, props.orderContext)) then
+            prevCtxRef.current <- props.orderContext
+
+            match props.orderContext with
+            | Resolved _ -> revisionRef.current <- revisionRef.current + 1
+            | _ -> ()
+
+        let revision = revisionRef.current
+
         // Decrease/increase steps — inner (useCalc = false) and outer/first-last
         // (useCalc = true) — are reflected immediately via an optimistic value, so the
         // field must NOT show a loading indicator that would suggest the value hasn't
@@ -1191,7 +1208,7 @@ module Order =
                 null
 
         let content =
-            let createNav = ViewHelpers.createNav dispatch
+            let createNav = ViewHelpers.createNav dispatch revision
 
             let contentSx =
                 {|
@@ -1623,6 +1640,7 @@ module Order =
                                          else
                                              None
                                      useDebounce = not navigable && solved
+                                     revision = revision
                                  |}
                                  |> Some
 

--- a/src/Informedica.GenPRES.Client/Views/ViewHelpers.fs
+++ b/src/Informedica.GenPRES.Client/Views/ViewHelpers.fs
@@ -138,14 +138,22 @@ module ViewHelpers =
 
 
     /// Build a per-click step function for a solved order variable. Given the net inner
-    /// click delta (single-step buttons, using the DEFINED increment) and the net outer
-    /// click delta (first/last buttons, using the server's CALCULATED increment) it returns
-    /// the (key, label) of the moved value, clamped to the defined range. The increments
-    /// mirror the server (Informedica.GenORDER.Lib.OrderVariable.step): inner uses the
-    /// defined increment, outer follows the server's calculated increment. Used to show
-    /// optimistic feedback that follows the live click count (the badge) before the server
-    /// confirms. Returns None when no increment is available (cannot step locally).
-    let ovarStep (format: decimal -> string) (ovar: OrderVariable) : (int * int -> string * string) option =
+    /// click delta (single-step buttons, DEFINED increment) and the net outer click delta
+    /// (first/last buttons, server CALCULATED increment) it returns the (key, label) of the
+    /// predicted value. This mirrors the server step (Informedica.GenORDER.Lib.OrderVariable.step),
+    /// which moves freely along the increment grid with NO upper bound and is then re-solved —
+    /// so the optimistic value is deliberately NOT bounded to the defined range (doing so would
+    /// make it undershoot what the server returns). The only ceiling applied is the structural
+    /// feasibility `ceiling`: a bound the solver genuinely enforces (e.g. a
+    /// multi-component dose quantity cannot exceed the prepared orderable quantity). A floor of
+    /// one increment mirrors the server keeping the value non-zero positive. Returns None when
+    /// no increment is available (cannot step locally).
+    let ovarStepTo
+        (ceiling: decimal option)
+        (format: decimal -> string)
+        (ovar: OrderVariable)
+        : (int * int -> string * string) option
+        =
         let firstSnd (vu: Types.ValueUnit) =
             vu.Value |> Array.tryHead |> Option.map snd
 
@@ -163,30 +171,87 @@ module ViewHelpers =
             match firstSnd vals with
             | Some cur ->
                 let unit = vals.Unit
-
-                // Clamp against the DEFINED constraint range (the real allowed bounds),
-                // NOT the solved Variable's own Min/Max — for a solved variable those
-                // collapse to the single value, which would pin every step back to it.
-                let clamp v =
-                    let v =
-                        ovar.DefinedConstraints.Max
-                        |> Option.bind firstSnd
-                        |> Option.map (min v)
-                        |> Option.defaultValue v
-
-                    ovar.DefinedConstraints.Min
-                    |> Option.bind firstSnd
-                    |> Option.map (max v)
-                    |> Option.defaultValue v
-
                 let ci = outerIncr |> Option.defaultValue di
 
+                // The server's step applies no upper bound (it explores freely and re-solves),
+                // so the prediction follows the increment grid freely. Apply only the structural
+                // feasibility ceiling plus a one-increment floor — both of which the server
+                // genuinely enforces (the floor keeps the value non-zero positive).
+                let applyBounds v =
+                    let v = ceiling |> Option.map (min v) |> Option.defaultValue v
+                    max v di
+
                 (fun (innerDelta, outerDelta) ->
-                    let next = (cur + decimal innerDelta * di + decimal outerDelta * ci) |> clamp
+                    let next = (cur + decimal innerDelta * di + decimal outerDelta * ci) |> applyBounds
                     string next, $"{format next} {unit}"
                 )
                 |> Some
             | None -> None
+        | _ -> None
+
+
+    /// Like <see cref="ovarStepTo"/> but without a feasibility ceiling — the prediction
+    /// follows the increment grid freely (mirroring the server's unbounded step).
+    let ovarStep (format: decimal -> string) (ovar: OrderVariable) : (int * int -> string * string) option =
+        ovarStepTo None format ovar
+
+
+    /// Upper bound for the orderable dose quantity. For a multi-component orderable the
+    /// dose quantity cannot exceed the prepared orderable quantity ("you cannot give more
+    /// than you have", and the individual components cannot be grown to follow a larger
+    /// dose). For a single component the orderable quantity follows the dose, so there is
+    /// no extra ceiling and stepping stays unconstrained (beyond the defined range).
+    let orderableDoseQuantityCeiling (ord: Types.Order) : decimal option =
+        if ord.Orderable.Components |> Array.length > 1 then
+            ord.Orderable.OrderableQuantity.Variable.Vals
+            |> Option.bind (fun vu ->
+                if vu.Value |> Array.isEmpty then
+                    None
+                else
+                    vu.Value |> Array.map snd |> Array.max |> Some
+            )
+        else
+            None
+
+
+    /// How many inner (defined-increment) steps fit between the variable's current value
+    /// and a feasibility ceiling. Used to saturate an increase at the maximum: dispatching
+    /// more steps than this would overshoot the ceiling, which the solver rejects — leaving
+    /// the value reverted to where it was instead of landing on the max. None when there is
+    /// no ceiling or no usable increment (i.e. no saturation needed).
+    let incrementStepsToCeiling (ceiling: decimal option) (ovar: OrderVariable) : int option =
+        let firstSnd (vu: Types.ValueUnit) =
+            vu.Value |> Array.tryHead |> Option.map snd
+
+        let definedIncr =
+            [ ovar.DefinedConstraints.Incr; ovar.Variable.Incr ]
+            |> List.tryPick (Option.bind firstSnd)
+
+        match ceiling, ovar.Variable.Vals |> Option.bind firstSnd, definedIncr with
+        | Some ceil, Some cur, Some incr when incr > 0M ->
+            System.Math.Floor((ceil - cur) / incr) |> int |> max 0 |> Some
+        | _ -> None
+
+
+    /// Like <see cref="incrementStepsToCeiling"/> but counts steps of the OUTER
+    /// (server-calculated) increment used by the first/last buttons, falling back to the
+    /// defined increment when the server emits none. Lets an outer step saturate at the
+    /// feasibility ceiling exactly like the inner step, so the larger outer increment does
+    /// not overshoot the ceiling and get reverted by the solver. None when there is no
+    /// ceiling or no usable increment.
+    let outerIncrementStepsToCeiling (ceiling: decimal option) (ovar: OrderVariable) : int option =
+        let firstSnd (vu: Types.ValueUnit) =
+            vu.Value |> Array.tryHead |> Option.map snd
+
+        let definedIncr =
+            [ ovar.DefinedConstraints.Incr; ovar.Variable.Incr ]
+            |> List.tryPick (Option.bind firstSnd)
+
+        let outerIncr = ovar.OuterIncr |> Option.bind firstSnd |> Option.orElse definedIncr
+
+        match ceiling, ovar.Variable.Vals |> Option.bind firstSnd, outerIncr with
+        | Some ceil, Some cur, Some incr when incr > 0M ->
+            System.Math.Floor((ceil - cur) / incr) |> int |> max 0 |> Some
         | _ -> None
 
 

--- a/src/Informedica.GenPRES.Client/Views/ViewHelpers.fs
+++ b/src/Informedica.GenPRES.Client/Views/ViewHelpers.fs
@@ -137,10 +137,20 @@ module ViewHelpers =
         )
 
 
-    /// Build a per-click step function for a solved order variable. Given the net inner
-    /// click delta (single-step buttons, DEFINED increment) and the net outer click delta
-    /// (first/last buttons, server CALCULATED increment) it returns the (key, label) of the
-    /// predicted value. This mirrors the server step (Informedica.GenORDER.Lib.OrderVariable.step),
+    /// The defined (small-step) increment: the defined constraint's increment, else the
+    /// solved variable's own increment.
+    let definedIncrement (ovar: OrderVariable) : decimal option =
+        let firstSnd (vu: Types.ValueUnit) =
+            vu.Value |> Array.tryHead |> Option.map snd
+
+        [ ovar.DefinedConstraints.Incr; ovar.Variable.Incr ]
+        |> List.tryPick (Option.bind firstSnd)
+
+
+    /// Build a per-click step function for a solved order variable. Given the net small-step
+    /// click delta (single-step buttons, the DEFINED increment) and the net large-step click
+    /// delta (jump buttons, the server's CALCULATED LargeIncr) it returns the (key, label) of
+    /// the predicted value. This mirrors the server step (Informedica.GenORDER.Lib.OrderVariable.step),
     /// which moves freely along the increment grid with NO upper bound and is then re-solved —
     /// so the optimistic value is deliberately NOT bounded to the defined range (doing so would
     /// make it undershoot what the server returns). The only ceiling applied is the structural
@@ -157,21 +167,18 @@ module ViewHelpers =
         let firstSnd (vu: Types.ValueUnit) =
             vu.Value |> Array.tryHead |> Option.map snd
 
-        let definedIncr =
-            [ ovar.DefinedConstraints.Incr; ovar.Variable.Incr ]
-            |> List.tryPick (Option.bind firstSnd)
-
-        // The outer (first/last) buttons follow the server-provided effective increment
-        // (OuterIncr); when the server emits none, the outer step falls back to the
-        // defined increment (i.e. behaves like the inner buttons).
-        let outerIncr = ovar.OuterIncr |> Option.bind firstSnd
+        let definedIncr = definedIncrement ovar
 
         match ovar.Variable.Vals, definedIncr with
-        | Some vals, Some di when di > 0M ->
+        | Some vals, Some smallIncr when smallIncr > 0M ->
             match firstSnd vals with
             | Some cur ->
                 let unit = vals.Unit
-                let ci = outerIncr |> Option.defaultValue di
+
+                // The large step follows the server-provided LargeIncr; when the server emits
+                // none, it falls back to the defined increment (behaving like the small step).
+                let largeIncr =
+                    ovar.LargeIncr |> Option.bind firstSnd |> Option.defaultValue smallIncr
 
                 // The server's step applies no upper bound (it explores freely and re-solves),
                 // so the prediction follows the increment grid freely. Apply only the structural
@@ -179,10 +186,13 @@ module ViewHelpers =
                 // genuinely enforces (the floor keeps the value non-zero positive).
                 let applyBounds v =
                     let v = ceiling |> Option.map (min v) |> Option.defaultValue v
-                    max v di
+                    max v smallIncr
 
-                (fun (innerDelta, outerDelta) ->
-                    let next = (cur + decimal innerDelta * di + decimal outerDelta * ci) |> applyBounds
+                (fun (smallDelta, largeDelta) ->
+                    let next =
+                        cur + decimal smallDelta * smallIncr + decimal largeDelta * largeIncr
+                        |> applyBounds
+
                     string next, $"{format next} {unit}"
                 )
                 |> Some
@@ -214,45 +224,159 @@ module ViewHelpers =
             None
 
 
-    /// How many inner (defined-increment) steps fit between the variable's current value
-    /// and a feasibility ceiling. Used to saturate an increase at the maximum: dispatching
-    /// more steps than this would overshoot the ceiling, which the solver rejects — leaving
-    /// the value reverted to where it was instead of landing on the max. None when there is
-    /// no ceiling or no usable increment (i.e. no saturation needed).
+    /// How many whole `incr`-sized steps fit between the variable's current value and a
+    /// feasibility ceiling, never negative. Shared core of incrementStepsToCeiling and
+    /// largeIncrementStepsToCeiling — the two differ only in which increment they pass.
+    let stepsToCeiling (ceiling: decimal option) (incr: decimal option) (ovar: OrderVariable) : int option =
+        let firstSnd (vu: Types.ValueUnit) =
+            vu.Value |> Array.tryHead |> Option.map snd
+
+        match ceiling, ovar.Variable.Vals |> Option.bind firstSnd, incr with
+        | Some ceil, Some cur, Some i when i > 0M -> System.Math.Floor((ceil - cur) / i) |> int |> max 0 |> Some
+        | _ -> None
+
+
+    /// How many whole defined-increment steps fit between the current value and a
+    /// feasibility ceiling. Used to cap an increase so it lands on the last step below the
+    /// ceiling rather than overshooting it — an overshoot is rejected by the solver, which
+    /// reverts the value to where it started. Returns 0 when less than one step fits (already
+    /// at the max). None when there is no ceiling or no usable increment.
     let incrementStepsToCeiling (ceiling: decimal option) (ovar: OrderVariable) : int option =
+        ovar |> stepsToCeiling ceiling (definedIncrement ovar)
+
+
+    /// Like <see cref="incrementStepsToCeiling"/> but counts steps of the LARGE increment
+    /// (the server's calculated LargeIncr used by the jump buttons), falling back to the
+    /// defined increment when the server emits none. Lets a large step saturate at the
+    /// feasibility ceiling exactly like a small step, so the larger increment does not
+    /// overshoot the ceiling and get reverted by the solver. None when there is no ceiling
+    /// or no usable increment.
+    let largeIncrementStepsToCeiling (ceiling: decimal option) (ovar: OrderVariable) : int option =
         let firstSnd (vu: Types.ValueUnit) =
             vu.Value |> Array.tryHead |> Option.map snd
 
-        let definedIncr =
-            [ ovar.DefinedConstraints.Incr; ovar.Variable.Incr ]
-            |> List.tryPick (Option.bind firstSnd)
+        let largeIncr =
+            ovar.LargeIncr |> Option.bind firstSnd |> Option.orElse (definedIncrement ovar)
 
-        match ceiling, ovar.Variable.Vals |> Option.bind firstSnd, definedIncr with
-        | Some ceil, Some cur, Some incr when incr > 0M ->
-            System.Math.Floor((ceil - cur) / incr) |> int |> max 0 |> Some
-        | _ -> None
+        ovar |> stepsToCeiling ceiling largeIncr
 
 
-    /// Like <see cref="incrementStepsToCeiling"/> but counts steps of the OUTER
-    /// (server-calculated) increment used by the first/last buttons, falling back to the
-    /// defined increment when the server emits none. Lets an outer step saturate at the
-    /// feasibility ceiling exactly like the inner step, so the larger outer increment does
-    /// not overshoot the ceiling and get reverted by the solver. None when there is no
-    /// ceiling or no usable increment.
-    let outerIncrementStepsToCeiling (ceiling: decimal option) (ovar: OrderVariable) : int option =
-        let firstSnd (vu: Types.ValueUnit) =
-            vu.Value |> Array.tryHead |> Option.map snd
+    /// Build the navigate record for the orderable dose-quantity select, shared by the Order
+    /// and Nutrition views. Handles the optimistic stepping with feasibility-ceiling
+    /// saturation: the displayed value follows the click count up to the prepared orderable
+    /// quantity, and dispatched steps are saturated at that ceiling so an overshoot is not
+    /// reverted by the solver. The five message constructors (setMin/decr/setMed/incr/setMax)
+    /// are supplied by each view from its own Msg type. Returns None when navigation must be
+    /// hidden (a multi-component orderable whose components do not each have a single distinct
+    /// orderable quantity).
+    let createDoseQtyNav
+        dispatch
+        revision
+        (ord: Order)
+        (setMin: 'Msg)
+        (decr: int * bool -> 'Msg)
+        (setMed: 'Msg)
+        (incr: int * bool -> 'Msg)
+        (setMax: 'Msg)
+        =
+        // Only show nav when every component has a single distinct orderable quantity.
+        let showNav =
+            ord.Orderable.Components
+            |> Array.forall (fun cmp ->
+                cmp.OrderableQuantity.Variable.Vals
+                |> Option.map (fun vu -> vu.Value |> Array.length = 1)
+                |> Option.defaultValue false
+            )
 
-        let definedIncr =
-            [ ovar.DefinedConstraints.Incr; ovar.Variable.Incr ]
-            |> List.tryPick (Option.bind firstSnd)
+        if not showNav then
+            None
+        else
+            let canIncr =
+                ord.Orderable.Components |> Array.length = 1
+                || ord.Orderable.DoseCount.Variable.Vals
+                   |> Option.map (fun vu -> vu.Value |> Array.map snd |> Array.forall (fun v -> v > 1m))
+                   |> Option.defaultValue false
 
-        let outerIncr = ovar.OuterIncr |> Option.bind firstSnd |> Option.orElse definedIncr
+            let solved = ord |> isSolved
+            let navigable = ord.Orderable.Dose.Quantity |> OrderVariable.isNavigable
 
-        match ceiling, ovar.Variable.Vals |> Option.bind firstSnd, outerIncr with
-        | Some ceil, Some cur, Some incr when incr > 0M ->
-            System.Math.Floor((ceil - cur) / incr) |> int |> max 0 |> Some
-        | _ -> None
+            // For a multi-component orderable the dose quantity cannot exceed the prepared
+            // orderable quantity. Use it as a feasibility ceiling: the optimistic value stays
+            // within it, and an overflowing increase is saturated at the max (saturateInc)
+            // instead of overshooting, which the solver would reject — reverting the value.
+            // Single component: orderable quantity follows the dose, so no ceiling.
+            let doseQtyCeiling = ord |> orderableDoseQuantityCeiling
+
+            let saturateInc n =
+                ord.Orderable.Dose.Quantity
+                |> incrementStepsToCeiling doseQtyCeiling
+                |> Option.map (min n)
+                |> Option.defaultValue n
+
+            // Large-step counterpart of saturateInc: clamp the dispatched large steps so the
+            // larger increment lands on the last grid point at or below the ceiling instead of
+            // overshooting and being reverted by the solver.
+            let saturateLarge n =
+                ord.Orderable.Dose.Quantity
+                |> largeIncrementStepsToCeiling doseQtyCeiling
+                |> Option.map (min n)
+                |> Option.defaultValue n
+
+            // Whether a full defined-increment step still fits below the feasibility ceiling.
+            // The increment grid cannot generally land exactly on the ceiling, so the server
+            // value settles just below it while the optimistic display clamps to the ceiling —
+            // leaving DoseCount > 1 (so canIncr stays true) and the increase buttons permanently
+            // active despite the field showing the max. Gating on remaining ceiling room
+            // disables them once no further step fits.
+            let canStepUp =
+                ord.Orderable.Dose.Quantity
+                |> incrementStepsToCeiling doseQtyCeiling
+                |> Option.map (fun steps -> steps > 0)
+                |> Option.defaultValue true
+
+            // Large-step counterpart of canStepUp, measured against the large increment so the
+            // last button disables exactly when no further large step fits below the ceiling.
+            let canStepUpLarge =
+                ord.Orderable.Dose.Quantity
+                |> largeIncrementStepsToCeiling doseQtyCeiling
+                |> Option.map (fun steps -> steps > 0)
+                |> Option.defaultValue true
+
+            {|
+                step = ord.Orderable.Dose.Quantity |> ovarStepTo doseQtyCeiling string
+                first =
+                    if navigable then
+                        (fun (_: int) -> setMin |> dispatch) |> Some
+                    elif solved then
+                        (fun n -> (n, true) |> decr |> dispatch) |> Some
+                    else
+                        None
+                decrease =
+                    if solved then
+                        (fun n -> (n, false) |> decr |> dispatch) |> Some
+                    else
+                        None
+                median =
+                    if navigable then
+                        (fun () -> setMed |> dispatch) |> Some
+                    else
+                        None
+                increase =
+                    if solved && canIncr && canStepUp then
+                        (fun n -> (saturateInc n, false) |> incr |> dispatch) |> Some
+                    else
+                        None
+                last =
+                    if navigable then
+                        (fun (_: int) -> setMax |> dispatch) |> Some
+                    elif solved && canIncr && canStepUpLarge then
+                        (fun n -> (saturateLarge n, true) |> incr |> dispatch) |> Some
+                    else
+                        None
+                useDebounce = not navigable && solved
+                revision = revision
+            |}
+            |> Some
 
 
     let ovarDisplay select (name: string) (format: decimal -> string) minWidth (ovar: OrderVariable) =

--- a/src/Informedica.GenPRES.Client/Views/ViewHelpers.fs
+++ b/src/Informedica.GenPRES.Client/Views/ViewHelpers.fs
@@ -68,6 +68,7 @@ module ViewHelpers =
 
     let createNav
         dispatch
+        revision
         navigable
         solved
         setMin
@@ -109,6 +110,7 @@ module ViewHelpers =
                 else
                     None
             useDebounce = not navigable && solved
+            revision = revision
         |}
         |> Some
 

--- a/src/Informedica.GenPRES.Client/Views/ViewHelpers.fs
+++ b/src/Informedica.GenPRES.Client/Views/ViewHelpers.fs
@@ -137,12 +137,15 @@ module ViewHelpers =
         )
 
 
+    /// The value of the first (key, value) pair of a ValueUnit, if any. Shared helper for
+    /// the increment/step calculations below.
+    let firstSnd (vu: Types.ValueUnit) =
+        vu.Value |> Array.tryHead |> Option.map snd
+
+
     /// The defined (small-step) increment: the defined constraint's increment, else the
     /// solved variable's own increment.
     let definedIncrement (ovar: OrderVariable) : decimal option =
-        let firstSnd (vu: Types.ValueUnit) =
-            vu.Value |> Array.tryHead |> Option.map snd
-
         [ ovar.DefinedConstraints.Incr; ovar.Variable.Incr ]
         |> List.tryPick (Option.bind firstSnd)
 
@@ -164,9 +167,6 @@ module ViewHelpers =
         (ovar: OrderVariable)
         : (int * int -> string * string) option
         =
-        let firstSnd (vu: Types.ValueUnit) =
-            vu.Value |> Array.tryHead |> Option.map snd
-
         let definedIncr = definedIncrement ovar
 
         match ovar.Variable.Vals, definedIncr with
@@ -228,9 +228,6 @@ module ViewHelpers =
     /// feasibility ceiling, never negative. Shared core of incrementStepsToCeiling and
     /// largeIncrementStepsToCeiling — the two differ only in which increment they pass.
     let stepsToCeiling (ceiling: decimal option) (incr: decimal option) (ovar: OrderVariable) : int option =
-        let firstSnd (vu: Types.ValueUnit) =
-            vu.Value |> Array.tryHead |> Option.map snd
-
         match ceiling, ovar.Variable.Vals |> Option.bind firstSnd, incr with
         | Some ceil, Some cur, Some i when i > 0M -> System.Math.Floor((ceil - cur) / i) |> int |> max 0 |> Some
         | _ -> None
@@ -252,9 +249,6 @@ module ViewHelpers =
     /// overshoot the ceiling and get reverted by the solver. None when there is no ceiling
     /// or no usable increment.
     let largeIncrementStepsToCeiling (ceiling: decimal option) (ovar: OrderVariable) : int option =
-        let firstSnd (vu: Types.ValueUnit) =
-            vu.Value |> Array.tryHead |> Option.map snd
-
         let largeIncr =
             ovar.LargeIncr |> Option.bind firstSnd |> Option.orElse (definedIncrement ovar)
 
@@ -328,19 +322,28 @@ module ViewHelpers =
             // leaving DoseCount > 1 (so canIncr stays true) and the increase buttons permanently
             // active despite the field showing the max. Gating on remaining ceiling room
             // disables them once no further step fits.
+            //
+            // No ceiling (single component) → stepping is unconstrained, so stay enabled. With a
+            // ceiling, require a positive step count; if the step count can't be computed (ceiling
+            // known but increment unavailable) disable rather than dispatch an unsaturated step the
+            // solver would revert.
             let canStepUp =
-                ord.Orderable.Dose.Quantity
-                |> incrementStepsToCeiling doseQtyCeiling
-                |> Option.map (fun steps -> steps > 0)
-                |> Option.defaultValue true
+                match doseQtyCeiling with
+                | None -> true
+                | Some _ ->
+                    ord.Orderable.Dose.Quantity
+                    |> incrementStepsToCeiling doseQtyCeiling
+                    |> Option.exists (fun steps -> steps > 0)
 
             // Large-step counterpart of canStepUp, measured against the large increment so the
             // last button disables exactly when no further large step fits below the ceiling.
             let canStepUpLarge =
-                ord.Orderable.Dose.Quantity
-                |> largeIncrementStepsToCeiling doseQtyCeiling
-                |> Option.map (fun steps -> steps > 0)
-                |> Option.defaultValue true
+                match doseQtyCeiling with
+                | None -> true
+                | Some _ ->
+                    ord.Orderable.Dose.Quantity
+                    |> largeIncrementStepsToCeiling doseQtyCeiling
+                    |> Option.exists (fun steps -> steps > 0)
 
             {|
                 step = ord.Orderable.Dose.Quantity |> ovarStepTo doseQtyCeiling string

--- a/src/Informedica.GenPRES.Server/ServerApi.Mappers.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Mappers.fs
@@ -73,7 +73,7 @@ module Mappers =
         /// Generic order variables pass None so NO multiple is applied (the ×10 must only
         /// happen for the rate / quantity that the server actually multiplies). Optional —
         /// many order variables have no calculated increment.
-        let mapOuterIncr
+        let mapLargeIncr
             (coarse: Informedica.GenUnits.Lib.ValueUnit option)
             (dto: OrderVariable.Dto.Dto)
             : Types.ValueUnit option
@@ -117,7 +117,7 @@ module Mappers =
                 (dto.Constraints |> mapToVariable)
                 (dto.Calculated |> mapToVariable)
                 (dto.Variable |> mapToVariable)
-                (dto |> mapOuterIncr coarse)
+                (dto |> mapLargeIncr coarse)
                 level
 
 

--- a/src/Informedica.GenPRES.Shared/Models.fs
+++ b/src/Informedica.GenPRES.Shared/Models.fs
@@ -1668,7 +1668,7 @@ module Models =
                     DefinedConstraints = cst
                     CalculatedConstraints = cal
                     Variable = var
-                    OuterIncr = outerIncr
+                    LargeIncr = outerIncr
                     Level = level
                 }
 

--- a/src/Informedica.GenPRES.Shared/Types.fs
+++ b/src/Informedica.GenPRES.Shared/Types.fs
@@ -171,7 +171,7 @@ module Types =
             // The effective "bigger" per-click increment used by the outer (first/last)
             // navigation buttons, as computed by the server. Optional: only order
             // variables whose outer step differs from the defined increment emit one.
-            OuterIncr: ValueUnit option
+            LargeIncr: ValueUnit option
             Level: Level
         }
 


### PR DESCRIPTION
## Summary

Fixes a navigation regression in the Nutrition view and refactors the order-entry
UI (`Order.fs`, `Nutrition.fs`, `ViewHelpers.fs`, `SimpleSelect.fs`) for readability
and de-duplication. UI-only changes; no server or domain logic touched.

## Bug fix — dose-quantity nav stopped recalculating (NutritionView)

When a multi-component order's dose quantity was within one increment of its
feasibility ceiling, the increase/last buttons stayed **enabled** but dispatched
no-op `(0, …)` steps: the value optimistically jumped to the max, the server
returned it unchanged, and it snapped back — so changing the value appeared to no
longer trigger a recalculate.

Root cause: the overflow-saturation mechanism (`saturateInc`) was added to both
views, but only `Order.fs` also got the `canStepUp` gate that disables the buttons
once no further step fits below the ceiling. `Nutrition.fs` was missing it.

**Fix:** ported `canStepUp`/`canStepUpLarge` to Nutrition and switched its `last`
button from raw `(n, true)` to `saturateLarge` — so the buttons now disable at the
ceiling instead of firing no-op round-trips.

## Refactors (no behaviour change)

- **Shared dose-qty nav builder.** Extracted the ~90-line duplicated `navigate`
  record (built identically in Order and Nutrition) into one generic helper
  `ViewHelpers.createDoseQtyNav`, mirroring the existing `createNav`. Both call
  sites drop to ~9 lines (~190 duplicated lines removed). It's a function, not a
  component, because `navigate` is a data prop consumed by the existing
  `SimpleSelect`.

- **Order.fs `<Stack>` readability.** The ~426-line `<Stack>` of inline
  `{match displayOrder … -> select …}` blocks is now a flat list of 18 named
  children (`{componentSelect}`, `{itemSelect}`, … `{timeSelect}`), each a named
  `let` binding before the JSX — matching the file's existing divider pattern.

- **Nested record updates → F# 8 copy-and-update.** Collapsed manual
  `{ ord with Orderable = { ord.Orderable with Components = … } }` nesting to
  `{ ord with Order.Orderable.Components = … }` across 10 update handlers (and the
  inner `Dose = { itm.Dose with … }` → `Item.Dose.X = …` in the three `*Adjust`
  handlers), matching the convention already used elsewhere in the file.

- **Increment terminology + helper dedup.** Renamed UI-position-based naming
  (`inner`/`outer`, "first/last") to size-based (`small`/`large`) in
  `SimpleSelect.fs` and `ViewHelpers.fs`. Extracted a shared `stepsToCeiling` core
  plus a `definedIncrement` helper so `incrementStepsToCeiling` /
  `largeIncrementStepsToCeiling` become thin wrappers. Tightened the doc comments.

## Testing

- Fable compiles cleanly; IDE/FCS diagnostics clear (only cosmetic
  Fantomas-fixable hints).
- Manual check: in NutritionView, solve a multi-component order (e.g. TPN) and
  step the dose quantity to its ceiling — the increase/last buttons now disable at
  the max instead of snapping the value back on each click.

## AI assistance

UI code in this PR was AI-assisted (Claude Code) and reviewed via Fable compilation
and inspection of the generated JSX output.
