### PR TITLE
build(docker): default DOCKER_IMAGE to ghcr.io/informedica/genpres

### DIFF
--- a/Build.fs
+++ b/Build.fs
@@ -329,11 +329,12 @@ let requireEnvVar name =
 
 
 // Override via DOCKER_IMAGE if you're pushing to your own registry/namespace
-// rather than the project's `halcwb/genpres`.
+// rather than the project's `ghcr.io/informedica/genpres` (the same image
+// tag-release.yml's publish-docker-image job pushes on release).
 let dockerImage =
     match System.Environment.GetEnvironmentVariable "DOCKER_IMAGE" with
     | null
-    | "" -> "halcwb/genpres"
+    | "" -> "ghcr.io/informedica/genpres"
     | image -> image
 
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -102,7 +102,7 @@ packages for the Fable/Vite dev server).
 | `dotnet run TestHeadless` | `TestHeadless` | Build and run tests without launching a browser |
 | `dotnet run WatchTests` | `WatchTests` | Run tests in watch mode (re-runs on file changes) |
 | `dotnet run Format` | `Format` | Format all F# source files using Fantomas |
-| `dotnet run DockerBuild` | `DockerBuild` | Build the production image (`halcwb/genpres` by default, override with `DOCKER_IMAGE`), labelling it with the version from the root `Directory.Build.props` |
+| `dotnet run DockerBuild` | `DockerBuild` | Build the production image (`ghcr.io/informedica/genpres` by default, override with `DOCKER_IMAGE`), labelling it with the version from the root `Directory.Build.props` |
 | `dotnet run DockerRun` | `DockerRun` | Run the built image locally, using `GENPRES_URL_ID`/`GENPRES_PASSWORD` from the current environment (source `.env` first) |
 
 #### Target Dependency Chains
@@ -333,7 +333,7 @@ dotnet run
 
 Building and running the image no longer needs a hand-copied shell script: the `DockerBuild` and `DockerRun` FAKE targets (see [FAKE Build Targets Reference](#fake-build-targets-reference)) cover both, work identically from PowerShell, Git Bash, or any POSIX shell, and are tracked in `Build.fs` rather than living only as documentation. Neither target bakes `GENPRES_URL_ID` into the image — that constraint is enforced by the `Dockerfile` itself and described in [Environment Configuration](#environment-configuration).
 
-**Build** — `dotnet run DockerBuild` reads the app's single curated version number from the root `Directory.Build.props` and passes it to `docker build --build-arg APP_VERSION=...`, so the image's `org.opencontainers.image.version` label always matches what was built. To cross-build for a different platform set `DOCKER_PLATFORM`; to tag/push under your own name instead of the project's `halcwb/genpres` default, set `DOCKER_IMAGE` (both `DockerBuild` and `DockerRun` read it).
+**Build** — `dotnet run DockerBuild` reads the app's single curated version number from the root `Directory.Build.props` and passes it to `docker build --build-arg APP_VERSION=...`, so the image's `org.opencontainers.image.version` label always matches what was built. To cross-build for a different platform set `DOCKER_PLATFORM`; to tag/push under your own name instead of the project's `ghcr.io/informedica/genpres` default, set `DOCKER_IMAGE` (both `DockerBuild` and `DockerRun` read it).
 
 ```bash
 # local architecture
@@ -518,7 +518,8 @@ successful push — the workflow's `GITHUB_TOKEN` can't change package visibilit
 
 To build and smoke test the same image locally before relying on the workflow, use the existing
 `DockerBuild`/`DockerRun` FAKE targets (see [Docker wrappers](#docker-wrappers) above); they build
-`halcwb/genpres` by default (override with `DOCKER_IMAGE`), separate from what the workflow publishes.
+`ghcr.io/informedica/genpres` by default (override with `DOCKER_IMAGE`), matching what the workflow
+publishes, though the local build is never pushed.
 
 ### IDE Integration
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -917,7 +917,7 @@ This means you can always override `.env` values by setting an environment varia
 - **Shell**: Source `.env` manually with `set -a; source .env; set +a` before running commands.
 - **F# scripts (FSI)**: Scripts call `Informedica.Utils.Lib.Env.loadDotEnv()` which searches upward for `.env` from the current directory.
 - **IDEs (Rider, VS Code)**: The `Env.loadDotEnv()` call in scripts ensures variables are available even when the IDE doesn't inherit shell environment.
-- **Docker**: Inject `GENPRES_URL_ID` (and `GENPRES_PASSWORD` for admin operations) at *container runtime*, not at build time. Example: `docker run -e GENPRES_URL_ID="$GENPRES_URL_ID" -e GENPRES_PASSWORD="$GENPRES_PASSWORD" -p 8080:8085 halcwb/genpres`. For production, use a Docker or Kubernetes secret. **Do not** use `--build-arg`: the value would be persisted as image metadata and visible to anyone who can pull the image.
+- **Docker**: Inject `GENPRES_URL_ID` (and `GENPRES_PASSWORD` for admin operations) at *container runtime*, not at build time. Example: `docker run -e GENPRES_URL_ID="$GENPRES_URL_ID" -e GENPRES_PASSWORD="$GENPRES_PASSWORD" -p 8080:8085 ghcr.io/informedica/genpres`. For production, use a Docker or Kubernetes secret. **Do not** use `--build-arg`: the value would be persisted as image metadata and visible to anyone who can pull the image.
 
 #### Common Environment Variable Issues
 


### PR DESCRIPTION
DockerBuild/DockerRun still defaulted to halcwb/genpres, left over from before #459/#482 wired up GHCR publishing on release. Align the local default with what tag-release.yml publishes so a plain `dotnet run DockerBuild` produces the same image name as CI.  Update the DEVELOPMENT.md references to match.
