### PR TITLE
Remove duplicate uses statement from merge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,6 @@ jobs:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - name: Use .NET Core 10.0 SDK
       uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
-      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '10.0.x'
         cache: true


### PR DESCRIPTION
This pull request removes the duplicate `uses` that was introduced during an auto-merge.