### PR TITLE
ci: Update github actions also pin publish-unit-test-result-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Use .NET Core 10.0 SDK
-      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
       with:
         dotnet-version: '10.0.x'
         cache: true
@@ -43,6 +43,6 @@ jobs:
 
     - name: Publish test results
       if: always() && runner.os == 'Linux'
-      uses: EnricoMi/publish-unit-test-result-action@v2
+      uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
       with:
         files: '**/TestResults/**/*.trx'


### PR DESCRIPTION
## Summary

Pins our three GitHub Actions (`checkout`, `setup-dotnet`, `publish-unit-test-result-action`) to exact commit hashes instead of floating version tags, and bumps them to their current stable releases along the way.

## Why

I failed to add the hash for the publish-unit-test-result-action so this is the standard supply-chain hardening move for this third-party Action.

Now the version bumps. The Node 20 runtime these actions were built for hit end of life a few months back so GitHub has been throwing deprecation warnings about it ever since, eventually those warnings will result in the actions stopping working.

This is purely the internal runtime GitHub uses to execute the Action's own JS code. This workflow doesn't even touch npm, so nothing about our actual build changes.

## What changed

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | v4.3.1 | v7.0.0 |
| `actions/setup-dotnet` | v4.3.1 | v5.4.0 |
| `EnricoMi/publish-unit-test-result-action` | `@v2` (floating) | v2.24.0 |

Checked the changelog for anything obvious that might affect us.

checkout v6 picked up a real security fix (git creds no longer get embedded in `.git/config`),

v7 is a small correctness fix for fork PRs plus internal cleanup.

setup-dotnet's jump is additive (new inputs, a `global.json` bugfix). None of it should change any behavior, just what's running under the hood.