### PR TITLE
docs(config): link ADR-0021 to the deferred follow-up issues

### DIFF
--- a/docs/implementation-plans/234-improve-build-system.md
+++ b/docs/implementation-plans/234-improve-build-system.md
@@ -92,6 +92,9 @@ is written against it — see Step 1 below.
 7. **Split `Build` into `ServerBuild`/`ClientBuild`** in `Build.fs`, update
    `DEVELOPMENT.md`'s target table and dependency-chain diagram and
    `AGENTS.md`'s quick-start section in the same PR.
-8. **File follow-up issues** for items 3 and 4, linked from ADR-0021.
+8. **File follow-up issues** for items 3 and 4, linked from ADR-0021. Done:
+   [#459](https://github.com/informedica/GenPRES/issues/459) (Docker image on
+   release) and [#460](https://github.com/informedica/GenPRES/issues/460)
+   (auto-generated API documentation).
 
 Each of steps 3, 5, 6, and 7 is a separate, independently reviewable PR sized to CONTRIBUTING.md's guidance (~100–200 lines).

--- a/docs/mdr/design-history/0021-build-system-versioning-and-release.md
+++ b/docs/mdr/design-history/0021-build-system-versioning-and-release.md
@@ -65,7 +65,7 @@ at a time, rather than as a single documentation pass.
 | 1 | EasyBuild.ShipIt over MinVer/Nerdbank.GitVersioning | Only option that covers versioning **and** changelog generation **and** release-PR creation in one tool; MinVer/Nerdbank would still leave changelog automation and Repo Assist's Task 8 duplication unresolved |
 | 2 | Merge commits disabled; squash and rebase merging both left enabled | ShipIt needs each PR to land without a `Merge pull request ...` commit to parse cleanly; squash and rebase both satisfy that per ShipIt's own README, so contributors keep the choice instead of being forced to squash away commit-level history |
 | 3 | Retire Repo Assist Task 8 in the same PR that turns on CI-driven ShipIt | Prevents two bots from proposing competing release PRs on the same merge |
-| 4 | Docker-on-release (item 3) and API docs (item 4) deferred to new follow-up issues | Both are greenfield efforts (no existing docfx/GitHub Pages/Docker-publish infrastructure) with no dependency on the versioning work landing first being a blocker either way; keeping them separate lets #234 close on a coherent, reviewable scope |
+| 4 | Docker-on-release (item 3) and API docs (item 4) deferred to new follow-up issues — filed as [#459](https://github.com/informedica/GenPRES/issues/459) and [#460](https://github.com/informedica/GenPRES/issues/460) | Both are greenfield efforts (no existing docfx/GitHub Pages/Docker-publish infrastructure) with no dependency on the versioning work landing first being a blocker either way; keeping them separate lets #234 close on a coherent, reviewable scope |
 | 5 | `Build` FAKE target split into `ServerBuild`/`ClientBuild`, with `Build` kept as an umbrella target | Existing dependency chains (`Build ==> ServerTests`, `Build ==> CheckVersions`, `Build ==> Run`) keep working unchanged; new targets are additive |
 | 6 | Agent-visible docs (`AGENTS.md`/`DEVELOPMENT.md`) updated per-PR, not as a separate pass | Each PR already knows which target/behaviour it changed; batching risks the docs pass lagging behind or being skipped |
 
@@ -118,6 +118,8 @@ This determines whether `scripts/CheckSolutionVersions.fsx` needs to change at a
 ## References
 
 - [Issue #234 — Improve build system](https://github.com/informedica/GenPRES/issues/234)
+- [Issue #459 — Publish the Docker image automatically on release](https://github.com/informedica/GenPRES/issues/459) (follow-up, item 3)
+- [Issue #460 — Auto-generate and publish API documentation](https://github.com/informedica/GenPRES/issues/460) (follow-up, item 4)
 - [Implementation plan for issue #234](../../implementation-plans/234-improve-build-system.md)
 - [EasyBuild.ShipIt](https://github.com/easybuild-org/EasyBuild.ShipIt)
 - [Repo Assist workflow](../../../.github/workflows/repo-assist.md)


### PR DESCRIPTION
## What

Documentation-only. Records the two follow-up issues that ADR-0021 said would be
filed, now that they exist:

- #459 — Publish the Docker image automatically on release (#234 item 3)
- #460 — Auto-generate and publish API documentation (#234 item 4)

Updated in three places: ADR-0021's key-design-choices table (decision 4), its
references list, and step 8 of the #234 implementation plan.

## Why

ADR-0021 decision 4 deferred items 3 and 4 out of #234 to keep that issue's scope
coherent, but the follow-up issues were never filed, so the ADR deferred to
nothing. Anyone reading the ADR had no way to find where that work went.

This closes step 8 of the #234 implementation plan. Step 7 (splitting the `Build`
FAKE target into `ServerBuild`/`ClientBuild`) is the only remaining step, so #234
stays open.

## Verification

Markdown only, no code paths touched. `npx markdownlint-cli2` on both files
reports no new issues (the ADR has pre-existing MD009 trailing-space warnings on
untouched lines, left alone rather than mixed into this diff).

Refs #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)
