### PR TITLE
build(config): centralize markdownlint ignores

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -6,7 +6,7 @@
     // Exclude vendored/generated content. A bare "node_modules" glob only matches a node_modules 
     // folder at the repo root; "**/node_modules/**" is required to also match the nested one under 
     // src/Informedica.GenPRES.Client/node_modules (see issue #433).
-    "ignores": [ "**/node_modules" ],
+    "ignores": [ "**/node_modules/**" ],
 
     // Markdownlint rule overrides go inside "config".
     "config": {

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -3,6 +3,11 @@
     // See https://github.com/DavidAnson/markdownlint-cli2#configuration
     // Rules reference: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
 
+    // Exclude vendored/generated content. A bare "node_modules" glob only matches a node_modules 
+    // folder at the repo root; "**/node_modules/**" is required to also match the nested one under 
+    // src/Informedica.GenPRES.Client/node_modules (see issue #433).
+    "ignores": [ "**/node_modules" ],
+
     // Markdownlint rule overrides go inside "config".
     "config": {
         // Enable all rules by default, then selectively disable noisy/stylistic ones.

--- a/Build.fs
+++ b/Build.fs
@@ -271,7 +271,7 @@ Target.create
     "MarkdownLint"
     (fun _ ->
         try
-            run npx [ "--yes"; "markdownlint-cli2"; "**/*.md"; "#node_modules" ] "."
+            run npx [ "--yes"; "markdownlint-cli2"; "**/*.md" ] "."
         with ex ->
             Trace.traceImportant $"⚠️  MarkdownLint: {ex.Message}"
     )

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,8 +151,9 @@ Lint issues should still be assessed and addressed over time to maintain documen
 ### Running the linter manually
 
 ```bash
-# Lint all Markdown files
-npx markdownlint-cli2 "**/*.md" "#node_modules"
+# Lint all Markdown files (node_modules is excluded via the "ignores"
+# key in .markdownlint-cli2.jsonc)
+npx markdownlint-cli2 "**/*.md"
 
 # Lint a specific file
 npx markdownlint-cli2 README.md


### PR DESCRIPTION
Move node_modules exclusion into .markdownlint-cli2.jsonc using "**/node_modules" so nested client dependencies are ignored consistently (issue #433). Update the FAKE MarkdownLint target and CONTRIBUTING examples to rely on config-based ignores instead of passing "#node_modules" on the CLI.
