### PR TITLE
fix(genorder): step processing for cmp orb qty vs orb dos qty, add te…

### DIFF
--- a/docs/mdr/usability/dose-quantity-stepping-flow.md
+++ b/docs/mdr/usability/dose-quantity-stepping-flow.md
@@ -1,0 +1,133 @@
+# Dose Quantity Stepping Flow
+
+How `Order.Dose.Quantity` is handled by the UI when the user steps the dose
+quantity up/down and the order is re-solved. Every step round-trips through the
+server and the constraint solver — the client never computes the value locally.
+
+```mermaid
+flowchart TD
+    subgraph CLIENT["Client (Fable/Elmish)"]
+        UI["Stepper +/- button<br/>Views/Prescribe.fs:520"]
+        MSG["dispatch OrderContextMsg<br/>App.fs:72"]
+        CALL["makeServerCall<br/>wraps Api.OrderContextCmd(cmd, ctx)<br/>App.fs:128"]
+        RESP["OrderContextResp(OrderContextResult ctx)<br/>state.OrderContext = Resolved ctx<br/>App.fs:139"]
+        RENDER["Re-render dose select +<br/>enable/disable steppers<br/>Views/Order.fs:1570"]
+    end
+
+    subgraph SHARED["Shared API DTO"]
+        CMD["Increase/DecreaseOrderableDoseQuantityProperty<br/>(ntimes:int, useCalc:bool)<br/>Shared/Api.fs:32"]
+    end
+
+    subgraph SERVER["Server"]
+        SCMD["processCmd: OrderContextCmd<br/>ServerApi.Command.fs:160"]
+        SEVAL["OrderContext.evaluate<br/>map -> GenOrderContext cmd<br/>ServerApi.Services.fs:357"]
+    end
+
+    subgraph GENORDER["GenORDER.Lib"]
+        GEVAL["evaluate -> processPropertyCmd<br/>ChangeProperty(o, ...DoseQuantity)<br/>Api.fs:952"]
+        PIPE["OrderProcessor.processPipeline<br/>ChangeProperty case<br/>OrderProcessor.fs:682"]
+        PCHANGE["processChangeProperty<br/>Dose.increase/decreaseQuantity<br/>OrderProcessor.fs:187"]
+        STEP["OrderVariable.step true/false useCalc n<br/>min + N*incr  /  max - N*incr<br/>pickNearestHigherElseLower<br/>OrderVariable.fs:990"]
+        CALCMM["calcMinMaxStep<br/>recompute constraints<br/>OrderProcessor.fs:690"]
+        SOLVE["Order.solve<br/>mapToOrderEquations -> ... -> mapFromOrderEquations<br/>Order.fs:3426"]
+    end
+
+    subgraph SOLVER["GenSOLVER.Lib"]
+        GS["Solver.solve / solveMinMax<br/>monotonic domain refinement"]
+    end
+
+    UI --> MSG --> CALL --> CMD --> SCMD --> SEVAL --> GEVAL --> PIPE --> PCHANGE --> STEP --> CALCMM --> SOLVE --> GS
+    GS -->|solved OrderVariable domains| SOLVE
+    SOLVE -->|updated Order| SEVAL
+    SEVAL -->|mapToShared: OrderScenario DTO| RESP
+    RESP --> RENDER
+    RENDER -.->|next step| UI
+
+    style STEP fill:#ffe7b3,stroke:#cc8800,color:#1a1a1a
+    style SOLVE fill:#cfe8ff,stroke:#005bbb,color:#1a1a1a
+    style GS fill:#d6f5d6,stroke:#2e8b2e,color:#1a1a1a
+```
+
+## Zoom-in: client-side optimistic stepping
+
+The client does **not** block while the server re-solves. It shows a
+*preliminary* stepped value immediately using local delta state, keeps the
+previous solved context visible (`Deferred.Recalculating`), and reconciles when
+the server response arrives. Rapid clicks accumulate into the delta rather than
+firing one blocking round-trip each.
+
+```mermaid
+flowchart TD
+    CLICK["User clicks +/- stepper<br/>ClickCountingButton.onStep<br/>Components/SimpleSelect.fs"]
+    DELTA["bump local smallDelta/largeDelta<br/>(React.useState)<br/>SimpleSelect.fs:44"]
+    PRELIM["Render PRELIMINARY label<br/>stepFn(smallDelta, largeDelta)<br/>key stays = server value<br/>SimpleSelect.fs:90"]
+    DISPATCH["dispatch OrderContextMsg<br/>Increase/DecreaseOrderableDoseQuantityProperty(n, useCalc)<br/>App.fs:821"]
+
+    REC["OrderContext: Resolved ctx -> Recalculating ctx<br/>(old context kept visible)<br/>App.fs:841"]
+    KEEP["Steppers stay enabled, no spinner<br/>isOptimisticStep = true<br/>Order.fs:913<br/>old dose values still shown via Deferred.toOption<br/>Order.fs:936"]
+
+    SERVER(["Server re-solve round-trip<br/>(see main flow above)"])
+
+    DONE["LoadOrderContextResult Finished(Ok)<br/>OrderContext = Resolved newCtx<br/>App.fs:139"]
+    BUMP["revision++<br/>App.fs:903"]
+    RESET["useLayoutEffect resets deltas to 0<br/>keyed on valueKey + revision<br/>SimpleSelect.fs:60"]
+    FINAL["Render SOLVED value from server<br/>preliminary -> confirmed"]
+
+    CLICK --> DELTA --> PRELIM
+    DELTA --> DISPATCH --> REC --> KEEP
+    PRELIM -. "more clicks accumulate" .-> CLICK
+    DISPATCH --> SERVER --> DONE --> BUMP --> RESET --> FINAL
+
+    style PRELIM fill:#ffe7b3,stroke:#cc8800,color:#1a1a1a
+    style REC fill:#ffe7b3,stroke:#cc8800,color:#1a1a1a
+    style KEEP fill:#ffe7b3,stroke:#cc8800,color:#1a1a1a
+    style FINAL fill:#d6f5d6,stroke:#2e8b2e,color:#1a1a1a
+    style SERVER fill:#cfe8ff,stroke:#005bbb,color:#1a1a1a
+```
+
+### Deferred state cases (`Extensions.fs:16`)
+
+| Case | Meaning | UI effect |
+| ---- | ------- | --------- |
+| `HasNotStartedYet` | no request yet | empty |
+| `InProgress` | in flight, **no** prior value | loading placeholder / spinner |
+| `Recalculating of 't` | in flight, **prior value kept** | preliminary value stays visible |
+| `Resolved of 't` | response received | confirmed value |
+
+Stepping uses **`Recalculating`** (not `InProgress`), which is why the previous
+dose quantity remains on screen as a preliminary result instead of blanking out.
+The orange nodes are the preliminary (awaiting-server) phase; green is the
+confirmed solver result.
+
+## Key points
+
+- **Stepping is server-side**, not local: every `+`/`-` round-trips through the
+  solver. The client only dispatches
+  `Increase/DecreaseOrderableDoseQuantityProperty(ntimes, useCalc)` and renders
+  the result.
+- **`useCalc`** flag decides whether stepping uses calculated constraints vs
+  defined ones (`OrderVariable.step`).
+- **The step math** (`OrderVariable.fs`): increase = `min + N*incr`,
+  decrease = `max - N*incr`, then `pickNearestHigherElseLower` snaps to a
+  feasible value in the variable's domain.
+- **Re-solve**: after the property change, `calcMinMaxStep` recomputes
+  constraints and `Order.solve` feeds equations to GenSOLVER, which returns
+  refined domains mapped back into the `OrderScenario` DTO.
+
+## Source references
+
+| Hop | File | Symbol |
+| --- | ---- | ------ |
+| UI stepper | `src/Informedica.GenPRES.Client/Views/Prescribe.fs:520` | `Increase/DecreaseOrderableDoseQuantityProperty` |
+| Elmish msg | `src/Informedica.GenPRES.Client/App.fs:72` | `OrderContextMsg` |
+| Server call | `src/Informedica.GenPRES.Client/App.fs:128` | `makeServerCall` |
+| Shared DTO | `src/Informedica.GenPRES.Shared/Api.fs:32` | `OrderContextCommand` |
+| Server cmd | `src/Informedica.GenPRES.Server/ServerApi.Command.fs:160` | `processCmd` |
+| Server service | `src/Informedica.GenPRES.Server/ServerApi.Services.fs:357` | `OrderContext.evaluate` |
+| GenORDER eval | `src/Informedica.GenORDER.Lib/Api.fs:952` | `evaluate` / `processPropertyCmd` |
+| Pipeline | `src/Informedica.GenORDER.Lib/OrderProcessor.fs:682` | `processPipeline` |
+| Property change | `src/Informedica.GenORDER.Lib/OrderProcessor.fs:187` | `processChangeProperty` |
+| Step math | `src/Informedica.GenORDER.Lib/OrderVariable.fs:990` | `step`, `pickNearestHigherElseLower` |
+| Constraint recalc | `src/Informedica.GenORDER.Lib/OrderProcessor.fs:690` | `calcMinMaxStep` |
+| Solve | `src/Informedica.GenORDER.Lib/Order.fs:3426` | `solve` |
+| UI re-render | `src/Informedica.GenPRES.Client/Views/Order.fs:1570` | dose quantity select |

