### PR TITLE
Get totals per method call

### DIFF
--- a/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
@@ -72,8 +72,6 @@ module Adapters =
         (orderCtxPort: OrderContextPort)
         : OrderPlanPort
         =
-        let totals = provider.GetTotals()
-
         {
             updateOrderPlan =
                 fun tp cmdOpt ->
@@ -85,7 +83,12 @@ module Adapters =
                         return updated |> OrderPlanService.calculateTotals totals |> Ok
                     }
 
-            filterOrderPlan = fun tp -> async { return tp |> OrderPlanService.calculateTotals totals |> Ok }
+            filterOrderPlan =
+                fun tp ->
+                    async {
+                        let totals = provider.GetTotals()
+                        return tp |> OrderPlanService.calculateTotals totals |> Ok
+                    }
         }
 
 

--- a/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
@@ -81,6 +81,7 @@ module Adapters =
                         do! setComponentName "OrderPlan" agent
 
                         let! updated = OrderPlanService.updateOrderPlan orderCtxPort tp cmdOpt
+                        let totals = provider.GetTotals()
                         return updated |> OrderPlanService.calculateTotals totals |> Ok
                     }
 

--- a/tests/Informedica.GenPRES.Server.Tests/Tests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/Tests.fs
@@ -468,6 +468,8 @@ module StubAdapterTests =
 
     let emptyCtx = Models.OrderContext.empty
 
+    // Copied to TotalsTests. One more copy/paste, and by the rule of three we should consider deduplication.
+    // An OrderPlan.empty value seems reasonable.
     let emptyPlan: OrderPlan =
         {
             Patient = Models.Patient.empty
@@ -808,3 +810,64 @@ module DoseCheckTests =
 
     [<Tests>]
     let tests = testList "DoseCheck Tests" [ doseCheckTests ]
+
+module TotalsTests =
+    open System
+    open Shared
+    open Shared.Types
+    open Swensen.Unquote
+
+    type TotalsSpy() =
+        let mutable callCount = 0
+        member this.CallCount = callCount
+
+        interface Resources.IResourceProvider with
+            member _.Get _ = raise (NotImplementedException())
+            member _.GetData() = raise (NotImplementedException())
+            member _.GetDoseRules() = raise (NotImplementedException())
+            member _.GetEnteralFeeding() = raise (NotImplementedException())
+            member _.GetFormRoutes() = raise (NotImplementedException())
+            member _.GetFormularyProducts() = raise (NotImplementedException())
+            member _.GetGStandProvider() = raise (NotImplementedException())
+            member _.GetParenteralMeds() = raise (NotImplementedException())
+            member _.GetProducts() = raise (NotImplementedException())
+            member _.GetReconstitution() = raise (NotImplementedException())
+            member _.GetRenalRules() = raise (NotImplementedException())
+            member _.GetResourceInfo() = raise (NotImplementedException())
+            member _.GetRouteMappings() = raise (NotImplementedException())
+            member _.GetSolutionRules() = raise (NotImplementedException())
+
+            member _.GetTotals() =
+                callCount <- callCount + 1
+                [||]
+
+            member _.GetUnitMappings() = raise (NotImplementedException())
+            member _.GetValidForms() = raise (NotImplementedException())
+
+    // Copied from StubAdapterTests. One more copy/paste, and by the rule of three we should consider deduplication.
+    // An OrderPlan.empty value seems reasonable.
+    let emptyPlan: OrderPlan =
+        {
+            Patient = Models.Patient.empty
+            Scenarios = [||]
+            Selected = None
+            Filtered = [||]
+            Totals = Models.Totals.empty
+        }
+
+    [<Tests>]
+    let tests =
+        testList
+            "Totals Tests"
+            [
+                testAsync "updateOrderPlan doesn't cache totals" {
+                    let spy = TotalsSpy()
+                    let sut = ServerApi.Adapters.makeAppEnv spy
+                    let countBefore = spy.CallCount
+
+                    let! _ = sut.orderPlan.updateOrderPlan emptyPlan None
+
+                    let countAfter = spy.CallCount
+                    countBefore <! countAfter
+                }
+            ]

--- a/tests/Informedica.GenPRES.Server.Tests/Tests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/Tests.fs
@@ -870,4 +870,15 @@ module TotalsTests =
                     let countAfter = spy.CallCount
                     countBefore <! countAfter
                 }
