### PR TITLE
fix(config):  Add deps-dev as valid scope as Dependabot used this often

### DIFF
--- a/.husky/scripts/commit-lint.fsx
+++ b/.husky/scripts/commit-lint.fsx
@@ -7,7 +7,7 @@ let commitMsgFile = fsi.CommandLineArgs[1]
 let types = "feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert"
 
 let scopes =
-    "agents|logging|nlp|ots|genunits|gensolver|gencore|zindex|zform|nkf|ftk|genform|genorder|mcp|fhir|dataplatform|hixconnect|utils|client|server|api|ui|config|deps|docker|github|deploy"
+    "agents|logging|nlp|ots|genunits|gensolver|gencore|zindex|zform|nkf|ftk|genform|genorder|mcp|fhir|dataplatform|hixconnect|utils|client|server|api|ui|config|deps|deps-dev|docker|github|deploy"
 
 let pattern = $"^(?:%s{types})(?:\((?:%s{scopes})\))?(?::) "
 let msgHeading = commitMsgFile |> File.ReadAllLines |> Array.head


### PR DESCRIPTION
 Add deps-dev as valid scope as Dependabot used this often to update dependencies, this is used by both the commit hook and CI checks for commit and PR adherence.