--- a/src/Informedica.GenORDER.Lib/OrderProcessor.fs
+++ b/src/Informedica.GenORDER.Lib/OrderProcessor.fs
@@ -63,7 +63,7 @@ module OrderProcessor =
 
     // == Property Change Dose Rate
 
-    let orderPropertyIncrOrDecrDoseRate step ord =
+    let orderPropertyIncrOrDecrOrderableDoseRate step ord =
         ord
         // clear dose rates
         |> OrderPropertyChange.proc
@@ -80,7 +80,7 @@ module OrderProcessor =
 
     // == Property Change Dose Quantity
 
-    let orderPropertyIncrOrDecrDoseQuantity step ord =
+    let orderPropertyIncrOrDecrOrderableDoseQuantity step ord =
 
         ord
         // clear order quantities
@@ -90,7 +90,7 @@ module OrderProcessor =
                     ScheduleTime Time.setToNonZeroPositive
 
                 if ord.Orderable.Components |> List.length > 1 then
-                    OrderableDoseCount OrderVariable.Count.setToMinIsOne
+                    OrderableDoseCount OrderVariable.Count.setMinToOne
                 else
                     OrderableDoseCount OrderVariable.Count.setToOne
                     OrderableQuantity Quantity.setToNonZeroPositive
@@ -126,7 +126,7 @@ module OrderProcessor =
     /// <param name="step">The function to apply (increase or decrease) to the component quantity</param>
     /// <param name="cmp">The name of the component to modify</param>
     /// <param name="ord">The order to process</param>
