### PR TITLE
UI/refactor and improve layout

### DIFF
--- a/src/Informedica.GenPRES.Client/App.fs
+++ b/src/Informedica.GenPRES.Client/App.fs
@@ -1281,6 +1281,20 @@ let View () =
                 """
         | None -> null
 
+    let genPresProps =
+        {|
+            appEnv = appEnv
+            showDisclaimer = state.ShowDisclaimer
+            isDemo = state.IsDemo
+            acceptDisclaimer = fun _ -> AcceptDisclaimer |> dispatch
+            updatePage = UpdatePage >> dispatch
+            page = state.Page
+            languages = Localization.languages
+            hospitals = state.Hospitals
+            switchLang = UpdateLanguage >> dispatch
+            switchHosp = UpdateHospital >> dispatch
+        |}
+
     JSX.jsx
         $"""
     import {{ ThemeProvider }} from '@mui/material/styles';
@@ -1300,19 +1314,7 @@ let View () =
                 <CssBaseline />
                 {serverErrorBanner}
                 {Components.Router.View {| onUrlChanged = UrlChanged >> dispatch |}}
-                {Pages.GenPres.View
-                     {|
-                         appEnv = appEnv
-                         showDisclaimer = state.ShowDisclaimer
-                         isDemo = state.IsDemo
-                         acceptDisclaimer = fun _ -> AcceptDisclaimer |> dispatch
-                         updatePage = UpdatePage >> dispatch
-                         page = state.Page
-                         languages = Localization.languages
-                         hospitals = state.Hospitals
-                         switchLang = UpdateLanguage >> dispatch
-                         switchHosp = UpdateHospital >> dispatch
-                     |}
+                {Pages.GenPres.View genPresProps
                  |> toReact
                  |> Components.Context.Context state.Context}
             </Box>

--- a/src/Informedica.GenPRES.Client/App.fs
+++ b/src/Informedica.GenPRES.Client/App.fs
@@ -497,13 +497,10 @@ module private Elmish =
 
             let ctx =
                 { OrderContext.empty with
-                    Filter =
-                        { OrderContext.empty.Filter with
-                            Indication = indication |> nonEmpty
-                            Generic = Some generic
-                            Route = route |> nonEmpty
-                            DoseType = doseType |> nonEmpty |> Option.map DoseType.doseTypeFromString
-                        }
+                    OrderContext.Filter.Indication = indication |> nonEmpty
+                    OrderContext.Filter.Generic = Some generic
+                    OrderContext.Filter.Route = route |> nonEmpty
+                    OrderContext.Filter.DoseType = doseType |> nonEmpty |> Option.map DoseType.doseTypeFromString
                 }
 
             { state with

--- a/src/Informedica.GenPRES.Client/Components/Localization.fs
+++ b/src/Informedica.GenPRES.Client/Components/Localization.fs
@@ -40,6 +40,12 @@ module Localization =
                 """
             )
 
+        let menuOrigin =
+            {|
+                vertical = "top"
+                horizontal = "right"
+            |}
+
         JSX.jsx
             $"""
         import Box from '@mui/material/Box';
@@ -57,15 +63,9 @@ module Localization =
             <Menu
                 sx={ {| marginTop = "40px" |} }
                 anchorEl={anchorElLang}
-                anchorOrigin={ {|
-                                   vertical = "top"
-                                   horizontal = "right"
-                               |} }
+                anchorOrigin={menuOrigin}
                 keepMounted
-                transformOrigin={ {|
-                                      vertical = "top"
-                                      horizontal = "right"
-                                  |} }
+                transformOrigin={menuOrigin}
                 open={anchorElLang.IsSome}
                 onClose={handleCloseLangMenu}
             >

--- a/src/Informedica.GenPRES.Client/Components/ResponsiveTable.fs
+++ b/src/Informedica.GenPRES.Client/Components/ResponsiveTable.fs
@@ -202,6 +202,13 @@ module ResponsiveTable =
                     """
                 )
 
+            let columnSpacing =
+                {|
+                    xs = 1
+                    sm = 2
+                    md = 3
+                |}
+
             JSX.jsx
                 $"""
             import Grid from '@mui/material/Grid';
@@ -212,11 +219,7 @@ module ResponsiveTable =
                 <Box sx={ {| marginBottom = 1.5 |} }>
                     {props.filter |> Option.defaultValue null}
                 </Box>
-                <Grid container rowSpacing={1} columnSpacing={ {|
-                                                                   xs = 1
-                                                                   sm = 2
-                                                                   md = 3
-                                                               |} } >
+                <Grid container rowSpacing={1} columnSpacing={columnSpacing} >
                     {React.Fragment(cards |> unbox<seq<ReactElement>>)}
                 </Grid>
             </Stack>
@@ -311,7 +314,7 @@ module ResponsiveTable =
                         |> Array.distinct
                         |> Array.sortBy _.ToLower()
 
-                    MultipleSelect.View(
+                    MultipleSelect.View
                         {|
                             label = "Filter"
                             selected = state
@@ -320,7 +323,6 @@ module ResponsiveTable =
                             isLoading = false
                             disabled = false
                         |}
-                    )
             |> toReact
 
         let onRowClick = fun pars -> pars?id |> string |> props.onRowClick

--- a/src/Informedica.GenPRES.Client/Components/SimpleSelect.fs
+++ b/src/Informedica.GenPRES.Client/Components/SimpleSelect.fs
@@ -18,7 +18,7 @@ module SimpleSelect =
                 selected: string option
                 values: (string * string)[]
                 updateSelected: string option -> unit
-                navigate:
+                stepper:
                     {|
                         step: (int * int -> string * string) option
                         first: (int -> unit) option
@@ -60,7 +60,7 @@ module SimpleSelect =
         // no-op step (already at the maximum) leaves the current value unchanged, so
         // valueKey never changes and would otherwise leave a stale optimistic value shown.
         let revision =
-            props.navigate |> Option.map (fun n -> n.revision) |> Option.defaultValue 0
+            props.stepper |> Option.map (fun n -> n.revision) |> Option.defaultValue 0
 
         // useLayoutEffect (not useEffect) so the deltas are reset BEFORE the browser
         // paints the frame on which the server's new value arrives — otherwise that frame
@@ -75,7 +75,7 @@ module SimpleSelect =
             [| box valueKey; box revision |]
         )
 
-        let stepFn = props.navigate |> Option.bind (fun n -> n.step)
+        let stepFn = props.stepper |> Option.bind (fun n -> n.step)
 
         // Only accumulate a click that actually moves the predicted value. When the step
         // has saturated at a bound (the feasibility ceiling or the increment floor) the
@@ -133,15 +133,18 @@ module SimpleSelect =
 
         let clear = fun _ -> None |> props.updateSelected
 
+        let menuItemSx =
+            {|
+                maxWidth = 400
+                paddingY = if isMobile then 0.25 else 0.75
+            |}
+
         let items =
             displayValues
             |> Array.mapi (fun i (k, v) ->
                 JSX.jsx
                     $"""
-                <MenuItem key={i} value={k} sx = { {|
-                                                       maxWidth = 400
-                                                       paddingY = (if isMobile then 0.25 else 0.75)
-                                                   |} } dense={isMobile} >
+                <MenuItem key={i} value={k} sx={menuItemSx} dense={isMobile} >
                     {v}
                 </MenuItem>
                 """
@@ -172,7 +175,7 @@ module SimpleSelect =
             |}
 
         let navigation =
-            props.navigate
+            props.stepper
             |> Option.map (fun nav ->
                 let getNav prop =
                     match prop with
@@ -186,19 +189,19 @@ module SimpleSelect =
 
                 let firstDisabled, firstClick = nav.first |> getNavN
                 let decreaseDisabled, decreaseClick = nav.decrease |> getNavN
+                let medianDisabled, medianClick = nav.median |> getNav
                 let increaseDisabled, increaseClick = nav.increase |> getNavN
                 let lastDisabled, lastClick = nav.last |> getNavN
 
                 let firstButton =
                     if nav.useDebounce then
-                        ClickCountingButton.View(
+                        ClickCountingButton.View
                             {|
                                 disabled = firstDisabled
                                 onClick = firstClick
                                 onStep = bumpLarge -1
                                 icon = Mui.Icons.FirstPageIcon
                             |}
-                        )
                     else
                         JSX.jsx
                             $"""
@@ -208,14 +211,13 @@ module SimpleSelect =
 
                 let decreaseButton =
                     if nav.useDebounce then
-                        ClickCountingButton.View(
+                        ClickCountingButton.View
                             {|
                                 disabled = decreaseDisabled
                                 onClick = decreaseClick
                                 onStep = bumpSmall -1
                                 icon = Mui.Icons.SkipPreviousIcon
                             |}
-                        )
                     else
                         JSX.jsx
                             $"""
@@ -223,16 +225,22 @@ module SimpleSelect =
                         <IconButton disabled={decreaseDisabled} onClick={fun _ -> decreaseClick 1} >{Mui.Icons.SkipPreviousIcon}</IconButton>
                         """
 
+                let medianButton =
+                    JSX.jsx
+                        $"""
+                    import IconButton from "@mui/material/IconButton";
+                    <IconButton disabled={medianDisabled} onClick={fun _ -> medianClick ()} >{Mui.Icons.PauseIcon}</IconButton>
+                    """
+
                 let increaseButton =
                     if nav.useDebounce then
-                        ClickCountingButton.View(
+                        ClickCountingButton.View
                             {|
                                 disabled = increaseDisabled
                                 onClick = increaseClick
                                 onStep = bumpSmall 1
                                 icon = Mui.Icons.SkipNextIcon
                             |}
-                        )
                     else
                         JSX.jsx
                             $"""
@@ -242,14 +250,13 @@ module SimpleSelect =
 
                 let lastButton =
                     if nav.useDebounce then
-                        ClickCountingButton.View(
+                        ClickCountingButton.View
                             {|
                                 disabled = lastDisabled
                                 onClick = lastClick
                                 onStep = bumpLarge 1
                                 icon = Mui.Icons.LastPageIcon
                             |}
-                        )
                     else
                         JSX.jsx
                             $"""
@@ -268,7 +275,7 @@ module SimpleSelect =
                 <ButtonGroup variant="text" aria-label="navigation button group">
                     {firstButton}
                     {decreaseButton}
-                    <IconButton disabled={nav.median |> getNav |> fst} onClick={fun _ -> (nav.median |> getNav |> snd) ()} >{Mui.Icons.PauseIcon}</IconButton>
+                    {medianButton}
                     {increaseButton}
                     {lastButton}
                 </ButtonGroup>
@@ -283,7 +290,7 @@ module SimpleSelect =
                 navigation
 
         let hasNavigation =
-            props.navigate
+            props.stepper
             |> Option.map (fun nav ->
                 nav.first.IsSome
                 || nav.decrease.IsSome

--- a/src/Informedica.GenPRES.Client/Views/ContinuousMeds.fs
+++ b/src/Informedica.GenPRES.Client/Views/ContinuousMeds.fs
@@ -264,40 +264,45 @@ module ContinuousMeds =
             """
             |> toReact
 
+        let boxSx = {| height = "100%" |}
+
+        let tableProps =
+            {|
+                hideFilter = false
+                columns = columns
+                rows = rows
+                rowCreate = rowCreate
+                height = "100%"
+                onRowClick = onSelectItem
+                checkboxSelection = false
+                selectedRows = [||]
+                onSelectChange = ignore
+                showToolbar = true
+                showFooter = true
+                onPrint =
+                    Some(fun filteredRows ->
+                        setPrintData filteredRows
+                        setPrintOpen true
+                    )
+                selectedFilter = Some filterState
+                onFilterChange = Some onFilterChange
+            |}
+
+        let printDialogProps =
+            {|
+                isOpen = printOpen
+                onClose = fun () -> setPrintOpen false
+                title = Terms.``Continuous Medication List`` |> getTerm "Continue Medicatie"
+                children = printContent
+            |}
+
         JSX.jsx
             $"""
         import Box from '@mui/material/Box';
         import React from 'react';
 
-        <Box sx={ {| height = "100%" |} } >
-            {Components.ResponsiveTable.View(
-                 {|
-                     hideFilter = false
-                     columns = columns
-                     rows = rows
-                     rowCreate = rowCreate
-                     height = "100%"
-                     onRowClick = onSelectItem
-                     checkboxSelection = false
-                     selectedRows = [||]
-                     onSelectChange = ignore
-                     showToolbar = true
-                     showFooter = true
-                     onPrint =
-                         Some(fun filteredRows ->
-                             setPrintData filteredRows
-                             setPrintOpen true
-                         )
-                     selectedFilter = Some filterState
-                     onFilterChange = Some onFilterChange
-                 |}
-             )}
-            {ViewHelpers.PrintView.PrintDialog
-                 {|
-                     isOpen = printOpen
-                     onClose = fun () -> setPrintOpen false
-                     title = Terms.``Continuous Medication List`` |> getTerm "Continue Medicatie"
-                     children = printContent
-                 |}}
+        <Box sx={boxSx} >
+            {Components.ResponsiveTable.View tableProps}
+            {ViewHelpers.PrintView.PrintDialog printDialogProps}
         </Box>
         """

--- a/src/Informedica.GenPRES.Client/Views/EmergencyList.fs
+++ b/src/Informedica.GenPRES.Client/Views/EmergencyList.fs
@@ -305,40 +305,45 @@ module EmergencyList =
             """
             |> toReact
 
+        let boxSx = {| height = "100%" |}
+
+        let tableProps =
+            {|
+                hideFilter = false
+                columns = columns
+                rows = rows
+                rowCreate = rowCreate
+                height = "100%"
+                onRowClick = onSelectItem
+                checkboxSelection = false
+                selectedRows = [||]
+                onSelectChange = ignore
+                showToolbar = true
+                showFooter = true
+                onPrint =
+                    Some(fun filteredRows ->
+                        setPrintData filteredRows
+                        setPrintOpen true
+                    )
+                selectedFilter = Some filterState
+                onFilterChange = Some onFilterChange
+            |}
+
+        let printDialogProps =
+            {|
+                isOpen = printOpen
+                onClose = fun () -> setPrintOpen false
+                title = Terms.``Emergency List`` |> getTerm "Noodlijst"
+                children = printContent
+            |}
+
         JSX.jsx
             $"""
         import Box from '@mui/material/Box';
         import React from 'react';
 
-        <Box sx={ {| height = "100%" |} }>
-            {Components.ResponsiveTable.View(
-                 {|
-                     hideFilter = false
-                     columns = columns
-                     rows = rows
-                     rowCreate = rowCreate
-                     height = "100%"
-                     onRowClick = onSelectItem
-                     checkboxSelection = false
-                     selectedRows = [||]
-                     onSelectChange = ignore
-                     showToolbar = true
-                     showFooter = true
-                     onPrint =
-                         Some(fun filteredRows ->
-                             setPrintData filteredRows
-                             setPrintOpen true
-                         )
-                     selectedFilter = Some filterState
-                     onFilterChange = Some onFilterChange
-                 |}
-             )}
-            {ViewHelpers.PrintView.PrintDialog
-                 {|
-                     isOpen = printOpen
-                     onClose = fun () -> setPrintOpen false
-                     title = Terms.``Emergency List`` |> getTerm "Noodlijst"
-                     children = printContent
-                 |}}
+        <Box sx={boxSx}>
+            {Components.ResponsiveTable.View tableProps}
+            {ViewHelpers.PrintView.PrintDialog printDialogProps}
         </Box>
         """

--- a/src/Informedica.GenPRES.Client/Views/Nutrition.fs
+++ b/src/Informedica.GenPRES.Client/Views/Nutrition.fs
@@ -148,17 +148,14 @@ module Nutrition =
                 | Some ord ->
                     let msg =
                         { ord with
-                            Orderable =
-                                { ord.Orderable with
-                                    Components =
-                                        ord.Orderable.Components
-                                        |> Array.map (fun cmp ->
-                                            if cmp.Name = cmpName then
-                                                { cmp with OrderableQuantity = cmp.OrderableQuantity |> setOvar s }
-                                            else
-                                                cmp
-                                        )
-                                }
+                            Order.Orderable.Components =
+                                ord.Orderable.Components
+                                |> Array.map (fun cmp ->
+                                    if cmp.Name = cmpName then
+                                        { cmp with OrderableQuantity = cmp.OrderableQuantity |> setOvar s }
+                                    else
+                                        cmp
+                                )
                         }
                         |> UpdateOrderScenario
 
@@ -170,20 +167,16 @@ module Nutrition =
                 | Some ord ->
                     let msg =
                         { ord with
-                            Orderable =
-                                { ord.Orderable with
-                                    Components =
-                                        ord.Orderable.Components
-                                        |> Array.map (fun cmp ->
-                                            if cmp.Name = cmpName then
-                                                { cmp with
-                                                    Component.Dose.QuantityAdjust =
-                                                        cmp.Dose.QuantityAdjust |> setOvar s
-                                                }
-                                            else
-                                                cmp
-                                        )
-                                }
+                            Order.Orderable.Components =
+                                ord.Orderable.Components
+                                |> Array.map (fun cmp ->
+                                    if cmp.Name = cmpName then
+                                        { cmp with
+                                            Component.Dose.QuantityAdjust = cmp.Dose.QuantityAdjust |> setOvar s
+                                        }
+                                    else
+                                        cmp
+                                )
                         }
                         |> UpdateOrderScenario
 
@@ -1140,12 +1133,13 @@ module Nutrition =
                 $"""
             import Grid from '@mui/material/Grid';
             import Typography from '@mui/material/Typography';
+            import Divider from '@mui/material/Divider';
             <Grid container spacing={{2}}>
                 <Grid size={halfSize}>
-                    <Typography variant="caption" color="text.secondary">bereiding</Typography>
+                    <Divider><Typography variant="caption">bereiding</Typography></Divider>
                 </Grid>
                 <Grid size={halfSize}>
-                    <Typography variant="caption" color="text.secondary">dosering</Typography>
+                    <Divider><Typography variant="caption">dosering</Typography></Divider>
                 </Grid>
             </Grid>
             """

--- a/src/Informedica.GenPRES.Client/Views/Nutrition.fs
+++ b/src/Informedica.GenPRES.Client/Views/Nutrition.fs
@@ -84,7 +84,7 @@ module Nutrition =
         let update
             updateOrderScenario
             resetOrderScenario
-            (navigate:
+            (stepper:
                 {|
                     setRateMin: OrderLoader -> unit
                     setRateDec: int * bool -> OrderLoader -> unit
@@ -231,27 +231,25 @@ module Nutrition =
                 | _ -> state, Cmd.none
 
             // Rate navigation
-            | SetMinDoseRateProperty -> handleNav navigate.setRateMin
-            | DecreaseDoseRateProperty(n, uc) -> handleNav (navigate.setRateDec (n, uc))
-            | SetMedianDoseRateProperty -> handleNav navigate.setRateMed
-            | IncreaseDoseRateProperty(n, uc) -> handleNav (navigate.setRateInc (n, uc))
-            | SetMaxDoseRateProperty -> handleNav navigate.setRateMax
+            | SetMinDoseRateProperty -> handleNav stepper.setRateMin
+            | DecreaseDoseRateProperty(n, uc) -> handleNav (stepper.setRateDec (n, uc))
+            | SetMedianDoseRateProperty -> handleNav stepper.setRateMed
+            | IncreaseDoseRateProperty(n, uc) -> handleNav (stepper.setRateInc (n, uc))
+            | SetMaxDoseRateProperty -> handleNav stepper.setRateMax
 
             // Dose Quantity navigation
-            | SetMinDoseQuantityProperty -> handleNav navigate.setDoseQtyMin
-            | DecreaseDoseQuantityProperty(n, uc) -> handleNav (navigate.setDoseQtyDec (n, uc))
-            | SetMedianDoseQuantityProperty -> handleNav navigate.setDoseQtyMed
-            | IncreaseDoseQuantityProperty(n, uc) -> handleNav (navigate.setDoseQtyInc (n, uc))
-            | SetMaxDoseQuantityProperty -> handleNav navigate.setDoseQtyMax
+            | SetMinDoseQuantityProperty -> handleNav stepper.setDoseQtyMin
+            | DecreaseDoseQuantityProperty(n, uc) -> handleNav (stepper.setDoseQtyDec (n, uc))
+            | SetMedianDoseQuantityProperty -> handleNav stepper.setDoseQtyMed
+            | IncreaseDoseQuantityProperty(n, uc) -> handleNav (stepper.setDoseQtyInc (n, uc))
+            | SetMaxDoseQuantityProperty -> handleNav stepper.setDoseQtyMax
 
             // Component Quantity navigation
-            | SetMinComponentQuantityProperty cmp -> handleNavWithCmp cmp navigate.setComponentQtyMin
-            | DecreaseComponentQuantityProperty(cmp, n, uc) ->
-                handleNavWithCmp cmp (navigate.setComponentQtyDec (n, uc))
-            | SetMedianComponentQuantityProperty cmp -> handleNavWithCmp cmp navigate.setComponentQtyMed
-            | IncreaseComponentQuantityProperty(cmp, n, uc) ->
-                handleNavWithCmp cmp (navigate.setComponentQtyInc (n, uc))
-            | SetMaxComponentQuantityProperty cmp -> handleNavWithCmp cmp navigate.setComponentQtyMax
+            | SetMinComponentQuantityProperty cmp -> handleNavWithCmp cmp stepper.setComponentQtyMin
+            | DecreaseComponentQuantityProperty(cmp, n, uc) -> handleNavWithCmp cmp (stepper.setComponentQtyDec (n, uc))
+            | SetMedianComponentQuantityProperty cmp -> handleNavWithCmp cmp stepper.setComponentQtyMed
+            | IncreaseComponentQuantityProperty(cmp, n, uc) -> handleNavWithCmp cmp (stepper.setComponentQtyInc (n, uc))
+            | SetMaxComponentQuantityProperty cmp -> handleNavWithCmp cmp stepper.setComponentQtyMax
 
 
     open Elmish
@@ -715,7 +713,7 @@ module Nutrition =
             Api.NavigateNutritionOrderContext(planRef.current, ncId, Api.ResetOrderScenario, ctx)
             |> props.nutritionPlanMsg
 
-        let navigate =
+        let stepper =
             let create nav =
                 fun (ol: OrderLoader) ->
                     let updCtx =
@@ -844,7 +842,7 @@ module Nutrition =
             |}
 
         let state, dispatch =
-            React.useElmish (init (Resolved ctx), update updateOrderScenario resetOrderScenario navigate, [| box ctx |])
+            React.useElmish (init (Resolved ctx), update updateOrderScenario resetOrderScenario stepper, [| box ctx |])
 
         let isOrderLoading = props.isRecalculating
         let isLoading = state.Order.IsNone && not props.isRecalculating
@@ -868,6 +866,7 @@ module Nutrition =
                     // Quantity control (bereiding)
                     let qtyVals = cmp.OrderableQuantity |> ViewHelpers.ovarValsWithRange string 3
 
+                    // can jump to the min, median, or max
                     let navigable = cmp.OrderableQuantity |> OrderVariable.isNavigable
                     let solved = ord |> isSolved
 
@@ -885,7 +884,7 @@ module Nutrition =
                         else
                             let cmpName = cmp.Name
 
-                            ViewHelpers.createNav
+                            ViewHelpers.createStepper
                                 dispatch
                                 revision
                                 navigable
@@ -967,7 +966,7 @@ module Nutrition =
                 let vals = ord.Orderable.Dose.Quantity |> ViewHelpers.ovarValsWithRange string 3
 
                 let doseQtyNav =
-                    ViewHelpers.createDoseQtyNav
+                    ViewHelpers.createDoseQtyStepper
                         dispatch
                         revision
                         ord
@@ -1077,10 +1076,11 @@ module Nutrition =
             match displayOrder with
             | Some ord when ord.Schedule.IsTimed || ord.Schedule.IsContinuous ->
                 let solved = ord |> isSolved
+                // can jump to the min, median, or max
                 let navigable = ord.Orderable.Dose.Rate |> OrderVariable.isNavigable
 
                 let nav =
-                    ViewHelpers.createNav
+                    ViewHelpers.createStepper
                         dispatch
                         revision
                         navigable

--- a/src/Informedica.GenPRES.Client/Views/Order.fs
+++ b/src/Informedica.GenPRES.Client/Views/Order.fs
@@ -119,7 +119,7 @@ module Order =
         let update
             updateOrderScenario
             resetOrderScenario
-            (navigate:
+            (stepper:
                 {|
                     setFreqMin: OrderLoader -> unit
                     setFreqDec: OrderLoader -> unit
@@ -562,29 +562,29 @@ module Order =
                 | _ -> state, Cmd.none
 
             // == Frequency ==
-            | SetMinFrequencyProperty -> handleNav navigate.setFreqMin
-            | DecreaseFrequencyProperty -> handleNav navigate.setFreqDec
-            | SetMedianFrequencyProperty -> handleNav navigate.setFreqMed
-            | IncreaseFrequencyProperty -> handleNav navigate.setFreqInc
-            | SetMaxFrequencyProperty -> handleNav navigate.setFreqMax
+            | SetMinFrequencyProperty -> handleNav stepper.setFreqMin
+            | DecreaseFrequencyProperty -> handleNav stepper.setFreqDec
+            | SetMedianFrequencyProperty -> handleNav stepper.setFreqMed
+            | IncreaseFrequencyProperty -> handleNav stepper.setFreqInc
+            | SetMaxFrequencyProperty -> handleNav stepper.setFreqMax
             // == Rate ==
-            | SetMinDoseRateProperty -> handleNav navigate.setRateMin
-            | DecreaseDoseRateProperty(n, uc) -> handleNav (navigate.setRateDec (n, uc))
-            | SetMedianDoseRateProperty -> handleNav navigate.setRateMed
-            | IncreaseDoseRateProperty(n, uc) -> handleNav (navigate.setRateInc (n, uc))
-            | SetMaxDoseRateProperty -> handleNav navigate.setRateMax
+            | SetMinDoseRateProperty -> handleNav stepper.setRateMin
+            | DecreaseDoseRateProperty(n, uc) -> handleNav (stepper.setRateDec (n, uc))
+            | SetMedianDoseRateProperty -> handleNav stepper.setRateMed
+            | IncreaseDoseRateProperty(n, uc) -> handleNav (stepper.setRateInc (n, uc))
+            | SetMaxDoseRateProperty -> handleNav stepper.setRateMax
             // == DoseQty ==
-            | SetMinDoseQuantityProperty -> handleNav navigate.setDoseQtyMin
-            | DecreaseDoseQuantityProperty(n, uc) -> handleNav (navigate.setDoseQtyDec (n, uc))
-            | SetMedianDoseQuantityProperty -> handleNav navigate.setDoseQtyMed
-            | IncreaseDoseQuantityProperty(n, uc) -> handleNav (navigate.setDoseQtyInc (n, uc))
-            | SetMaxDoseQuantityProperty -> handleNav navigate.setDoseQtyMax
+            | SetMinDoseQuantityProperty -> handleNav stepper.setDoseQtyMin
+            | DecreaseDoseQuantityProperty(n, uc) -> handleNav (stepper.setDoseQtyDec (n, uc))
+            | SetMedianDoseQuantityProperty -> handleNav stepper.setDoseQtyMed
+            | IncreaseDoseQuantityProperty(n, uc) -> handleNav (stepper.setDoseQtyInc (n, uc))
+            | SetMaxDoseQuantityProperty -> handleNav stepper.setDoseQtyMax
             // == ComponentQty ==
-            | SetMinComponentQuantityProperty -> handleNav navigate.setComponentQtyMin
-            | DecreaseComponentQuantityProperty(n, uc) -> handleNav (navigate.setComponentQtyDec (n, uc))
-            | SetMedianComponentQuantityProperty -> handleNav navigate.setComponentQtyMed
-            | IncreaseComponentQuantityProperty(n, uc) -> handleNav (navigate.setComponentQtyInc (n, uc))
-            | SetMaxComponentQuantityProperty -> handleNav navigate.setComponentQtyMax
+            | SetMinComponentQuantityProperty -> handleNav stepper.setComponentQtyMin
+            | DecreaseComponentQuantityProperty(n, uc) -> handleNav (stepper.setComponentQtyDec (n, uc))
+            | SetMedianComponentQuantityProperty -> handleNav stepper.setComponentQtyMed
+            | IncreaseComponentQuantityProperty(n, uc) -> handleNav (stepper.setComponentQtyInc (n, uc))
+            | SetMaxComponentQuantityProperty -> handleNav stepper.setComponentQtyMax
 
 
         let showOrderName (ord: Order option) =
@@ -649,7 +649,7 @@ module Order =
             {|
                 orderContext: Deferred<OrderContext>
                 updateOrderScenario: OrderContext -> unit
-                navigateOrderScenario:
+                stepOrderScenario:
                     {|
                         // Frequency
                         setMinFrequency: OrderContext -> unit
@@ -737,7 +737,7 @@ module Order =
                 |> props.refreshOrderScenario
             | _ -> ()
 
-        let navigate =
+        let stepper =
             let create nav =
                 fun (ol: OrderLoader) ->
                     match props.orderContext with
@@ -839,35 +839,35 @@ module Order =
 
             {|
                 // Frequency
-                setFreqMin = create props.navigateOrderScenario.setMinFrequency
-                setFreqDec = create props.navigateOrderScenario.decrFrequency
-                setFreqMed = create props.navigateOrderScenario.setMedianFrequency
-                setFreqInc = create props.navigateOrderScenario.incrFrequency
-                setFreqMax = create props.navigateOrderScenario.setMaxFrequency
+                setFreqMin = create props.stepOrderScenario.setMinFrequency
+                setFreqDec = create props.stepOrderScenario.decrFrequency
+                setFreqMed = create props.stepOrderScenario.setMedianFrequency
+                setFreqInc = create props.stepOrderScenario.incrFrequency
+                setFreqMax = create props.stepOrderScenario.setMaxFrequency
                 // Dose Rate
-                setRateMin = create props.navigateOrderScenario.setMinRate
-                setRateDec = createWithN props.navigateOrderScenario.decrRate
-                setRateMed = create props.navigateOrderScenario.setMedianRate
-                setRateInc = createWithN props.navigateOrderScenario.incrRate
-                setRateMax = create props.navigateOrderScenario.setMaxRate
+                setRateMin = create props.stepOrderScenario.setMinRate
+                setRateDec = createWithN props.stepOrderScenario.decrRate
+                setRateMed = create props.stepOrderScenario.setMedianRate
+                setRateInc = createWithN props.stepOrderScenario.incrRate
+                setRateMax = create props.stepOrderScenario.setMaxRate
                 // Dose Quantity
-                setDoseQtyMin = create props.navigateOrderScenario.setMinDoseQty
-                setDoseQtyDec = createWithN props.navigateOrderScenario.decrDoseQty
-                setDoseQtyMed = create props.navigateOrderScenario.setMedianDoseQty
-                setDoseQtyInc = createWithN props.navigateOrderScenario.incrDoseQty
-                setDoseQtyMax = create props.navigateOrderScenario.setMaxDoseQty
+                setDoseQtyMin = create props.stepOrderScenario.setMinDoseQty
+                setDoseQtyDec = createWithN props.stepOrderScenario.decrDoseQty
+                setDoseQtyMed = create props.stepOrderScenario.setMedianDoseQty
+                setDoseQtyInc = createWithN props.stepOrderScenario.incrDoseQty
+                setDoseQtyMax = create props.stepOrderScenario.setMaxDoseQty
                 // Component Quantity
-                setComponentQtyMin = createWithCmp props.navigateOrderScenario.setMinComponentQty
-                setComponentQtyDec = createWithCmpN props.navigateOrderScenario.decrComponentQty
-                setComponentQtyMed = createWithCmp props.navigateOrderScenario.setMedianComponentQty
-                setComponentQtyInc = createWithCmpN props.navigateOrderScenario.incrComponentQty
-                setComponentQtyMax = createWithCmp props.navigateOrderScenario.setMaxComponentQty
+                setComponentQtyMin = createWithCmp props.stepOrderScenario.setMinComponentQty
+                setComponentQtyDec = createWithCmpN props.stepOrderScenario.decrComponentQty
+                setComponentQtyMed = createWithCmp props.stepOrderScenario.setMedianComponentQty
+                setComponentQtyInc = createWithCmpN props.stepOrderScenario.incrComponentQty
+                setComponentQtyMax = createWithCmp props.stepOrderScenario.setMaxComponentQty
             |}
 
         let state, dispatch =
             React.useElmish (
                 init props.orderContext,
-                update updateOrderScenario resetOrderScenario navigate,
+                update updateOrderScenario resetOrderScenario stepper,
                 [| box props.orderContext |]
             )
 
@@ -1108,7 +1108,7 @@ module Order =
                        |> Option.map (fun v -> v.Value |> Array.isEmpty |> not)
                        |> Option.defaultValue false
                 // orderable dose rate: shown when continuous/timed/onceTimed
-                // (navigate is always Some, so select renders even with empty vals)
+                // (stepper is always Some, so select renders even with empty vals)
                 let hasDoseRate =
                     ord.Schedule.IsContinuous || ord.Schedule.IsTimed || ord.Schedule.IsOnceTimed
                 // administration time: shown when has vals
@@ -1162,7 +1162,7 @@ module Order =
                 null
 
         let content =
-            let createNav = ViewHelpers.createNav dispatch revision
+            let createStepper = ViewHelpers.createStepper dispatch revision
 
             let contentSx =
                 {|
@@ -1297,7 +1297,7 @@ module Order =
                 | _ -> null
 
             let substRateSelect =
-                let navigate = None
+                let stepper = None
 
                 match substIndx, displayOrder with
                 | Some i, Some ord when ord.Schedule.IsContinuous && itms |> Array.length > 0 ->
@@ -1327,7 +1327,7 @@ module Order =
                         (Terms.``Order Adjusted dose`` |> getTerm "dosering")
                         None
                         dispatch
-                        navigate
+                        stepper
                         true
                         warning
                         None
@@ -1347,7 +1347,7 @@ module Order =
                         |> Option.map (_.OrderableQuantity >> ViewHelpers.ovarValsWithRange string 3)
                         |> Option.defaultValue [||]
 
-                    let navigate =
+                    let stepper =
                         let c = vals |> Array.length
 
                         let show =
@@ -1364,12 +1364,13 @@ module Order =
                         else
                             let solved = ord |> isSolved
 
+                            // can jump to the min, median, or max
                             let navigable =
                                 cmp
                                 |> Option.map (_.OrderableQuantity >> OrderVariable.isNavigable)
                                 |> Option.defaultValue false
 
-                            createNav
+                            createStepper
                                 navigable
                                 solved
                                 SetMinComponentQuantityProperty
@@ -1387,7 +1388,7 @@ module Order =
                         "bereiding hoeveelheid"
                         None
                         (ChangeComponentOrderableQuantity >> dispatch)
-                        navigate
+                        stepper
                         false
                         warning
                         None
@@ -1528,14 +1529,15 @@ module Order =
                 | Some ord when ord.Schedule.IsDiscontinuous || ord.Schedule.IsTimed ->
                     let xs = ord.Schedule.Frequency |> ViewHelpers.ovarVals string
 
-                    let navigate =
+                    let stepper =
                         if xs |> Array.length <> 1 then
                             None
                         else
                             let solved = ord |> isSolved
+                            // frequency: no jump to the min, median, or max
                             let navigable = false
 
-                            createNav
+                            createStepper
                                 navigable
                                 solved
                                 SetMinFrequencyProperty
@@ -1552,7 +1554,7 @@ module Order =
                         (Terms.``Order Frequency`` |> getTerm "frequentie")
                         None
                         (ChangeFrequency >> dispatch)
-                        navigate
+                        stepper
                         false
                         warning
                         None
@@ -1562,8 +1564,8 @@ module Order =
             let ordDoseQtySelect =
                 match displayOrder with
                 | Some ord when ord.Schedule.IsContinuous |> not ->
-                    let navigate =
-                        ViewHelpers.createDoseQtyNav
+                    let stepper =
+                        ViewHelpers.createDoseQtyStepper
                             dispatch
                             revision
                             ord
@@ -1582,7 +1584,7 @@ module Order =
                         "toedien hoeveelheid"
                         None
                         (ChangeOrderableDoseQuantity >> dispatch)
-                        navigate
+                        stepper
                         false
                         warning
                         None
@@ -1592,10 +1594,11 @@ module Order =
                 match displayOrder with
                 | Some ord when ord.Schedule.IsContinuous || ord.Schedule.IsTimed || ord.Schedule.IsOnceTimed ->
                     let solved = ord |> isSolved
+                    // can jump to the min, median, or max
                     let navigable = ord.Orderable.Dose.Rate |> OrderVariable.isNavigable
 
-                    let navigate =
-                        createNav
+                    let stepper =
+                        createStepper
                             navigable
                             solved
                             SetMinDoseRateProperty
@@ -1614,7 +1617,7 @@ module Order =
                         (Terms.``Order Drip rate`` |> getTerm "inloop snelheid")
                         None
                         (ChangeOrderableDoseRate >> dispatch)
-                        navigate
+                        stepper
                         false
                         warning
                         None
@@ -1639,6 +1642,8 @@ module Order =
                         None
                 | _ -> null
 
+            let titleSlotProps = {| title = {| variant = "h6" |} |}
+
             JSX.jsx
                 $"""
             import CardHeader from '@mui/material/CardHeader';
@@ -1651,7 +1656,7 @@ module Order =
             <CardHeader
                 sx = {headerSx}
                 title={displayOrder |> showOrderName}
-                slotProps={ {| title = {| variant = "h6" |} |} }
+                slotProps={titleSlotProps}
             ></CardHeader>
             <CardContent sx={contentSx}>
                 <Stack direction={"column"} spacing={if isMobile then 1.5 else 3} >

--- a/src/Informedica.GenPRES.Client/Views/OrderPlan.fs
+++ b/src/Informedica.GenPRES.Client/Views/OrderPlan.fs
@@ -306,7 +306,7 @@ module OrderPlan =
         let refreshOrderScenario (ctx: OrderContext) =
             orderContextMsg (Api.ResetOrderScenario, ctx)
 
-        let navigateOrderScenario =
+        let stepOrderScenario =
             {|
                 // Frequency
                 setMinFrequency = fun ctx -> orderContextMsg (Api.SetMinScheduleFrequencyProperty, ctx)
@@ -395,7 +395,7 @@ module OrderPlan =
                 {|
                     orderContext = orderContext
                     updateOrderScenario = updateOrderScenario
-                    navigateOrderScenario = navigateOrderScenario
+                    stepOrderScenario = stepOrderScenario
                     refreshOrderScenario = refreshOrderScenario
                     closeOrder = handleModalClose
                     localizationTerms = localizationTerms

--- a/src/Informedica.GenPRES.Client/Views/Patient.fs
+++ b/src/Informedica.GenPRES.Client/Views/Patient.fs
@@ -183,20 +183,19 @@ module Patient =
                     isExpanded |> not |> setExpanded
 
         let createSelect label sel changeValue vs =
-            Components.SimpleSelect.View(
+            Components.SimpleSelect.View
                 {|
                     label = label
                     selected = sel |> Option.map string
                     values = vs
                     updateSelected = changeValue
-                    navigate = None
+                    stepper = None
                     isLoading = false
                     disabled = false
                     hasClear = true
                     warning = None
                     minWidth = None
                 |}
-            )
 
         let wghts =
             [| 21000..1000..100000 |]
@@ -382,12 +381,15 @@ module Patient =
                         )
             |]
             |> Array.map (fun el ->
+                let gridSize =
+                    {|
+                        xs = 6
+                        lg = 2
+                    |}
+
                 JSX.jsx
                     $"""
-                <Grid size = { {|
-                                   xs = 6
-                                   lg = 2
-                               |} }>{el}</Grid>
+                <Grid size={gridSize}>{el}</Grid>
                 """
             )
 
@@ -437,13 +439,16 @@ module Patient =
 
             |]
             |> Array.map (fun el ->
+                let gridSize =
+                    {|
+                        xs = 6
+                        md = 4
+                        lg = 4
+                    |}
+
                 JSX.jsx
                     $"""
-                <Grid size = { {|
-                                   xs = 6
-                                   md = 4
-                                   lg = 4
-                               |} }>{el}</Grid>
+                <Grid size={gridSize}>{el}</Grid>
                 """
             )
 

--- a/src/Informedica.GenPRES.Client/Views/Prescribe.fs
+++ b/src/Informedica.GenPRES.Client/Views/Prescribe.fs
@@ -128,7 +128,7 @@ module Prescribe =
         let select = ViewHelpers.filterSelect isAnythingLoading
 
         let multiSelect isLoading lbl selected dispatch xs =
-            Components.MultipleSelect.View(
+            Components.MultipleSelect.View
                 {|
                     updateSelected = dispatch
                     label = lbl
@@ -137,7 +137,6 @@ module Prescribe =
                     isLoading = isLoading
                     disabled = isAnythingLoading
                 |}
-            )
 
         let autoComplete = ViewHelpers.autoComplete isAnythingLoading
 
@@ -502,7 +501,7 @@ module Prescribe =
                          {|
                              orderContext = orderContext
                              updateOrderScenario = fun ctx -> orderContextMsg (Api.UpdateOrderScenario, ctx)
-                             navigateOrderScenario =
+                             stepOrderScenario =
                                  {|
                                      // Frequency
                                      setMinFrequency = fun ctx -> orderContextMsg (Api.SetMinScheduleFrequencyProperty, ctx)

--- a/src/Informedica.GenPRES.Client/Views/Totals.fs
+++ b/src/Informedica.GenPRES.Client/Views/Totals.fs
@@ -122,12 +122,11 @@ module Totals =
             columns
             |> Array.mapi (fun i col ->
                 $"table{i + 1}",
-                Components.BasicTable.View(
+                Components.BasicTable.View
                     {|
                         header = [||]
                         rows = mapRow props.intake col
                     |}
-                )
                 |> toReact
             )
 

--- a/src/Informedica.GenPRES.Client/Views/ViewHelpers.fs
+++ b/src/Informedica.GenPRES.Client/Views/ViewHelpers.fs
@@ -15,7 +15,7 @@ module ViewHelpers =
     let filterSelect disabled isLoading lbl selected dispatch xs =
         let isEmpty = xs |> Array.isEmpty
 
-        Components.SimpleSelect.View(
+        Components.SimpleSelect.View
             {|
                 updateSelected = if isEmpty then ignore else dispatch
                 label = lbl
@@ -24,11 +24,10 @@ module ViewHelpers =
                 isLoading = isLoading
                 disabled = disabled || isEmpty
                 hasClear = true
-                navigate = None
+                stepper = None
                 warning = None
                 minWidth = None
             |}
-        )
 
 
     let getWarning warning =
@@ -39,14 +38,14 @@ module ViewHelpers =
         | IsAlert -> Some Mui.Colors.Red.``700``
 
 
-    let orderSelect alwaysShow disabled isLoading lbl selected updateSelected navigate hasClear warning minWidth xs =
+    let orderSelect alwaysShow disabled isLoading lbl selected updateSelected stepper hasClear warning minWidth xs =
 
-        if not alwaysShow && xs |> Array.isEmpty && navigate |> Option.isNone then
+        if not alwaysShow && xs |> Array.isEmpty && stepper |> Option.isNone then
             null
         else
-            let isEmpty = xs |> Array.isEmpty && navigate |> Option.isNone
+            let isEmpty = xs |> Array.isEmpty && stepper |> Option.isNone
 
-            Components.SimpleSelect.View(
+            Components.SimpleSelect.View
                 {|
                     updateSelected = if isEmpty then ignore else updateSelected
                     label = lbl
@@ -60,13 +59,14 @@ module ViewHelpers =
                     disabled = disabled || isEmpty
                     hasClear = hasClear
                     warning = warning
-                    navigate = navigate
+                    stepper = stepper
                     minWidth = minWidth
                 |}
-            )
 
 
-    let createNav
+    /// Build the stepper record for a select. `navigable` = can jump to the min, median, or max
+    /// (gates the first/median/last buttons); `solved` enables single-step decrease/increase.
+    let createStepper
         dispatch
         revision
         navigable
@@ -255,7 +255,7 @@ module ViewHelpers =
         ovar |> stepsToCeiling ceiling largeIncr
 
 
-    /// Build the navigate record for the orderable dose-quantity select, shared by the Order
+    /// Build the stepper record for the orderable dose-quantity select, shared by the Order
     /// and Nutrition views. Handles the optimistic stepping with feasibility-ceiling
     /// saturation: the displayed value follows the click count up to the prepared orderable
     /// quantity, and dispatched steps are saturated at that ceiling so an overshoot is not
@@ -263,7 +263,7 @@ module ViewHelpers =
     /// are supplied by each view from its own Msg type. Returns None when navigation must be
     /// hidden (a multi-component orderable whose components do not each have a single distinct
     /// orderable quantity).
-    let createDoseQtyNav
+    let createDoseQtyStepper
         dispatch
         revision
         (ord: Order)
@@ -292,6 +292,7 @@ module ViewHelpers =
                    |> Option.defaultValue false
 
             let solved = ord |> isSolved
+            // can jump to the min, median, or max
             let navigable = ord.Orderable.Dose.Quantity |> OrderVariable.isNavigable
 
             // For a multi-component orderable the dose quantity cannot exceed the prepared
@@ -392,7 +393,7 @@ module ViewHelpers =
     let autoComplete disabled isLoading lbl selected dispatch xs =
         let isEmpty = xs |> Array.isEmpty
 
-        Components.Autocomplete.View(
+        Components.Autocomplete.View
             {|
                 updateSelected = if isEmpty then ignore else dispatch
                 label = lbl
@@ -401,7 +402,6 @@ module ViewHelpers =
                 isLoading = isLoading
                 disabled = disabled || isEmpty
             |}
-        )
 
 
     let inlineProgress isLoading =


### PR DESCRIPTION
# refactor(ui): stepper rename, JSX/record cleanup, and layout tweak

## Summary

Client-only (UI) housekeeping pass over the prescribing/nutrition views plus one small
layout improvement. No behavioural change except the nutrition section-divider tweak.
All edits are in `src/Informedica.GenPRES.Client/` — no `Shared`, `Server`, or `Lib`
changes, and no API/DU renames.

13 files changed across 3 commits.

## Changes

### 1. `navigate` → `stepper` rename (refactor)

The `SimpleSelect` stepper control was named `navigate`, which read as a verb and was
inconsistent with everything derived from it. Renamed the concept to `stepper`:

- `SimpleSelect.View`'s `navigate` prop → `stepper`; builders `createNav` → `createStepper`,
  `createDoseQtyNav` → `createDoseQtyStepper`; `orderSelect` threading param.
- Internal dispatch record `let navigate` + each `update` param → `stepper` (Order.fs, Nutrition.fs).
- Cross-component prop `navigateOrderScenario` → `stepOrderScenario` (Order.fs, OrderPlan.fs, Prescribe.fs).
- Inner field names left unchanged; the `SimpleSelect` component name was kept (it's also used
  as a plain select with `stepper = None`).

### 2. JSX & anonymous-record cleanup (refactor)

- Removed redundant parens around single anonymous-record args in 11 `Component.View(...)`
  call sites (`Func( {| … |} )` → `Func {| … |}`).
- Extracted inline multiline anonymous records out of `JSX.jsx` templates into named `let`
  bindings (per the project Fable-JSX rule): `App` (genPresProps), `Localization` (menuOrigin),
  `ResponsiveTable` (columnSpacing), `SimpleSelect` (menuItemSx), `Patient` (gridSize),
  `ContinuousMeds`/`EmergencyList` (boxSx/tableProps/printDialogProps), `Order` (titleSlotProps).
- Extracted the inline median `IconButton` in `SimpleSelect` into a named `medianButton`
  binding, matching the other four button bindings.

### 3. Nutrition section layout (feat)

In the parenteral/nutrition view, the **bereiding** and **dosering** column headers now render
as centered `<Divider>` labels, matching the existing **toediening** section divider.

### 4. Flatten nested copy-and-update literals (refactor)

Replaced verbose nested record updates (`{ ord with Orderable = { ord.Orderable with … } }`)
with F#'s dotted-path copy-and-update syntax (`{ ord with Order.Orderable.Components = … }`),
matching the convention already used across `Order.fs`/`Prescribe.fs`/`Patient.fs`:

- The two component-array handlers in `Nutrition.fs`'s `update`.
- The `OrderContext.empty` / `Filter` initialisation in `App.fs`.

### 5. Clarifying comments / docs

- Added `// can jump to the min, median, or max` at every `navigable` site (and the negative
  form at the hardcoded-`false` frequency case), since `navigable` is easy to misread.
- Added a `///` doc on `createStepper` documenting what `navigable` and `solved` control.
- Confirmed `navigable` is the correct, domain-aligned term (mirrors `Shared`'s `isNavigable`,
  distinct from `Stepable`) — deliberately **not** renamed.

## Verification

- `dotnet run Build` — green (0 warnings, 0 errors); the Client project type-checks the
  anonymous-record props, so a missed rename would fail the build.
- Fable compile + inspection of generated `output/**/*.jsx` artifacts to confirm the JSX-template
  edits (paren removal, extracted records) emit identical structure.
- Manual smoke-test of the stepper controls and the nutrition view.

## Scope & safety

- UI-layer only; no dosing/rule/parsing/resource logic touched. No changelog or
  `0003-resource-requirements.md` update needed.

## AI-assisted contribution

- **Vibe coded:** yes — the refactors, JSX/record extractions, and comments were generated with
  AI assistance (Claude Code), confined to client UI `.fs` files per the project's LLM policy.
- **Verification:** `dotnet run Build`, Fable compilation, generated-artifact inspection, and
  manual review of every diff.