+
+                testAsync "filterOrderPlan doesn't cache totals" {
+                    let spy = TotalsSpy()
+                    let sut = ServerApi.Adapters.makeAppEnv spy
+                    let countBefore = spy.CallCount
+
+                    let! _ = sut.orderPlan.filterOrderPlan emptyPlan
+
+                    let countAfter = spy.CallCount
+                    countBefore <! countAfter
+                }
             ]


### PR DESCRIPTION
## Overview

Call `provider.GetTotals()` every time a method is invoked, rather than using a cached/memoized value.

## Further information

This pull request addresses an issue first described in the discussion of #441. It only addresses the issue for `makeOrderPlanPort`, in order to show a direction. If the direction demonstrated here is desirable or acceptable, a similar approach can be applied to `makeNutritionPlanPort`, either as an addition to this pull request, or as a new pull request, as desired. 

## Divergence from plan

As I've written in the commit messages:

> Using a Test Spy to demonstrate the presence of a defect is not my first
> choice, but it has turned out that testing via observable behaviour is
> hard: In order to test via observable behaviour, a test must call
> `updateOrderPlan` twice, with the provider returning two different
> values from `GetTotals`, and then observe that the two return values'
> `Totals` values differ.
>
> In order for two `Totals` values to differ, at least one of them must be
> non-empty. This requires that one is able to pass input values to
> `updateOrderPlan` that will produce a non-empty `Totals` value on the
> return value. Finding such a combination of input values has so far
> turned out to be much harder than expected.
>
> So while we could argue that using a Test Spy tests an implementation
> detail, carefully picking the right combination of input values is also
> dependent on implementation details.

## Verification

- Added two new tests following red-green-refactor. Saw both tests fail as expected.
- Executed `dotnet run servertests`, which passed.

## Author checklist

> [!NOTE]
> An issue and agreed implementation plan are necessary unless either fewer than 25 lines have been changed or only documentation has been changed.

I confirm that these changes:

- [x] Follow the process described in [CONTRIBUTING.md](../CONTRIBUTING.md#Pull_Request_Process).
- [x] Make the changes proposed in the linked issue (if applicable): #441
- [ ] Follow the approach documented in the linked implementation plan (if applicable): n/a
- [x] Are no more than 200 lines of changed code, ideally 25-100.
- [x] Are not more complex than necessary.
- [x] Cannot easily be split in a way that would make reviewing them significantly easier.
- [x] Follow the guidelines specified in [DEVELOPMENT.md](../../DEVELOPMENT.md).
- [x] Have been thoroughly tested.
- [x] Don't introduce new security vulnerabilities.
- [ ] Follow the [AI/LLM Usage Policy](../../AGENTS.md#aillm-usage-policy) — LLMs were not given direct write access to `.fs` source files (except client-side UI code).

### AI/Vibe Coding Disclosure

- [ ] Some or all code in this PR is **vibe coded** (substantially AI-generated). If checked, describe below which parts were AI-generated, which tool was used, and how the code was verified.

I haven't vibe-coded anything, but I've allowed the IDE-integrated Copilot to do a bit of 'auto-complete on steroids'. For example, Copilot predicted the second test faster than I could write it myself, so I allowed it, and then subsequently edited the code.

I confirm that I have:

- [x] Added appropriate automated tests.
- [ ] Updated documentation appropriately.
- [x] Added comments that highlight important changes and add justification, where necessary. (Create the PR as a draft first, add your comments, then mark as ready for review.)

## Reviewer checklist

I confirm that:

- [ ] I am confident that the changes work.
- [ ] The changed code meets our guidelines and standards.
- [ ] The new code is not more complex than necessary.
- [ ] I have clearly labelled suggestions as blocking, required but not blocking, or optional (see [CONTRIBUTING.md](../CONTRIBUTING.md#Pull_Request_Process)).