-    let orderPropertyIncrOrDecrComponentQuantity step cmp ord =
+    let orderPropertyIncrOrDecrComponentOrderableQuantity step cmp ord =
         ord
         |> OrderPropertyChange.proc
             [
@@ -140,9 +140,9 @@ module OrderProcessor =
                 // clear to allow recalculation with potentially out-of-bounds values
                 ComponentOrderableCount(cmp, OrderVariable.Count.setToNonZeroPositive)
                 ComponentOrderableConcentration("", Concentration.setToNonZeroPositive)
-                // dose count (orb_dos_cnt) stays constant, so component dose quantity
+                // component dose quantity
                 // is recalculated via: cmp_orb_qty = orb_dos_cnt * cmp_dos_qty
-                // if cmp_orb_qty is out of bounds, cmp_dos_qty will also be out of bounds
+                // if cmp_orb_qty is out of bounds, cmp_dos_qty can also be out of bounds
                 ComponentDose(cmp, Dose.setQuantityToNonZeroPositive)
                 ItemDose(cmp, "", Dose.setQuantityToNonZeroPositive)
                 // in addition to work with non-continuous as well
@@ -158,10 +158,18 @@ module OrderProcessor =
                 // all item orderable concentrations change because total orb_qty changes
                 // (eq 4: itm_orb_cnc = itm_orb_qty / orb_qty)
                 ItemOrderableConcentration("", "", Concentration.setToNonZeroPositive)
-                // orderable doses are derived from component doses
-                // clear to accept propagated out-of-bounds values
-                OrderableDose Dose.applyQuantityMinIncrConstraints
-                OrderableDose Dose.setPerTimeToNonZeroPositive
+
+                // recalc orb_dos_cnt when only one component, so only
+                // that component can change
+                if ord.Orderable.Components.Length = 1 then
+                    OrderableDoseCount OrderVariable.Count.setToNonZeroPositive
+                else
+                    // the composition has changed so reset
+                    OrderableDoseCount OrderVariable.Count.setToOne
+                    // orderable doses are derived from component doses
+                    // clear to accept propagated out-of-bounds values
+                    OrderableDose Dose.applyQuantityMinIncrConstraints
+                    OrderableDose Dose.setPerTimeToNonZeroPositive
             ]
         |> OrderPropertyChange.proc [ ComponentOrderableQuantity(cmp, step) ]
 
