### PR TITLE
ci(github): enable dotnet cache in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
         cache: true
         cache-dependency-path: |
           global.json
+          .config/dotnet-tools.json
           paket.dependencies
           **/paket.references
           **/paket.lock

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         cache-dependency-path: |
           global.json
           .config/dotnet-tools.json
-          paket.dependencies
+          **/paket.dependencies
           **/paket.references
           **/paket.lock
           Build.fsproj

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,14 @@ jobs:
       uses: actions/setup-dotnet@v4.1.0
       with:
         dotnet-version: '10.0.x'
+        cache: true
+        cache-dependency-path: |
+          global.json
+          paket.dependencies
+          **/paket.references
+          **/paket.lock
+          Build.fsproj
+          GenPRES.sln
 
     - name: Tool restore
       run: dotnet tool restore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4.2.2
     - name: Use .NET Core 10.0 SDK
-      uses: actions/setup-dotnet@v4.1.0
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '10.0.x'
         cache: true


### PR DESCRIPTION
Configure setup-dotnet to use built-in caching in the build pipeline. Add cache dependency paths so cache invalidation tracks dependency changes and reduces CI restore time.

- global.json The selected .NET SDK version affects restore behavior. If the SDK changes, the cache should be cleared.
- paket.dependencies defines the shared package feeds and top-level dependency declarations for the repo. A change there can alter what gets restored.
- paket.references files declare which packages a specific project actually uses. If a project adds or removes a package, the restore cache should refresh.
- paket.lock files because they record the resolved dependency graph. Signal that the restore result has changed and cache needs refreshing.
- Build.fsproj because the build script project can introduce or change tool and package inputs used during CI. If that project changes, it is reasonable to invalidate the cache.
- GenPRES.sln because the solution file defines which projects participate in the build. If the solution structure changes, refreshing the cache is a safe choice.

These together make a conservative cache invalidation scheme that should both improve build times but invalidate on any salient change.

This address the final point in #384