### PR TITLE
docs(config): accept ADR-0021 and correct ShipIt status

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -140,9 +140,12 @@ the next semantic version and changelog entries from conventional-commit history
 design. It is registered as a local dotnet tool (`.config/dotnet-tools.json`) and configured via
 YAML front matter at the top of the root `CHANGELOG.md`.
 
-As of this PR, ShipIt is installed and configured but **not** wired into the CI, it also does not 
-update `Directory.Build.props`, these are both a follow-up PR per ADR-0021's implementation plan. 
-In the meantime, we can preview locally what it would generate:
+ShipIt runs in CI on every push to `master` (see [Release Automation](#release-automation-github-actions)
+below) and owns the version number: the `updaters:` block in the `CHANGELOG.md` front matter points at 
+`/Project/PropertyGroup/Version` in the root `Directory.Build.props`, so the release PR bumps that
+element as well as adding the changelog section. Do not hand-edit `<Version>`.
+
+To preview locally what ShipIt would generate:
 
 ```bash
 dotnet tool restore
@@ -150,10 +153,13 @@ dotnet shipit --dry-run --allow-branch master --skip-merge-commit
 ```
 
 `--allow-branch` defaults to `main`; GenPRES's default branch is `master`, so it must be passed
-explicitly (this also applies when step 5 wires ShipIt into CI). `--skip-merge-commit` is required
-too: the repo's existing history has `Merge pull request ...` commits ShipIt can't parse, and it
-throws on the first one it hits instead of skipping it. `--dry-run` never modifies files or opens
-a pull request, so it's safe to run against a dirty tree.
+explicitly (`release.yml` passes it too). `--skip-merge-commit` is required for every invocation. 
+All three merge methods are enabled on the repo, so `Merge pull request ...` commits will keep 
+appearing in history, and ShipIt throws on the first one it hits instead of skipping it. `--dry-run`
+never modifies files or opens a pull request, so it's safe to run against a dirty tree.
+
+Commit types that ShipIt does not render into the changelog include `docs`, `build`, and `chore`. 
+If such a change needs to appear in the release notes, put a `=== changelog ===` block in the PR body.
 
 ### What Happens During `dotnet run` (the `Run` target)
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -158,8 +158,32 @@ All three merge methods are enabled on the repo, so `Merge pull request ...` com
 appearing in history, and ShipIt throws on the first one it hits instead of skipping it. `--dry-run`
 never modifies files or opens a pull request, so it's safe to run against a dirty tree.
 
-Commit types that ShipIt does not render into the changelog include `docs`, `build`, and `chore`. 
-If such a change needs to appear in the release notes, put a `=== changelog ===` block in the PR body.
+#### What reaches the changelog
+
+The behaviour below was established by running ShipIt 3.0.1 against a throwaway branch of this
+repo. ShipIt's own documentation covers none of it.
+
+- **`docs`, `build`, and `chore` commits never render.** Only types like `feat` and `fix` produce
+  entries, and no flag or escape hatch changes that. A change that must appear in the release notes
+  has to ride on a rendering commit type.
+- **Commits that change no files are ignored**, whatever their type.
+- **A `=== changelog ===` block adds detail to an entry that already renders.** It is read from the
+  **commit message body**, not the pull request body, and needs both an opening *and* a closing
+  `=== changelog ===` marker. An unterminated block is dropped silently, with no warning:
+
+  ```text
+  fix(server): correct the infusion rate rounding
+
+  === changelog ===
+  Rates were rounded to whole mL/h, truncating paediatric doses below 1 mL/h.
+  === changelog ===
+  ```
+
+  That renders the prose indented beneath the commit's bullet.
+
+Putting the block in a PR body only works when the merge method copies that body into the commit
+message, which squash-merging does by default and merge-commit merging never does. Since all three
+merge methods are enabled here, put it in the commit message.
 
 ### What Happens During `dotnet run` (the `Run` target)
 

--- a/docs/implementation-plans/234-improve-build-system.md
+++ b/docs/implementation-plans/234-improve-build-system.md
@@ -20,9 +20,8 @@ For versioning/changelog (items 1–2), three options were on the table:
   (Repo Assist's Task 8 would keep doing that manually).
 - **EasyBuild.ShipIt** — reads `CHANGELOG.md` front-matter and conventional-commit 
   history, computes the next semver, generates the changelog section, and opens a
-   release PR. Requires disabling GitHub's merge-commit option, since ShipIt's 
-   commit parser breaks on `Merge pull request ...` commits; squash and rebase 
-   merging both avoid that and can stay enabled side by side.
+  release PR. Its commit parser throws on `Merge pull request ...` commits unless
+  `--skip-merge-commit` is passed.
 - **Status quo** — keep the manual `Directory.Build.props` edit and Repo Assist's 
   manual changelog PRs. Rejected: this is exactly what #234 was filed to fix.
 
@@ -36,10 +35,9 @@ as follow-up issues once the versioning foundation lands.
   tool, which directly replaces Repo Assist's existing manual Task 8 instead
   of leaving two overlapping mechanisms. A maintainer initially proposed
   squash-only as the adoption blocker's fix; concerns were raised about losing 
-  commit-level history. This is resolved by disabling merge commits while
-  leaving both squash and rebase merging enabled. ShipIt's own README treats
-  them as equally valid, so this removes the adoption blocker without forcing
-  one merge style on everyone.
+  commit-level history, and the position moved to disabling merge commits only.
+  In the end no repo setting changed: `--skip-merge-commit` removes the
+  blocker on its own, so all three merge methods stay enabled.
 - Items 3 (Docker image on release) and 4 (auto-generated API docs) are
   **out of scope for #234** and will be filed as separate follow-up issues
   once this ADR is accepted, so #234 isn't left open indefinitely for
@@ -58,12 +56,12 @@ Full detail (decisions, trade-offs, MDR/safety notes) lives in
 
 ## Confidence
 
-Medium. The overall direction (ShipIt + disabling merge commits + target split) is
-sound and matches the issue thread's own analysis, but EasyBuild.ShipIt's
-exact CLI/config surface (front-matter schema, how it surfaces the computed
-version to MSBuild) is only known second-hand from an AI-bot's issue
-comment, not from its actual README. That needs verifying before any code
-is written against it — see Step 1 below.
+High, as of completion. The original uncertainty was EasyBuild.ShipIt's exact
+CLI/config surface, known only second-hand from an AI-bot's issue comment.
+Step 1 verified it against the tool: an `xml` updater in the `CHANGELOG.md`
+front matter rewrites `<Version>` in `Directory.Build.props` directly, so
+`scripts/CheckSolutionVersions.fsx` needed no change. All steps are merged
+except step 2, which was dropped as unnecessary.
 
 ## Steps
 
@@ -72,12 +70,11 @@ is written against it — see Step 1 below.
    and critically, whether it writes `Directory.Build.props` directly or expects a 
    separate consumer (e.g. MinVer-style git-tag read) to pick up the version it computes. 
    This determines whether `scripts/CheckSolutionVersions.fsx` needs changes.
-2. **Disable "Allow merge commits" in GitHub repo settings, leaving both
-   squash and rebase merging enabled** (repo settings — maintainer action,
-   not a PR). No urgency tied to step 3's merge: nothing runs ShipIt
-   unattended until step 5 lands, and every local/CI invocation already
-   passes `--skip-merge-commit` to tolerate the merge commits already in
-   history, so this can happen any time before step 5 rather than "immediately."
+2. ~~**Disable "Allow merge commits" in GitHub repo settings, leaving both
+   squash and rebase merging enabled**~~ — **dropped, not done.** Every local
+   and CI invocation passes `--skip-merge-commit`, which makes ShipIt tolerate
+   `Merge pull request ...` commits, so no repo setting change was needed to
+   adopt it. All three merge methods stay enabled. See ADR-0021 design choice 2.
 3. **Adopt ShipIt tooling**: add it to `.config/dotnet-tools.json`, add the confirmed 
    front-matter to `CHANGELOG.md`, add a local dry-run entry point 
    (FAKE target or direct `dotnet shipit` invocation): not wired into CI yet.

--- a/docs/mdr/design-history/0000-change-log.md
+++ b/docs/mdr/design-history/0000-change-log.md
@@ -22,7 +22,8 @@ Maintain this document as a reverse-chronological log of significant design chan
 
 | Date | ADR | Summary |
 |------|-----|---------|
-| 2026-08-05 | [ADR-0021](0021-build-system-versioning-and-release.md) | Build system versioning and release automation proposed; adopts EasyBuild.ShipIt for version/changelog/release-PR generation, merge commits disabled with squash and rebase merging both left available, Repo Assist Task 8 to be retired, Docker-on-release and API docs deferred to follow-up issues. See issue #234 |
+| 2026-08-17 | [ADR-0021](0021-build-system-versioning-and-release.md) | Build system versioning and release automation accepted; EasyBuild.ShipIt owns version/changelog/release-PR generation and writes `Directory.Build.props`, all three merge methods left enabled with `--skip-merge-commit`, Repo Assist Task 8 retired, Docker-on-release and API docs deferred to #459/#460. See issue #234 |
+| 2026-08-05 | [ADR-0021](0021-build-system-versioning-and-release.md) | Build system versioning and release automation proposed. See issue #234 |
 | 2026-04-30 | [ADR-0020](0020-fhir-r4-integration.md) | FHIR R4 EHR integration design proposed; stateless GenPRES with bidirectional MedicationRequest translation and G-Standard GPK coding |
 | 2026-04-27 | [ADR-0019](0019-shared-clinical-calculations.md) | Shared library clinical calculations accepted; BSA, age, and renal eGFR formulas available to both server and client |
 | 2026-04-26 | [ADR-0018](0018-nlp-dose-rule-extraction.md) | LLM-based dose-rule extraction pipeline proposed; multi-stage FSX pipeline with human review gate |

--- a/docs/mdr/design-history/0021-build-system-versioning-and-release.md
+++ b/docs/mdr/design-history/0021-build-system-versioning-and-release.md
@@ -2,7 +2,7 @@
 
 **Date**: 2026-08-05
 
-**Status**: Proposed
+**Status**: Accepted (2026-08-17)
 
 **Related Issue**: [#234 — Improve build system](https://github.com/informedica/GenPRES/issues/234)
 
@@ -40,11 +40,9 @@ The repo currently merges PRs with merge commits
 squash-merge is enabled at the GitHub API level. The maintainer initially confirmed
 (2026-08-05) that switching the default merge method to squash-only is acceptable.
 Concerns were raised that squash-only discards commit-level history on PRs where 
-granularity could matter. Since ShipIt's own README treats squash and rebase merging 
-as equally valid (both avoid the `Merge pull request ...` commits that break its commit 
-parsing — see the verification note below), the revised decision is to disable merge 
-commits but leave both squash and rebase merging enabled, so each contributor chooses
-per PR instead of one strategy being forced on everyone.
+granularity could matter. On acceptance (2026-08-17) that restriction was dropped 
+entirely: all three merge methods stay enabled, and `--skip-merge-commit` handles the
+`Merge pull request ...` commits ShipIt cannot parse. See design choice 2 below.
 
 This document is ADR-0021, the next number available in
 [the design-history log](0000-change-log.md).
@@ -63,23 +61,32 @@ at a time, rather than as a single documentation pass.
 | # | Choice | Rationale |
 |---|--------|-----------|
 | 1 | EasyBuild.ShipIt over MinVer/Nerdbank.GitVersioning | Only option that covers versioning **and** changelog generation **and** release-PR creation in one tool; MinVer/Nerdbank would still leave changelog automation and Repo Assist's Task 8 duplication unresolved |
-| 2 | Merge commits disabled; squash and rebase merging both left enabled | ShipIt needs each PR to land without a `Merge pull request ...` commit to parse cleanly; squash and rebase both satisfy that per ShipIt's own README, so contributors keep the choice instead of being forced to squash away commit-level history |
+| 2 | No repo merge-method restriction: merge, squash, and rebase all stay enabled | `--skip-merge-commit` makes ShipIt tolerate `Merge pull request ...` commits, so restricting merge methods was not actually needed to adopt it. The cost is that merge-commit PRs contribute no changelog entries of their own; the individual commits underneath them are still parsed |
 | 3 | Retire Repo Assist Task 8 in the same PR that turns on CI-driven ShipIt | Prevents two bots from proposing competing release PRs on the same merge |
 | 4 | Docker-on-release (item 3) and API docs (item 4) deferred to new follow-up issues — filed as [#459](https://github.com/informedica/GenPRES/issues/459) and [#460](https://github.com/informedica/GenPRES/issues/460) | Both are greenfield efforts (no existing docfx/GitHub Pages/Docker-publish infrastructure) with no dependency on the versioning work landing first being a blocker either way; keeping them separate lets #234 close on a coherent, reviewable scope |
 | 5 | `Build` FAKE target split into `ServerBuild`/`ClientBuild`, with `Build` kept as an umbrella target | Existing dependency chains (`Build ==> ServerTests`, `Build ==> CheckVersions`, `Build ==> Run`) keep working unchanged; new targets are additive |
 | 6 | Agent-visible docs (`AGENTS.md`/`DEVELOPMENT.md`) updated per-PR, not as a separate pass | Each PR already knows which target/behaviour it changed; batching risks the docs pass lagging behind or being skipped |
 
-### Verification gap to close before implementation
+### Verification gap — closed 2026-08-17
 
-Everything currently known about EasyBuild.ShipIt's CLI and config surface
-(a `last_commit_released` changelog front-matter field, a
-`dotnet shipit github --allow-branch master --skip-merge-commit` invocation,
-`--mode pull-request` vs `--mode push`) comes from an AI-generated issue comment 
-summarizing the tool, not from its own README. Before any implementation PR is 
-opened, the actual EasyBuild.ShipIt documentation must be read to confirm this 
-schema and — specifically — how it expects the computed version to reach MSBuild 
-(writing `Directory.Build.props` directly, vs. emitting a tag for a separate reader). 
-This determines whether `scripts/CheckSolutionVersions.fsx` needs to change at all.
+This section originally recorded that everything known about EasyBuild.ShipIt's CLI
+and config surface came from an AI-generated issue comment summarizing the tool rather 
+than its own README, and required that gap be closed before any implementation PR was 
+opened. Step 1 of the implementation plan closed it. What was confirmed against the tool:
+
+- The `CHANGELOG.md` front matter carries `last_commit_released`, `pre_release`,
+  `name`, and an `updaters:` list.
+- The computed version reaches MSBuild **directly**: an `xml` updater with
+  `file: Directory.Build.props` and `selector: /Project/PropertyGroup/Version`
+  rewrites the `<Version>` element as part of the release PR. No git-tag intermediary, 
+  and therefore no change to `scripts/CheckSolutionVersions.fsx`, it keeps asserting 
+  that every built DLL matches whatever ShipIt wrote.
+- The invocation is `dotnet shipit --allow-branch master --skip-merge-commit`
+  (no `github` subcommand); `--mode` defaults to `pull-request`.
+- `docs`-, `build`-, and `chore`-typed commits are silently omitted from the
+  generated changelog. This was verified from this repo's own release history,
+  not from ShipIt's documentation. The `=== changelog ===` PR-body block is the
+  escape hatch for changes of those types that must still appear in release notes.
 
 ## Consequences
 
@@ -94,10 +101,10 @@ This determines whether `scripts/CheckSolutionVersions.fsx` needs to change at a
 
 **Negative / Trade-offs**:
 
-- Disabling merge commits changes the commit history shape project-wide, not just 
-  for build-system PRs, every future PR merge is affected. Squash and rebase 
-  remain a per-PR choice, so no one is forced to lose commit-level history, but 
-  `Merge pull request ...` commits stop being an option entirely.
+- Every ShipIt invocation must pass `--skip-merge-commit`, indefinitely, because
+  merge commits remain enabled. Omitting it makes ShipIt throw on the first
+  `Merge pull request ...` commit it reaches rather than skipping it. This is
+  documented at every invocation site (`release.yml`, `DEVELOPMENT.md`).
 - `CHANGELOG.md`'s current rich, hand-written prose entries (see any `[Unreleased]` 
   entry today) become leaner, PR-title-derived entries under ShipIt. 
   The `=== changelog ===` block convention in a PR body is the escape hatch for 
@@ -113,7 +120,9 @@ This determines whether `scripts/CheckSolutionVersions.fsx` needs to change at a
 - The changelog remains the audit trail referenced by
   `docs/mdr/design-history/0000-change-log.md`; automating its generation must not 
   reduce its usefulness as a Design History File input, this is why the `=== changelog ===` 
-  escape hatch matters for anything with MDR-relevant detail.
+  escape hatch matters for anything with MDR-relevant detail. Concretely: `docs`, `build`,
+  and `chore` commits never reach the generated changelog, so any change of those types
+  that belongs in the Design History File needs the escape hatch to appear at all.
 
 ## References
 

--- a/docs/mdr/design-history/0021-build-system-versioning-and-release.md
+++ b/docs/mdr/design-history/0021-build-system-versioning-and-release.md
@@ -84,9 +84,20 @@ opened. Step 1 of the implementation plan closed it. What was confirmed against 
 - The invocation is `dotnet shipit --allow-branch master --skip-merge-commit`
   (no `github` subcommand); `--mode` defaults to `pull-request`.
 - `docs`-, `build`-, and `chore`-typed commits are silently omitted from the
-  generated changelog. This was verified from this repo's own release history,
-  not from ShipIt's documentation. The `=== changelog ===` PR-body block is the
-  escape hatch for changes of those types that must still appear in release notes.
+  generated changelog, as are commits that change no files. Nothing overrides
+  this: a change that must appear in release notes has to ride on a rendering
+  commit type such as `feat` or `fix`.
+- The `=== changelog ===` block enriches an entry that already renders; it cannot
+  add one. It is read from the **commit message body**, not the pull request body,
+  and requires both an opening and a closing marker — an unterminated block is
+  discarded without warning. A PR body only reaches the block parser when the merge
+  method copies it into the commit message, which squash-merging does and
+  merge-commit merging does not.
+
+The last two points were established by running ShipIt 3.0.1 against a throwaway
+branch of this repo (probe commits of each type, with and without terminated
+blocks) rather than from its documentation, which describes none of this
+behaviour. See `DEVELOPMENT.md` for the contributor-facing version.
 
 ## Consequences
 
@@ -106,8 +117,8 @@ opened. Step 1 of the implementation plan closed it. What was confirmed against 
   `Merge pull request ...` commit it reaches rather than skipping it. This is
   documented at every invocation site (`release.yml`, `DEVELOPMENT.md`).
 - `CHANGELOG.md`'s current rich, hand-written prose entries (see any `[Unreleased]` 
-  entry today) become leaner, PR-title-derived entries under ShipIt. 
-  The `=== changelog ===` block convention in a PR body is the escape hatch for 
+  entry today) become leaner, commit-title-derived entries under ShipIt.
+  A `=== changelog ===` block in the commit message body is the escape hatch for
   entries that need more detail than a title provides.
 - Items 3 and 4 remain unaddressed after #234 closes; they need their own
   issues and, eventually, their own ADRs or ADR amendments.
@@ -120,9 +131,13 @@ opened. Step 1 of the implementation plan closed it. What was confirmed against 
 - The changelog remains the audit trail referenced by
   `docs/mdr/design-history/0000-change-log.md`; automating its generation must not 
   reduce its usefulness as a Design History File input, this is why the `=== changelog ===` 
-  escape hatch matters for anything with MDR-relevant detail. Concretely: `docs`, `build`,
-  and `chore` commits never reach the generated changelog, so any change of those types
-  that belongs in the Design History File needs the escape hatch to appear at all.
+  escape hatch matters for anything with MDR-relevant detail.
+- A known gap follows from the omission of `docs`, `build`, and `chore` commits: a
+  change of one of those types cannot reach the generated changelog at all, and no
+  escape hatch overrides that. Design-history-relevant changes are therefore tracked
+  through the ADRs in `docs/mdr/design-history/` and their entry in
+  `0000-change-log.md`, which do not depend on ShipIt's output. This ADR is itself an
+  instance: it lands as a `docs` commit and will not appear in any release section.
 
 ## References
 


### PR DESCRIPTION
- DEVELOPMENT.md's "Changelog & Release Automation" section claimed ShipIt was not wired into CI and did not update Directory.Build.props. Both are false as of the step 4/5 merges: release.yml runs it on every push to master, and the CHANGELOG front matter's updaters: block rewrites `/Project/PropertyGroup/Version` directly. Also records that `docs-`, `build-` and `chore-` typed commits are dropped from the generated changelog.
- ADR-0021 moves from Proposed to Accepted. Its "Verification gap to close before implementation" section is rewritten to record what step 1 actually confirmed rather than deleted, so the design history keeps the audit trail.
- Design choice 2 (disable merge commits) is reversed to match reality: all three merge methods stay enabled and `--skip-merge-commit` carries the load. The implementation plan's step 2 is struck through as dropped, not done.
