### PR TITLE
ci(github): publish test results in CI for quick summary view

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       run: dotnet run ServerTests
 
     - name: Publish test results
-      if: always()
+      if: always() && runner.os == 'Linux'
       uses: EnricoMi/publish-unit-test-result-action@v2
       with:
         files: test-results.trx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,4 +30,10 @@ jobs:
       env:
         CI: true
         GENPRES_DEBUG: 1
-      run: dotnet run ServerTests
+      run: dotnet run ServerTests -- --junit-path test-results.xml
+
+    - name: Publish test results
+      if: always()
+      uses: EnricoMi/publish-unit-test-result-action@v2
+      with:
+        files: test-results.xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,10 +30,10 @@ jobs:
       env:
         CI: true
         GENPRES_DEBUG: 1
-      run: dotnet run ServerTests -- --junit-path test-results.xml
+      run: dotnet run ServerTests
 
     - name: Publish test results
       if: always()
       uses: EnricoMi/publish-unit-test-result-action@v2
       with:
-        files: test-results.xml
+        files: test-results.trx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,4 +36,4 @@ jobs:
       if: always() && runner.os == 'Linux'
       uses: EnricoMi/publish-unit-test-result-action@v2
       with:
-        files: test-results.trx
+        files: '**/TestResults/**/*.trx'

--- a/Build.fs
+++ b/Build.fs
@@ -170,6 +170,8 @@ Target.create
                 "quiet"
                 "--logger"
                 "console;verbosity=minimal"
+                "--logger"
+                "trx;LogFileName=test-results.trx"
             ]
         |> CreateProcess.withWorkingDirectory "."
         |> CreateProcess.redirectOutputIfNotRedirected


### PR DESCRIPTION
Output JUnit XML from ServerTests and use the publish-unit-test-result-action to surface test results directly in GitHub Actions.