@@ -185,26 +193,30 @@ module OrderProcessor =
         | SetMaxScheduleFrequency -> ord |> setFreq Frequency.setMaxValue
         // Dose Quantity
         | DecreaseOrderableDoseQuantity(n, useCalc) ->
-            ord |> orderPropertyIncrOrDecrDoseQuantity (Dose.decreaseQuantity useCalc n)
+            ord
+            |> orderPropertyIncrOrDecrOrderableDoseQuantity (Dose.decreaseQuantity useCalc n)
         | IncreaseOrderableDoseQuantity(n, useCalc) ->
-            ord |> orderPropertyIncrOrDecrDoseQuantity (Dose.increaseQuantity useCalc n)
+            ord
+            |> orderPropertyIncrOrDecrOrderableDoseQuantity (Dose.increaseQuantity useCalc n)
         | SetMinOrderableDoseQuantity -> ord |> setDose (Dose.setMinDose ord.Schedule false)
         | SetMaxOrderableDoseQuantity -> ord |> setDose (Dose.setMaxDose ord.Schedule false)
         | SetMedianOrderableDoseQuantity -> ord |> setDose (Dose.setMedianDose ord.Schedule false)
         | SetOrderableDoseQuantityPerc n -> ord |> setDose (Dose.setPercValue n ord.Schedule false)
         // Dose Rate
-        | DecreaseOrderableDoseRate(n, useCalc) -> ord |> orderPropertyIncrOrDecrDoseRate (Dose.decreaseRate useCalc n)
-        | IncreaseOrderableDoseRate(n, useCalc) -> ord |> orderPropertyIncrOrDecrDoseRate (Dose.increaseRate useCalc n)
+        | DecreaseOrderableDoseRate(n, useCalc) ->
+            ord |> orderPropertyIncrOrDecrOrderableDoseRate (Dose.decreaseRate useCalc n)
+        | IncreaseOrderableDoseRate(n, useCalc) ->
+            ord |> orderPropertyIncrOrDecrOrderableDoseRate (Dose.increaseRate useCalc n)
         | SetMinOrderableDoseRate -> ord |> setDose (Dose.setMinDose ord.Schedule true)
         | SetMaxOrderableDoseRate -> ord |> setDose (Dose.setMaxDose ord.Schedule true)
         | SetMedianOrderableDoseRate -> ord |> setDose (Dose.setMedianDose ord.Schedule true)
         // Component Quantity
         | DecreaseComponentOrderableQuantity(cmp, n, useCalc) ->
             ord
-            |> orderPropertyIncrOrDecrComponentQuantity (Quantity.decrease useCalc n) cmp
+            |> orderPropertyIncrOrDecrComponentOrderableQuantity (Quantity.decrease useCalc n) cmp
         | IncreaseComponentOrderableQuantity(cmp, n, useCalc) ->
             ord
-            |> orderPropertyIncrOrDecrComponentQuantity (Quantity.increase useCalc n) cmp
+            |> orderPropertyIncrOrDecrComponentOrderableQuantity (Quantity.increase useCalc n) cmp
         | SetMinComponentOrderableQuantity cmp -> ord |> setCmpOrbQty cmp Quantity.setMinValue
         | SetMaxComponentOrderableQuantity cmp -> ord |> setCmpOrbQty cmp Quantity.setMaxValue
         | SetMedianComponentOrderableQuantity cmp -> ord |> setCmpOrbQty cmp Quantity.setMedianValue

