### PR TITLE
build(config): split Build into ServerBuild and ClientBuild targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,9 @@ dotnet test
 
 - `dotnet run` - Start full application (server + client with hot reload)
 - `dotnet run list` - Show all available build targets
-- `dotnet run Build` - Build the solution
+- `dotnet run Build` - Build the whole solution (libraries, server, tests, client `.fsproj`); no npm involved
+- `dotnet run ServerBuild` - Build only the server and the libraries it depends on.
+- `dotnet run ClientBuild` - Build the client to browser output (Fable, then a production Vite bundle). Runs `npm ci` first
 - `dotnet run Bundle` - Create production bundle
 - `dotnet run CheckVersions` - Proves that every project shipped in GenPRES.sln reports the same version as the repo-root Directory.Build.props
 - `dotnet run Clean` - Clean build artifacts

--- a/Build.fs
+++ b/Build.fs
@@ -72,6 +72,50 @@ Target.create
     )
 
 
+let serverProj = Path.combine serverPath "Informedica.GenPRES.Server.fsproj"
+
+
+// Builds only the server and the libraries it depends on. Skips the test projects
+// and the client toolchain entirely, so it is the fastest loop for anyone working on
+// just the server or a domain library.
+Target.create
+    "ServerBuild"
+    (fun _ ->
+        run dotnet [ "restore"; serverProj ] "."
+        run dotnet [ "build"; serverProj; "--no-restore" ] "."
+    )
+
+
+// Builds the client's browser output: Fable compiles F# to .jsx, then Vite bundles
+// it into deploy/public (vite.config.js sets the outDir). Depends on RestoreClient
+// (npm ci), declared below. `Bundle` keeps its own copy of this because it runs the
+// client build in parallel with publishing the server.
+Target.create
+    "ClientBuild"
+    (fun _ ->
+        run
+            dotnet
+            [
+                "fable"
+                "-o"
+                "output"
+                "-s"
+                "-e"
+                ".jsx"
+                "--run"
+                "npx"
+                "vite"
+                "build"
+                "--emptyOutDir"
+            ]
+            clientPath
+    )
+
+
+// Umbrella target: restores and builds every project in the solution (libraries, server, tests, and client).
+// Its body is deliberately unchanged by the ServerBuild/ClientBuild split, so the chains that hang off it
+// behave exactly as before. In particular it still involves no npm, which is what keeps `Build ==> ServerTests`
+// cheap in CI, and it still builds the test projects, which `ServerTests` needs since it runs with --no-restore.
 Target.create
     "Build"
     (fun _ ->
@@ -390,6 +434,7 @@ let dependencies =
         "Clean" ==> "RestoreClient"
 
         "RestoreClient" ==> "Bundle"
+        "RestoreClient" ==> "ClientBuild"
 
         "Build" ==> "Run"
         "RestoreClient" ==> "Run"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -92,7 +92,9 @@ packages for the Fable/Vite dev server).
 |---|---|---|
 | `dotnet run` | `Run` | Start server + Fable/Vite dev server with hot reload (default) |
 | `dotnet run list` | *(special)* | List all available FAKE targets |
-| `dotnet run Build` | `Build` | Compile the entire solution (`GenPRES.sln`) |
+| `dotnet run Build` | `Build` | Compile the entire solution (`GenPRES.sln`) — libraries, server, tests, and the client `.fsproj`. No npm involved |
+| `dotnet run ServerBuild` | `ServerBuild` | Compile only the server and the libraries it depends on. Skips test projects and the client toolchain |
+| `dotnet run ClientBuild` | `ClientBuild` | Compile the client: Fable (F# → `.jsx`) then a production Vite bundle. Runs `npm ci` first via `RestoreClient` |
 | `dotnet run Clean` | `Clean` | Remove `deploy/` and `dist/` artefacts, delete Fable-generated `.jsx` files |
 | `dotnet run Bundle` | `Bundle` | Production build: publish server, compile client, copy data |
 | `dotnet run ServerTests` | `ServerTests` | Run all F# unit tests (Expecto) with quiet logging |
@@ -107,6 +109,9 @@ packages for the Fable/Vite dev server).
 
 ```text
 Clean ──► RestoreClient ──► Bundle
+Clean ──► RestoreClient ──► ClientBuild
+
+ServerBuild            (no prerequisites — restores itself)
 
 Build ──► Run
 RestoreClient ──► Run
@@ -120,6 +125,12 @@ RestoreClient ──► WatchTests
 Build ──► ServerTests
 Build ──► CheckVersions
 ```
+
+`ServerBuild` and `ClientBuild` are **additive**: nothing depends on them, and `Build`
+does not use them. `Build` still builds the test projects because `ServerTests` runs
+`dotnet test --no-restore`. It also stays npm-free so CI does not run `npm ci` and a
+Fable compile for every test run. Thus, `Build` remains the full-solution build,
+while the new targets compile either side separately.
 
 ### Changelog & Release Automation (EasyBuild.ShipIt)
 


### PR DESCRIPTION
Item 5 of #234 asked for separate targets to build the server and the client. Adds both as additive targets and leaves Build's body untouched.

Build stays the full-solution build rather than delegating to the two new targets, for two reasons. ServerTests runs dotnet test with --no-restore, so Build has to keep building the test projects or there is nothing to run. And CI reaches Build through Build ==> ServerTests, so making Build depend on ClientBuild would add npm ci plus a Fable compile and a Vite bundle to every test run. Both new targets are therefore reachable only when asked for by name, no existing dependency chain changes.

ServerBuild builds just the server project and its library graph, which is the fast compile check for library work. 

ClientBuild runs the Fable and Vite production build, and takes RestoreClient as a prerequisite.

DEVELOPMENT.md's target table and dependency diagram and AGENTS.md's quick-start list are updated in the same commit, per ADR-0021.

Refs #234
