### PR TITLE
fix(deps): decouple Build target from RestoreClient/Clean dependency chain

### DIFF
--- a/Build.fs
+++ b/Build.fs
@@ -285,11 +285,23 @@ open Fake.Core.TargetOperators
 
 let dependencies =
     [
-        "Clean" ==> "RestoreClient" ==> "Bundle"
-        "Clean" ==> "RestoreClient" ==> "Build" ==> "Run"
+        // Two independent prongs: a self-sufficient server build (Build restores
+        // and builds GenPRES.sln itself, no npm involved) and a client toolchain
+        // (Clean clears stale Fable/.jsx output, then RestoreClient runs npm ci).
+        // Each leaf target below declares only the prong(s) its body actually uses,
+        // rather than chaining everything through one sequence.
+        "Clean" ==> "RestoreClient"
 
-        "RestoreClient" ==> "Build" ==> "TestHeadless"
-        "RestoreClient" ==> "Build" ==> "WatchTests"
+        "RestoreClient" ==> "Bundle"
+
+        "Build" ==> "Run"
+        "RestoreClient" ==> "Run"
+
+        "Build" ==> "TestHeadless"
+        "RestoreClient" ==> "TestHeadless"
+
+        "Build" ==> "WatchTests"
+        "RestoreClient" ==> "WatchTests"
 
         "Build" ==> "ServerTests"
         "Build" ==> "CheckVersions"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -49,8 +49,10 @@ dotnet run [target]
                        └─► executes each target step
 ```
 
-For example, `dotnet run` (no target) runs the `Run` target, which depends on:
-`Clean → RestoreClient → Build → Run` (server + Fable watcher in parallel).
+For example, `dotnet run` (no target) runs the `Run` target, which depends on
+two independent prerequisites: `Build` (compiles the server, no npm involved)
+and `Clean → RestoreClient` (clears stale Fable output, then restores npm
+packages for the Fable/Vite dev server).
 
 ### FAKE Build Targets Reference
 
@@ -72,11 +74,22 @@ For example, `dotnet run` (no target) runs the `Run` target, which depends on:
 
 ```text
 Clean ──► RestoreClient ──► Bundle
-Clean ──► RestoreClient ──► Build ──► Run
 
-RestoreClient ──► Build ──► TestHeadless
-RestoreClient ──► Build ──► WatchTests
+Build ──► Run
+RestoreClient ──► Run
+
+Build ──► TestHeadless
+RestoreClient ──► TestHeadless
+
+Build ──► WatchTests
+RestoreClient ──► WatchTests
+
+Build ──► ServerTests
+Build ──► CheckVersions
 ```
+
+`Build` and `RestoreClient` are independent prongs — a target that only needs
+one of them (e.g. `ServerTests`, `CheckVersions`) doesn't pay for the other.
 
 ### What Happens During `dotnet run` (the `Run` target)
 


### PR DESCRIPTION
@halcwb 

Is the commented-out server watch-test line in WatchTests (Build.fs:244, `dotnet [ "watch"; "run"; "--no-restore" ] serverTestsPath`) abandoned, or still intended to be finished?

If it's abandoned, we can drop WatchTests's dependency on Build too, it only runs the client Fable/Vite watcher, so nothing in it currently needs a server build.

If it's not dead, then we can to leave the Build dependency in place as it is in this PR, so it's still there when that line gets uncommented and addressed.

Partially addresses point 5 in #387 