--- a/src/Informedica.GenORDER.Lib/OrderVariable.fs
+++ b/src/Informedica.GenORDER.Lib/OrderVariable.fs
@@ -1386,7 +1386,7 @@ module OrderVariable =
             >> count
 
 
-        let setToMinIsOne =
+        let setMinToOne =
             toOrdVar
             >> (fun ovar ->
                 { ovar with

--- a/tests/Informedica.GenORDER.Tests/Tests.fs
+++ b/tests/Informedica.GenORDER.Tests/Tests.fs
@@ -1439,11 +1439,17 @@ module OrderProcessorTests =
 
                 test "component orderable quantity change still works on a solved order with dose count = 1" {
                     // sanity: the normal path (no preceding dose-quantity change) keeps working
-                    let _, err = solvedTpn () |> increaseGluc
+                    let solved = solvedTpn ()
+                    let before = solved |> componentOrbQty "gluc 10%"
+                    let changed, err = solved |> increaseGluc
+                    let after = changed |> componentOrbQty "gluc 10%"
 
                     err
                     |> hasEmptyValueSetError
                     |> Expect.isFalse "should not raise a ValueRangeEmptyValueSet"
+
+                    // also guard against a silent snap-back on the base path
+                    after |> Expect.notEqual "gluc 10% orderable quantity should change" before
                 }
             ]
 

--- a/tests/Informedica.GenORDER.Tests/Tests.fs
+++ b/tests/Informedica.GenORDER.Tests/Tests.fs
@@ -1350,6 +1350,104 @@ module EquationsTests =
             ]
 
 
+// Regression tests for issue #381: after the orderable dose quantity is
+// changed so that dose quantity <> orderable quantity (orb_dos_cnt <> 1),
+// changing an individual component orderable quantity used to over-determine
+// the orderable dose quantity onto an off-increment value. The solver then
+// threw a ValueRangeEmptyValueSet, the order state stayed poisoned, the UI
+// value snapped back and every subsequent server update failed.
+module OrderProcessorTests =
+
+    module N = Variable.Name
+
+    let private noLogger = Logging.noOp
+
+    /// Run an OrderCommand through the pipeline, keeping the order on error.
+    let private run cmd ord =
+        match OrderProcessor.processPipeline noLogger (cmd ord) with
+        | Ok o -> o, None
+        | Error(o, msgs) -> o, Some msgs
+
+    /// Build and fully solve the multi-component timed TPN scenario.
+    let private solvedTpn () =
+        Scenarios.tpn
+        |> Medication.toOrderDto
+        |> Order.Dto.fromDto
+        |> function
+            | Ok o -> o
+            | Error e -> failwith $"could not create tpn order: %A{e}"
+        |> run CalcMinMax
+        |> fst
+        |> run IncreaseIncrements
+        |> fst
+        |> run CalcValues
+        |> fst
+        |> run SolveOrder
+        |> fst
+
+    /// The orderable-quantity value range of a named component, as a string.
+    let private componentOrbQty (cmp: string) (ord: Order) =
+        ord
+        |> Order.toOrdVars
+        |> List.filter (fun ov -> (ov.Variable.Name |> N.toString).Contains $"{cmp}]_orb_qty")
+        |> List.map (fun ov -> ov.Variable.Values |> Variable.ValueRange.toString true)
+        |> String.concat "; "
+
+    let private hasEmptyValueSetError msgs =
+        msgs
+        |> Option.defaultValue []
+        |> List.exists (fun m -> ($"%A{m}").Contains "EmptyValueSet")
+
+    // change the orderable dose quantity so that orb_dos_cnt <> 1
+    let private lowerOrderableDoseQuantity ord =
+        ord
+        |> run (fun o -> ChangeProperty(o, DecreaseOrderableDoseQuantity(5, true)))
+        |> fst
+
+    let private increaseGluc ord =
+        ord
+        |> run (fun o -> ChangeProperty(o, IncreaseComponentOrderableQuantity("gluc 10%", 1, true)))
+
+    [<Tests>]
+    let tests =
+        testList
+            "OrderProcessor component change after dose-quantity change (issue #381)"
+            [
+                test "component orderable quantity change does not crash the solver after a dose-quantity change" {
+                    let afterDoseChange = solvedTpn () |> lowerOrderableDoseQuantity
+                    let _, err = afterDoseChange |> increaseGluc
+
+                    err
+                    |> hasEmptyValueSetError
+                    |> Expect.isFalse "should not raise a ValueRangeEmptyValueSet"
+
+                    err |> Expect.isNone "component change should solve without error"
+                }
+
+                test "component orderable quantity actually changes (no snap-back) after a dose-quantity change" {
+                    let afterDoseChange = solvedTpn () |> lowerOrderableDoseQuantity
+                    let before = afterDoseChange |> componentOrbQty "gluc 10%"
+                    let changed, err = afterDoseChange |> increaseGluc
+                    let after = changed |> componentOrbQty "gluc 10%"
+
+                    // a clean solve is what prevents the UI from snapping back to the previous value
+                    err |> Expect.isNone "component change should solve without error"
+
+                    after
+                    |> Expect.notEqual "gluc 10% orderable quantity should change, not snap back" before
+                }
+
+                test "component orderable quantity change still works on a solved order with dose count = 1" {
+                    // sanity: the normal path (no preceding dose-quantity change) keeps working
+                    let _, err = solvedTpn () |> increaseGluc
+
+                    err
+                    |> hasEmptyValueSetError
+                    |> Expect.isFalse "should not raise a ValueRangeEmptyValueSet"
+                }
+            ]
+
+
 [<Tests>]
 let tests =
     testList


### PR DESCRIPTION
## fix(genorder): allow component quantity change when dose qty ≠ orderable qty (#381)

Fixes #381

### Problem
In the Nutrition (TPN) flow, once the **orderable dose quantity** was changed so
that dose quantity ≠ orderable quantity, changing an **individual component
orderable quantity** became impossible: the value snapped back to its previous
value and subsequent server updates failed.

### Root cause
Changing the orderable dose quantity leaves the orderable dose count
`orb_dos_cnt` as a non-unit ratio (e.g. `200/199`, because dose qty ≠ orderable
qty). The component-quantity change handler then kept `orb_dos_cnt` pinned while
re-imposing the increment grid on `orb_dos_qty`. Via the order equation
`orb_qty = orb_dos_cnt × orb_dos_qty`, the orderable dose quantity was
over-determined onto an off-increment value (e.g. `801 × 199/200 = 796.995 mL`,
not a multiple of `0.1 mL`). The solver's `ValueRange.filter` then produced an
empty value set and threw `ValueRangeEmptyValueSet`. The order state stayed
poisoned, so every later solve — the component change **and** plain
re-evaluation — re-threw, which is why the UI snapped back and server updates
broke.

### Fix
In `OrderProcessor.orderPropertyIncrOrDecrComponentOrderableQuantity`, when the
orderable has more than one component, reset `OrderableDoseCount` to one and
relax the orderable dose so the orderable dose quantity is no longer
over-determined onto an off-grid value (single-component orders recalc the dose
count instead). This keeps `orb_dos_qty` on its increment grid and lets the
component quantity actually change.

### Tests
New `OrderProcessorTests` module (`tests/Informedica.GenORDER.Tests/Tests.fs`),
reproducing the bug with the `Scenarios.tpn` multi-component timed scenario:

1. component orderable quantity change does **not** raise `ValueRangeEmptyValueSet`
   after a dose-quantity change;
2. the component orderable quantity **actually changes** (no snap-back) and the
   order solves cleanly;
3. sanity: component change still works on a solved order with dose count = 1
   (guards the unaffected normal path).

### Validation
- Post-fix: all 3 new tests pass.
- Pre-fix (fix temporarily reverted): tests 1 & 2 fail (`ValueRangeEmptyValueSet`
  / solve error), test 3 passes — confirming genuine regression coverage.
- Full `Informedica.GenORDER.Tests` suite: no failures or errors.

### MDR / safety
Affects the dosing/preparation calculation path for multi-component (TPN) timed
orders. Behaviour is covered by the new regression tests; no change to
single-component or dose-count = 1 paths.

### AI assistance disclosure
Root-cause analysis and the regression tests were AI-assisted (Claude Code),
verified via FSI reproduction and the fail-pre-fix / pass-post-fix check above.
The source fix in `OrderProcessor.fs` / `OrderVariable.fs` was authored and
reviewed by the maintainer.
