### PR TITLE
docs: trim ADRs to the decisions they record

### DIFF
--- a/docs/mdr/design-history/0001-system-architecture.md
+++ b/docs/mdr/design-history/0001-system-architecture.md
@@ -13,7 +13,7 @@ Adopt the SAFE Stack (Saturn, Azure, Fable, Elmish) as the technology foundation
 
 Two further foundational choices follow from it and are recorded here because they are equally hard to reverse:
 
-- **Google Spreadsheets as the configuration store.** All medication rules and constraints are authored in spreadsheets, downloaded as CSV and parsed at runtime; which spreadsheet is used is selected by the `GENPRES_URL_ID` environment variable. This lets clinical staff maintain the rule base without a developer, at the cost of coupling the system to an external service.
+- **Google Spreadsheets as the configuration store.** Medication rules and constraints are authored in spreadsheets, downloaded as CSV and parsed at runtime. This lets clinical staff maintain the rule base without a developer, at the cost of coupling the system to an external service. Note that `GENPRES_URL_ID` selects the *server's* sheet only; the client reads a few of its own sheets from IDs hard-coded in `Client/Utils.fs`, so it is not a single switch over all sheet-sourced data.
 - **Docker as the production delivery mechanism.**
 
 ## Consequences
@@ -21,7 +21,7 @@ Two further foundational choices follow from it and are recorded here because th
 - Server-side F# domain libraries remain pure and testable independent of the UI.
 - Client code (Fable/Elmish) compiles to JavaScript and runs in the browser.
 - Client and server share one type-safe contract through Fable.Remoting, so an API change that breaks a caller fails at compile time rather than at runtime.
-- Editing a production spreadsheet changes the behaviour of a running system with no deployment, which is the point — and the risk.
+- Editing a production spreadsheet changes the behaviour of a running system with no deployment, which is the point — and the risk. It is not instantaneous, though: the server holds resources in a `CachedResourceProvider` with no expiry, so an edit takes effect only after an admin `ReloadResources` (or a restart), and the client's own hard-coded sheets are separate again.
 - Proprietary medication cache files are not distributed with the repository; only demo cache files are.
 
 ## Alternatives considered

--- a/docs/mdr/design-history/0001-system-architecture.md
+++ b/docs/mdr/design-history/0001-system-architecture.md
@@ -11,222 +11,34 @@ GenPRES is a clinical decision support system (CDSS) for medication order manage
 
 Adopt the SAFE Stack (Saturn, Azure, Fable, Elmish) as the technology foundation for GenPRES. The system is structured as a client-server web application with all logic written in F#.
 
+Two further foundational choices follow from it and are recorded here because they are equally hard to reverse:
+
+- **Google Spreadsheets as the configuration store.** All medication rules and constraints are authored in spreadsheets, downloaded as CSV and parsed at runtime; which spreadsheet is used is selected by the `GENPRES_URL_ID` environment variable. This lets clinical staff maintain the rule base without a developer, at the cost of coupling the system to an external service.
+- **Docker as the production delivery mechanism.**
+
 ## Consequences
 
 - Server-side F# domain libraries remain pure and testable independent of the UI.
 - Client code (Fable/Elmish) compiles to JavaScript and runs in the browser.
-- All medication rules and configuration are stored in Google Spreadsheets, enabling non-developer updates.
-- Docker deployment is the primary production delivery mechanism.
+- Client and server share one type-safe contract through Fable.Remoting, so an API change that breaks a caller fails at compile time rather than at runtime.
+- Editing a production spreadsheet changes the behaviour of a running system with no deployment, which is the point — and the risk.
+- Proprietary medication cache files are not distributed with the repository; only demo cache files are.
 
----
+## Alternatives considered
 
-## Detailed Architecture
+Recorded retrospectively; the original decision predates this ADR format.
 
-This document describes the architecture of the GenPres application, a clinical decision support system (CDSS) for order management. The system is written entirely in F# and built with the SAFE Stack (Saturn, Azure, Fable, Elmish).
+- **A separate JavaScript/TypeScript front end** against an F# REST API. Rejected: it gives up the shared-type contract and forces the domain model to be restated in a second language — unacceptable where the model encodes dosing safety rules.
+- **A relational database for the rule base.** Rejected at this stage: it would put a developer or DBA between the clinical author and the rule, which is exactly the bottleneck the spreadsheet approach removes.
 
----
+## References
 
-## 1. High-Level Architecture
+The concrete code layout deliberately lives outside this ADR, so that it cannot go stale here:
 
-GenPres is a **client-server web application**:
-
-- **Server**: Runs in .NET (F#), can be hosted in a Docker container. Exposes a web API.
-- **Client**: F# (Fable) compiled to JavaScript, runs in the browser.
-- **Configuration**: All configuration and medication rules are (currently) maintained in Google Spreadsheets.
-- **Local Drug Repository**: Drug data is cached locally in text files for performance and offline access.
-
----
-
-## 2. Server
-
-### 2.1. Technologies
-
-- **F#** (.NET 10.0)
-- **Giraffe** for web server
-- **Saturn** for application composition
-- **Fable.Remoting** for type-safe API communication with the client
-
-For the canonical and up-to-date development toolchain requirements
-(.NET SDK, Node.js, npm), see the **Toolchain Requirements** section in
-[`DEVELOPMENT.md`](../../../DEVELOPMENT.md#toolchain-requirements).
-
-### 2.2. Structure
-
-- **Entry Point**: `src/Informedica.GenPRES.Server/Server.fs`
-- **API Implementation**: `src/Informedica.GenPRES.Server/ServerApi.fs`
-  - Implements protocol in `Informedica.GenPRES.Shared.Api.IServerApi`
-  - Processes commands from the client, performs calculations/validations, and returns results
-- **Domain Logic**: e.g., `src/Informedica.GenORDER.Lib`
-  - Uses F# MailboxProcessor (actor model) for concurrent/isolated processing (e.g., medication order calculations). NOT IMPLEMETENTED YET.
-
-### 2.3. Docker Hosting
-
-- **Dockerfile** builds the server, bundles the client, and sets up the environment.
-- Environment variables (e.g., `GENPRES_URL_ID`, `GENPRES_PROD`) configure which Google Spreadsheet is used for configuration.
-- Entry point: runs `dotnet Informedica.GenPRES.Server.dll` and exposes port 8085.
-
-**Example Docker Usage:**
-
-The proprietary `GENPRES_URL_ID` is **not** baked into the image. It must be
-injected at container runtime, preferably via a Docker or Kubernetes secret.
-
-```bash
-docker build -t halcwb/genpres .
-docker run -it -p 8080:8085 \
-  -e GENPRES_URL_ID="your_url_id" \
-  -e GENPRES_PASSWORD="your_admin_password" \
-  halcwb/genpres
-```
-
----
-
-## 3. Client
-
-### 3.1. Technologies
-
-- **F# (Fable)**: Compiles to JavaScript
-- **Elmish**: Model-View-Update architecture
-- **React**: UI rendering
-- **Vite**: Dev/bundle tooling (see `src/Informedica.GenPRES.Client/vite.config.js`)
-
-### 3.2. Structure
-
-- **Entry Point**: `src/Informedica.GenPRES.Client/App.fs` and `src/Informedica.GenPRES.Client/index.html`
-- Communicates with the server using Fable.Remoting proxies (`Informedica.GenPRES.Shared.Api.IServerApi`)
-- Handles application state, dispatches commands, and updates UI reactively
-
----
-
-## 4. Configuration via Google Spreadsheets
-
-- **All rules, constraints, and medication data** (except local drug cache) are stored in Google Spreadsheets.
-  - URLs are constructed dynamically and downloaded as CSV.
-  - Example: `https://docs.google.com/spreadsheets/d/{id}/gviz/tq?tqx=out:csv&sheet={sheet}`
-- **F# Modules** (e.g., `Informedica.Utils.Lib.Web.GoogleSheets`) handle fetching and parsing of spreadsheet data.
-- **Which spreadsheet to use** is controlled by the `GENPRES_URL_ID` environment variable.
-
----
-
-## 5. Local Medication Repository
-
-- **Data Cache**: Proprietary cache files (not distributed publicly) containing medication product information.
-  - Used for fast lookup/calculation and offline use.
-  - Demo cache files are included for development.
-  - Path: `src/Informedica.GenPRES.Server/data/cache/README.md` explains the folder usage.
-
-- **Medication Data Types and Logic**:
-  - Main types are defined in `src/Informedica.NKF.Lib/Drug.fs` and `src/Informedica.GenORDER.Lib/Types.fs`
-  - Includes types for Medication, Dose, Route, Schedule, and Medication order.
-  - Medication data can be loaded from local cache or generated from Google Sheets.
-
----
-
-## 5.1. Domain Architecture and Transformation Pipeline
-
-GenPres implements a comprehensive domain architecture described in detail in the `docs/domain` folder. For complete architectural specifications, see:
-
-- **[Core Domain Model](../../domain/core-domain.md)**: Defines the transformation pipeline from expert knowledge to executable orders
-- **[GenFORM](../../domain/genform-free-text-to-operational-rules.md)**: Transforms free text to Operational Knowledge Rules (OKRs)
-- **[GenORDER](../../domain/genorder-operational-rules-to-orders.md)**: Transforms OKRs to Order Scenarios and defines the Order Model (Orderable, Component, Item)
-- **[GenSOLVER](../../domain/gensolver-from-orders-to-quantitative-solutions.md)**: Quantitative constraint solving engine
-
-### Key Domain Concepts
-
-The system implements a transformation pipeline:
-
-```text
-Free Text → [GenFORM] → OKRs → [GenORDER] → Order Scenarios → [GenSOLVER] → Quantitative Solutions
-```
-
-**Operational Knowledge Rules (OKRs)** define:
-
-- Selection Constraints (Generic, Indication, Route, Patient Category, Dose Type, etc.)
-- Calculation Constraints (Dose Limits, Schedule, Duration, Volumes, Concentrations)
-
-**Order Model** (hierarchical structure):
-
-- Order → Prescription → Orderable → Component → Item → Dose
-
-For details on:
-
-- Rule types (Dose Rule, Solution Rule, Reconstitution Rule, Renal Rule), see [GenFORM Section 3](../../domain/genform-free-text-to-operational-rules.md#3-sources-and-types-of-dose-rules)
-- Order model structure, see [GenORDER Section 6](../../domain/genorder-operational-rules-to-orders.md#6.-order-model-(executable-structure))
-- Dose semantics (Quantity, Per Time, Rate, Total, Adjusted), see [GenORDER Section 7](../../domain/genorder-operational-rules-to-orders.md#7.-quantitative-dose-semantics)
-- Equation system (65 equations), see [GenORDER Appendix D.1](../../domain/genorder-operational-rules-to-orders.md#appendix-d.1.-equations-table)
-- Constraint solving algorithm, see [GenSOLVER Section 3](../../domain/gensolver-from-orders-to-quantitative-solutions.md#3.-formal-constraint-solving-model)
-
-### Core Capabilities
-
-1. **Order-Independent Calculations**: The constraint-based equation system allows calculations regardless of data entry order
-2. **Automatic Unit Handling**: All calculations use base units with automatic conversion
-3. **Absolute Precision**: Uses BigRationals to avoid rounding errors
-4. **Range and Restriction Modeling**: Supports dose ranges, frequency sets, and value constraints
-5. **Safety by Construction**: Invalid options are mathematically impossible to construct
-6. **Completeness Guarantee**: All valid options are preserved by the constraint solver
-
----
-
-## 6. Build and Development
-
-- **Development**: `dotnet run` for full stack, or `dotnet run list` for targets.
-- **Client**: Open browser at `http://localhost:5173`.
-- **Production**: Deploy via Docker.
-- **Environmental Variables**:
-  - `GENPRES_URL_ID`: Google Spreadsheet ID for config/data
-  - `GENPRES_LOG`, `GENPRES_PROD`, `GENPRES_DEBUG`: Control logging, production/demo mode, etc.
-
----
-
-## 7. Key Data Flow
-
-1. **Startup**:
-    - Server loads configuration from Google Spreadsheets (as CSV).
-    - Loads or generates local drug cache.
-2. **Runtime**:
-    - Client sends commands (e.g., calculate dose) via API.
-    - Server processes, applies rules, validates, and returns results.
-    - Drug lookup/calculation uses both spreadsheet config and local cache as needed.
-3. **Updates**:
-    - To update rules or configuration, edit the Google Spreadsheets referenced by the server.
-
----
-
-## 8. References
-
-### Technical Stack
-
-- [SAFE Stack Documentation](https://safe-stack.github.io/docs/)
-- [Saturn](https://saturnframework.org/)
-- [Fable](https://fable.io/docs/)
-- [Elmish](https://elmish.github.io/elmish/)
-- [.NET 10.0](https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-10/overview)
-
-### Domain Architecture
-
-- [Core Domain Model](../../domain/core-domain.md)
-- [GenFORM: Free Text to Operational Rules](../../domain/genform-free-text-to-operational-rules.md)
-- [GenORDER: Operational Rules to Orders](../../domain/genorder-operational-rules-to-orders.md)
-- [GenSOLVER: Order Scenarios to Quantitative Solutions](../../domain/gensolver-from-orders-to-quantitative-solutions.md)
-
----
-
-## 9. Notes & Limitations
-
-- Some medication data is proprietary and not included in the public repo.
-- Only demo cache files are distributed for development and testing.
-- The drug repository logic and calculation code is modular and can be extended for new data sources.
-
----
-
-## 10. Key Files and Libraries
-
-### Core Server Files
-
-- `src/Informedica.GenPRES.Server/Server.fs`: Application entry point
-- `src/Informedica.GenPRES.Server/ServerApi.fs`: API implementation
-- `src/Informedica.GenPRES.Client/App.fs`: Client application entry
-- `Dockerfile`: Container configuration for deployment
-
-### Domain Libraries
-
-For the complete library list with dependency order, see the [Core Libraries](../../../DEVELOPMENT.md#core-libraries) section in DEVELOPMENT.md. For detailed library specifications including capabilities, see [GenFORM Appendix B.3](../../domain/genform-free-text-to-operational-rules.md#addendum-b3-genform-libraries).
+- Build, run, toolchain and folder structure: [DEVELOPMENT.md](../../../DEVELOPMENT.md)
+- Domain architecture:
+  - [Core Domain Model](../../domain/core-domain.md)
+  - [GenFORM: Free Text to Operational Rules](../../domain/genform-free-text-to-operational-rules.md)
+  - [GenORDER: Operational Rules to Orders](../../domain/genorder-operational-rules-to-orders.md)
+  - [GenSOLVER: Order Scenarios to Quantitative Solutions](../../domain/gensolver-from-orders-to-quantitative-solutions.md)
+- Technical stack: [SAFE Stack](https://safe-stack.github.io/docs/), [Saturn](https://saturnframework.org/), [Fable](https://fable.io/docs/), [Elmish](https://elmish.github.io/elmish/), [.NET 10.0](https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-10/overview)

--- a/docs/mdr/design-history/0009-mcp-server-architecture.md
+++ b/docs/mdr/design-history/0009-mcp-server-architecture.md
@@ -62,13 +62,21 @@ Only `GenFORM.Lib` and `GenORDER.Lib` are exposed. The others are deliberately n
 | `Informedica.Utils.Lib` | Pure utility functions |
 | `Informedica.GenPRES.Server` | Already exposes the full API via `IServerApi`; MCP is an additional pathway, not a replacement |
 
-## Dependency
+## Dependencies
 
-The only new external dependency is the official .NET MCP SDK, `ModelContextProtocol`,
-maintained by the [modelcontextprotocol GitHub organisation](https://github.com/modelcontextprotocol/csharp-sdk).
-It is pinned to an exact version in `paket.dependencies` rather than a floating specifier, so
-builds stay reproducible as MDR traceability requires; re-run a GitHub Advisory Database check
-before each deliberate bump. No changes were required to `GenFORM.Lib` or `GenORDER.Lib`.
+Two new external dependencies, both listed in `src/Informedica.MCP.Lib/paket.references`:
+
+- `ModelContextProtocol` — the official .NET MCP SDK, maintained by the
+  [modelcontextprotocol GitHub organisation](https://github.com/modelcontextprotocol/csharp-sdk).
+- `Microsoft.Extensions.Hosting` — the generic host the SDK's server builder is wired into
+  (`McpServer.fs` opens it directly).
+
+The decision is to pin exact versions in `paket.dependencies` rather than floating specifiers, so
+builds stay reproducible as MDR traceability requires, and to re-run a GitHub Advisory Database
+check before each deliberate bump. `ModelContextProtocol` is pinned (`1.2.0`);
+`Microsoft.Extensions.Hosting` is currently declared without a version constraint and so does not
+yet follow this decision — `paket.lock` is what holds it steady today. No changes were required to
+`GenFORM.Lib` or `GenORDER.Lib`.
 
 ## Notes
 

--- a/docs/mdr/design-history/0009-mcp-server-architecture.md
+++ b/docs/mdr/design-history/0009-mcp-server-architecture.md
@@ -26,230 +26,15 @@ Implement MCP (Model Context Protocol) servers for `Informedica.GenFORM.Lib` and
 - <https://modelcontextprotocol.io/introduction>
 - <https://github.com/jovaneyck/fsi-mcp-server> — F# MCP server reference implementation
 
----
+## Transport
 
-## Table of Contents
-
-- [Summary](#summary)
-- [What Is MCP?](#what-is-mcp)
-- [Motivation](#motivation)
-- [Proposed Architecture](#proposed-architecture)
-  - [Overview](#overview)
-  - [Informedica.MCP.Lib](#informedicamcplib)
-  - [MCP Tool Mapping](#mcp-tool-mapping)
-    - [GenFORM Tools](#genform-tools)
-    - [GenORDER Tools](#genorder-tools)
-  - [Hosting Options](#hosting-options)
-- [Integration with Existing Architecture](#integration-with-existing-architecture)
-  - [Relationship to the Server Layering](#relationship-to-the-server-layering)
-- [Safety and Security Considerations](#safety-and-security-considerations)
-- [Implementation Approach](#implementation-approach)
-  - [Script Prototyping Plan](#script-prototyping-plan)
-  - [NuGet Dependencies](#nuget-dependencies)
-  - [Libraries Excluded](#libraries-excluded)
-- [Architecture Status](#architecture-status)
-
----
-
-## Summary
-
-The GenPRES system exposes medication knowledge (prescription rules, dose rules, solution rules, order contexts) through its `GenFORM` and `GenORDER` libraries. The **Model Context Protocol (MCP)** provides a standard interface for AI assistants to call external tools, making it possible to expose these libraries as AI-callable services without changing the domain logic.
-
-This ADR describes the plan to implement MCP servers for `Informedica.GenFORM.Lib` and `Informedica.GenORDER.Lib` using the existing placeholder `Informedica.MCP.Lib` and the existing `IResourceProvider` / `CachedResourceProvider` infrastructure.
-
-The initial scope is **read-only tools** only — no write operations that could affect running clinical workflows.
-
----
-
-## What Is MCP?
-
-The **Model Context Protocol** (MCP) is an open standard that allows AI assistants (LLMs) to interact with external systems through a defined protocol. An MCP server exposes:
-
-- **Tools** — callable functions with a name, description, and JSON Schema input specification
-- **Resources** — readable content (e.g., documents, data)
-- **Prompts** — pre-defined conversation templates
-
-When an AI assistant encounters a question it can answer with external data, it calls a tool, receives the response, and incorporates it into its answer. This is analogous to function calling in OpenAI or tool use in Anthropic's Claude.
-
-```text
-AI Assistant
-    │  tool call: { name: "get_dose_rules", input: { generic: "paracetamol" } }
-    ▼
-MCP Server (GenFORM / GenORDER)
-    │  invokes: GenForm.Api.filterDoseRules provider filter doseRules
-    ▼
-    │  response: { doseRules: [...] }
-    ▼
-AI Assistant incorporates response into answer
-```
-
----
-
-## Motivation
-
-GenPRES already exposes its medication knowledge through:
-
-1. A web API (`IServerApi`) for the Fable client
-2. Direct F# function calls for server-side composition
-
-Adding MCP servers enables a third access pathway — AI assistants — without duplicating or changing any domain logic. Practical use cases include:
-
-- An AI coding assistant asking "which dose rules exist for morphine IV in neonates?" during development
-- A clinical decision support AI consulting GenFORM to validate a dose before suggesting it
-- Automated testing harnesses using AI to generate and verify medication scenarios
-
-The `Informedica.MCP.Lib` project already exists as a placeholder in the solution. This ADR specifies how to fill it.
-
----
-
-## Proposed Architecture
-
-### Overview
-
-```text
-┌──────────────────────────────────────────────────────────────────┐
-│  AI Assistant / MCP Client                                       │
-│  (Claude Desktop, Cursor, VS Code Copilot, custom agent, etc.)  │
-└──────────────────────────┬───────────────────────────────────────┘
-                           │  MCP protocol (JSON-RPC 2.0 over stdio / SSE)
-                           ▼
-┌──────────────────────────────────────────────────────────────────┐
-│  Informedica.MCP.Lib                                             │
-│  McpServer (ModelContextProtocol NuGet)                          │
-│  ├── GenFormMcpServer   — tools backed by GenFORM API            │
-│  └── GenOrderMcpServer  — tools backed by GenORDER API           │
-└──────────────────────────┬───────────────────────────────────────┘
-                           │  delegates to
-                           ▼
-┌──────────────────────────────────────────────────────────────────┐
-│  Informedica.GenFORM.Lib / Informedica.GenORDER.Lib              │
-│  (IResourceProvider, Api.fs functions — unchanged)               │
-└──────────────────────────────────────────────────────────────────┘
-```
-
-The MCP layer is a **thin adapter**: it translates JSON tool calls into strongly typed F# function calls and serialises the responses back to JSON. No domain logic lives in `Informedica.MCP.Lib`.
-
-### Informedica.MCP.Lib
-
-The library currently contains only a stub (`Library.fs`). The plan is to replace this with:
-
-```text
-src/Informedica.GenFORM.Lib/Scripts/
-└── McpTools.fsx            — ✅ prototype script for GenFORM tools
-
-src/Informedica.GenORDER.Lib/Scripts/
-└── McpTools.fsx            — ✅ prototype script for GenORDER tools
-
-src/Informedica.MCP.Lib/
-├── Library.fs              — stub (to be removed after review)
-├── Scripts/
-│   └── McpServer.fsx       — ✅ MCP server wiring design prototype
-├── McpServer.fs            — MCP server wiring + entry-point helpers  (after review)
-├── McpTools.GenForm.fs     — tool handlers for GenFORM               (after review)
-└── McpTools.GenOrder.fs    — tool handlers for GenORDER              (after review)
-```
-
-> **Policy note**: Per `AGENTS.md`, new code must first be prototyped in `.fsx` scripts. The prototype scripts (✅ already committed) live in each library's own `Scripts/` folder because they need `load.fsx` from the same directory to access the library's compiled DLLs and source files. The `.fs` files listed above are created inside `Informedica.MCP.Lib` only after the human reviewer has approved the scripted prototypes.
-
-### MCP Tool Mapping
-
-Each MCP tool maps to one or more existing `GenFORM.Api` or `GenORDER.Api` functions. All tools are **read-only**; they never mutate resource state.
-
-#### GenFORM Tools
-
-| Tool name | API function | Description |
-|-----------|-------------|-------------|
-| `get_dose_rules` | `Api.getDoseRules provider` | Return all dose rules |
-| `filter_dose_rules` | `Api.filterDoseRules provider filter doseRules` | Filter dose rules by generic, route, form, patient category |
-| `get_solution_rules` | `Api.getSolutionRules provider` | Return all solution rules |
-| `get_renal_rules` | `Api.getRenalRules provider` | Return all renal adjustment rules |
-| `get_prescription_rules` | `Api.getPrescriptionRules provider patient` | Return prescription rules for a patient category |
-| `filter_prescription_rules` | `Api.filterPrescriptionRules provider filter` | Filter prescription rules |
-| `get_resource_info` | `provider.GetResourceInfo()` | Return cache status (last updated, loaded, messages) |
-| `get_formulary` | `provider.GetFormularyProducts()` | Return the list of formulary products |
-| `get_parenteral_meds` | `provider.GetParenteralMeds()` | Return available parenteral medications |
-
-**Input schema example — `filter_dose_rules`**:
-
-```json
-{
-  "type": "object",
-  "properties": {
-    "generic":    { "type": "string", "description": "Generic drug name (e.g. 'paracetamol')" },
-    "route":      { "type": "string", "description": "Administration route (e.g. 'iv', 'oraal')" },
-    "form":       { "type": "string", "description": "Drug form (e.g. 'tablet', 'infuusvloeistof')" },
-    "indication": { "type": "string", "description": "Clinical indication (optional)" },
-    "minAge":     { "type": "number", "description": "Minimum patient age in months (optional)" },
-    "maxAge":     { "type": "number", "description": "Maximum patient age in months (optional)" },
-    "minWeight":  { "type": "number", "description": "Minimum body weight in kg (optional)" },
-    "maxWeight":  { "type": "number", "description": "Maximum body weight in kg (optional)" }
-  },
-  "required": []
-}
-```
-
-#### GenORDER Tools
-
-| Tool name | API function | Description |
-|-----------|-------------|-------------|
-| `create_order_context` | `OrderContext.create logger provider patient` | Create a new order context for a patient |
-| `get_order_scenarios` | `OrderContext.getScenarios logger provider ctx` | Return available order scenarios for the current context |
-| `get_order_context_filter_options` | `OrderContext.getRules logger provider ctx` | Return available filter options (generics, routes, indications, forms) |
-| `get_dose_rules_for_context` | `OrderContext.getDoseRules provider filter` | Return dose rules for the current filter state |
-| `get_solution_rules_for_context` | `OrderContext.getSolutionRules provider generic form route` | Return solution rules for a specific drug |
-| `summarise_order_scenario` | `OrderContext.toString stage ctx` | Produce a human-readable summary of an order context |
-
-> **Note**: Navigation commands (increase/decrease dose, select scenario) are deferred to a later phase. The initial release is strictly read-only.
-
-### Hosting Options
-
-An MCP server can be hosted in multiple ways:
-
-| Option | Transport | Use case |
-|--------|-----------|----------|
-| **stdio** | Standard input/output | Local AI assistant (Claude Desktop, VS Code extension) |
-| **SSE** | Server-Sent Events (HTTP) | Remote AI agent or cloud deployment |
-| **In-process** | Direct .NET function call | Integration tests; embedding in GenPRES.Server |
-
-For the initial implementation, **stdio** transport is the primary target because:
-
-- It requires no network configuration
-- It is the standard for the reference implementation (fsi-mcp-server)
-- Claude Desktop and VS Code Copilot both support stdio-hosted MCP servers
-
-SSE transport can be added later to allow remote AI agents to call the server.
-
----
-
-## Integration with Existing Architecture
-
-### Relationship to the Server Layering
-
-The MCP server is a **new presentation layer** alongside the existing Fable.Remoting API, not a replacement. Tool handlers call `GenForm.Api` functions through the `IResourceProvider`, which is the stable boundary:
-
-```text
-┌──────────────────────────────────────────────────────────────┐
-│  PRESENTATION                                                │
-│  ├── IServerApi (Fable.Remoting)  — web client               │
-│  └── IMcpServer (MCP protocol)    — AI assistants  [NEW]     │
-├──────────────────────────────────────────────────────────────┤
-│  APPLICATION LAYER  (ServerApi.Services.fs, .Ports.fs)       │
-├──────────────────────────────────────────────────────────────┤
-│  DOMAIN  GenOrder.Lib  GenForm.Lib  GenSolver.Lib            │
-│          (pure — no changes required)                        │
-└──────────────────────────────────────────────────────────────┘
-```
-
-The MCP server can be hosted:
-
-- **Standalone** — a separate executable that loads `IResourceProvider` independently
-- **Embedded** — started inside `GenPRES.Server` on a background thread (SSE transport)
-
-For developer tooling, standalone is preferred. For production AI integration, embedded SSE is more appropriate.
-
----
+`stdio` is the primary transport: it needs no network configuration, it is what the
+`fsi-mcp-server` reference implementation uses, and both Claude Desktop and VS Code Copilot
+support stdio-hosted MCP servers. SSE (Server-Sent Events over HTTP) is deferred to a later
+phase for remote agents, and would additionally require authentication — see constraint 4 below.
 
 ## Safety and Security Considerations
+
 
 GenPRES is a **medical device software** project. The following constraints apply to the MCP integration:
 
@@ -265,53 +50,9 @@ GenPRES is a **medical device software** project. The following constraints appl
 
 6. **Review gate**: Per the repository policy, no new code may be merged to `.fs` source files without human review. The MCP implementation follows the scripts-first workflow.
 
----
+## Libraries excluded, and why
 
-## Implementation Approach
-
-Following the repository's **script-based development workflow** (see `AGENTS.md`):
-
-### Script Prototyping Plan
-
-1. **Prototype GenFORM tools** in `src/Informedica.GenFORM.Lib/Scripts/McpTools.fsx`
-   - Load `load.fsx` to access `GenFORM` types and functions
-   - Define tool input/output types as anonymous records
-   - Implement handler functions calling `GenForm.Api.*`
-   - Test with sample inputs (paracetamol, morphine, gentamicin)
-
-2. **Prototype GenORDER tools** in `src/Informedica.GenORDER.Lib/Scripts/McpTools.fsx`
-   - Load `load.fsx` to access `GenORDER` types and functions
-   - Implement handler functions for `create_order_context`, `get_order_scenarios`
-   - Test with `Scenarios.pcmSupp`, `Scenarios.morfCont` test cases
-
-3. **Prototype MCP server wiring** in `src/Informedica.MCP.Lib/Scripts/McpServer.fsx`
-   - Reference the `ModelContextProtocol` NuGet package
-   - Wire tool handlers into an `McpServerBuilder`
-   - Run against Claude Desktop or a mock MCP client
-
-4. **Human review** of all three scripts
-
-5. **Migration to source files** (only after approval):
-   - `McpTools.GenForm.fs` — tool handlers
-   - `McpTools.GenOrder.fs` — tool handlers
-   - `McpServer.fs` — server builder and entry point
-   - Update `Informedica.MCP.Lib.fsproj` to include new files and the `ModelContextProtocol` reference
-
-### NuGet Dependencies
-
-The only new external dependency required is the official .NET MCP SDK:
-
-| Package | Version | Use |
-|---------|---------|-----|
-| `ModelContextProtocol` | 1.2.0 | MCP server builder, tool registration, stdio/SSE transport |
-
-> **Security check** (performed 2026-03-29): The `ModelContextProtocol` package at version `1.2.0` was checked against the GitHub Advisory Database — no known vulnerabilities found. Before adding this dependency, re-run the advisory check to verify it remains clean. Pin the dependency to an exact version (e.g. `1.2.0`) in `paket.dependencies` and update it deliberately rather than using a floating or wildcard specifier, to ensure reproducible builds as required by MDR traceability.
-
-The `ModelContextProtocol` package is maintained by the [modelcontextprotocol GitHub organisation](https://github.com/modelcontextprotocol/csharp-sdk), which is the official .NET implementation. The fsi-mcp-server reference uses the same package.
-
-No changes are required to `GenFORM.Lib`, `GenORDER.Lib`, or any other library project.
-
-### Libraries Excluded
+Only `GenFORM.Lib` and `GenORDER.Lib` are exposed. The others are deliberately not:
 
 | Library | Reason |
 |---------|--------|
@@ -321,17 +62,16 @@ No changes are required to `GenFORM.Lib`, `GenORDER.Lib`, or any other library p
 | `Informedica.Utils.Lib` | Pure utility functions |
 | `Informedica.GenPRES.Server` | Already exposes the full API via `IServerApi`; MCP is an additional pathway, not a replacement |
 
-## Architecture Status
+## Dependency
 
-| Component | Status |
-|-----------|--------|
-| `Informedica.MCP.Lib` placeholder | ✅ Exists in solution |
-| GenFORM MCP tool prototype script | ✅ Added (`src/Informedica.GenFORM.Lib/Scripts/McpTools.fsx`) |
-| GenORDER MCP tool prototype script | ✅ Added (`src/Informedica.GenORDER.Lib/Scripts/McpTools.fsx`) |
-| MCP server wiring prototype script | ✅ Added (`src/Informedica.MCP.Lib/Scripts/McpServer.fsx`) |
-| Human review of scripts | ⬜ Pending review |
-| Source file migration | ⬜ Pending review |
-| stdio transport | ⬜ Not started |
-| SSE transport | ⬜ Deferred (phase 2) |
-| Audit logging integration | ⬜ Not started |
-| Claude Desktop configuration | ⬜ Not started |
+The only new external dependency is the official .NET MCP SDK, `ModelContextProtocol`,
+maintained by the [modelcontextprotocol GitHub organisation](https://github.com/modelcontextprotocol/csharp-sdk).
+It is pinned to an exact version in `paket.dependencies` rather than a floating specifier, so
+builds stay reproducible as MDR traceability requires; re-run a GitHub Advisory Database check
+before each deliberate bump. No changes were required to `GenFORM.Lib` or `GenORDER.Lib`.
+
+## Notes
+
+The tool surface, its wiring and its hosting are code, not documentation: see
+`src/Informedica.MCP.Lib/` (`McpServer.fs`, `McpTools.GenForm.fs`, `McpTools.GenOrder.fs`)
+and the standalone stdio host `src/Informedica.MCP.Server/Program.fs`.

--- a/docs/mdr/design-history/0014-staged-value-expansion-timed-orders.md
+++ b/docs/mdr/design-history/0014-staged-value-expansion-timed-orders.md
@@ -55,7 +55,7 @@ Before this ADR, one safeguard already existed:
 
 | Safeguard | Location | Threshold | Limitation |
 |---|---|---|---|
-| `ValueSet.create` hard limit | Variable.fs:970 | `> MAX_CALC_COUNT²` (250,000) → raise `ValueSetOverflow` | Fires **after** the cartesian product is computed; raises an error that terminates the solve |
+| `ValueSet.create` hard limit | `Variable.fs` | `> MAX_CALC_COUNT²` (250,000) → raise `ValueSetOverflow` | Fires **after** the cartesian product is computed; raises an error that terminates the solve |
 
 The `ValueSet.create` limit is a last-resort error, not a graceful fallback. When it fires, the entire solve fails and the order cannot be calculated.
 
@@ -66,8 +66,8 @@ This ADR introduces three new defenses (in addition to the existing hard limit):
 | Safeguard | Location | Threshold | Behavior |
 |---|---|---|---|
 | Staged value expansion | `Order.fs`, `OrderProcessor.fs` | N/A (structural) | Expands dose qty before rate for timed orders |
-| `ValueRange.calc` cartesian product cap | Variable.fs:2900-2908 | `c1 * c2 > MAX_CALC_COUNT` (500) | Falls back to min/max bounds |
-| `Increment.calcOpt` cap | Variable.fs:220-224 | `c1 * c2 > 10` → return `None` | Prevents increment explosion |
+| `ValueRange.calc` cartesian product cap | `Variable.fs` | `c1 * c2 > MAX_CALC_COUNT` (500) | Falls back to min/max bounds |
+| `Increment.calcOpt` cap | `Variable.fs` | `c1 * c2 > 10` → return `None` | Prevents increment explosion |
 
 ---
 
@@ -182,72 +182,6 @@ Same treatment as CalcValues — two-phase expansion for timed orders.
 - **CanSetNormDose guard interaction**: With `skipRate = true`, the Rate variable will not have discrete values, so `CanSetNormDose` returns `false`. This causes the `ensure-dose-values-1` guard (`_.CanSetNormDose >> not`) to trigger correctly. If this guard logic changes in the future, the staged expansion behavior must be re-validated
 - **Continuous orders must NOT use skipRate**: The condition `Schedule.isContinuous |> not` is critical because for Continuous orders, rate IS the primary dose variable. If this condition were accidentally removed, Continuous orders would fail
 
-### Verification
-
-#### Prototype Script
-
-The approach was validated in a prototype script (`src/Informedica.GenORDER.Lib/Scripts/StagedExpansion.fsx`) using module shadowing — not by modifying source files. The following test cases were run against the shadowed implementation:
-
-| Test | Scenario | Result |
-|---|---|---|
-| 1 | Kaliumchloride OnceTimed CalcMinMax | No overflow. Pre-existing `set-normdose` error (unrelated). |
-| 2 | Paracetamol OnceTimed CalcMinMax | Succeeded (regression check). |
-| 3 | Paracetamol Once CalcMinMax | Succeeded (non-timed order unaffected). |
-| 4 | Kaliumchloride CalcMinMax + CalcValues | CalcValues succeeded after CalcMinMax. Rate resolved to reasonable values. |
-
-All existing server tests continue to pass after migration to source files.
-
-#### Key Observations from Test Results
-
-After staged expansion, the kaliumchloride order shows:
-
-- Orderable dose qty: 31.5 mL (median, single value)
-- Orderable dose rate: 20 mL/uur..5 mL/uur..30 mL/uur (3 values, manageable)
-- Component dose qty: 14.5; 15; 15.5; 16; 16.5; 17 mL (6 values)
-- Substance dose qty adj: 0.47; 0.48; 0.5; 0.52; 0.53; 0.55 mmol/kg (within 0.45-0.55 mmol/kg constraint)
-
-### Implementation
-
-#### Files to Modify
-
-| File | Change |
-|---|---|
-| `Order.fs` | Add `skipRate: bool` parameter to `minIncrMaxToValues`. When true, omit dose rate from variable expansion list. |
-| `OrderProcessor.fs` | Thread `skipRate` through `calcValuesStep` and `reCalcValuesStep`. Split CalcValues and ReCalcValues into two-phase steps for timed orders. |
-
-#### Function Signature Change
-
-```fsharp
-// Before
-let minIncrMaxToValues useMaxNumberOfValues minTime logger ord =
-
-// After
-let minIncrMaxToValues useMaxNumberOfValues minTime (skipRate: bool) logger ord =
-```
-
-#### Variable List Change
-
-```fsharp
-// Before
-let ovars =
-    [
-        yield! ord.Orderable.Components |> List.map (_.OrderableQuantity >> Quantity.toOrdVar)
-        ord.Orderable.Dose.Quantity |> Quantity.toOrdVar
-        ord.Orderable.Dose.Rate |> Rate.toOrdVar
-    ]
-
-// After
-let ovars =
-    [
-        yield! ord.Orderable.Components |> List.map (_.OrderableQuantity >> Quantity.toOrdVar)
-        ord.Orderable.Dose.Quantity |> Quantity.toOrdVar
-        if not skipRate then
-            ord.Orderable.Dose.Rate |> Rate.toOrdVar
-    ]
-```
-
----
-
 ## Part 2: ValueRange Cartesian Product Cap (GenSOLVER)
 
 ### Context
@@ -284,9 +218,9 @@ The value accumulation happens through multiple propagation rounds:
 
 #### Where the Existing Cap Falls Short
 
-The existing `Increment.calcOpt` cap (Variable.fs:220-224) prevents increment explosion with a threshold of `c1 * c2 > 10`. However, this only applies to **increment** calculations, not to `ValSet × ValSet` multiplications.
+The existing `Increment.calcOpt` cap (`Variable.fs`) prevents increment explosion with a threshold of `c1 * c2 > 10`. However, this only applies to **increment** calculations, not to `ValSet × ValSet` multiplications.
 
-The `ValueSet.create` hard limit (Variable.fs:970) catches values exceeding `MAX_CALC_COUNT²` (250,000), but it fires **after** the full cartesian product has been computed by `BigRational.calcCartesian`. At that point:
+The `ValueSet.create` hard limit (`Variable.fs`) catches values exceeding `MAX_CALC_COUNT²` (250,000), but it fires **after** the full cartesian product has been computed by `BigRational.calcCartesian`. At that point:
 
 - The expensive `n × m` array allocation and computation has already happened
 - The error raises an exception that terminates the entire solve
@@ -296,64 +230,14 @@ The `ValueSet.create` hard limit (Variable.fs:970) catches values exceeding `MAX
 
 #### Add Pre-Check to ValueRange.calc
 
-Add a size guard in `ValueRange.calc` (Variable.fs:2900-2902) that checks the combined size of two `ValSet` operands **before** computing the cartesian product. When `c1 * c2` exceeds `MAX_CALC_COUNT` (500), fall back to computing only min/max bounds instead of the full cartesian product.
+Add a size guard in `ValueRange.calc` that checks the combined size of two `ValSet` operands
+**before** computing the cartesian product. When `c1 * c2` exceeds `MAX_CALC_COUNT` (500), fall
+back to computing only min/max bounds instead of the full cartesian product — the same fallback
+the function already takes under `onlyMinIncrMax`.
 
-**Before** (Variable.fs:2900-2902):
-
-```fsharp
-| ValSet s1, ValSet s2 ->
-    if not onlyMinIncrMax || s1 |> ValueSet.count = 1 && s2 |> ValueSet.count = 1 then
-        ValueSet.calc op s1 s2 |> ValSet
-    else
-        let min1, max1 = vr1 |> getMin, vr1 |> getMax
-        let min2, max2 = vr2 |> getMin, vr2 |> getMax
-        let min, max = calcMinMax min1 max1 min2 max2
-        match min, max with
-        | None, None -> unrestricted
-        | _ -> create min None max None
-```
-
-**After**:
-
-```fsharp
-| ValSet s1, ValSet s2 ->
-    let c1 = s1 |> ValueSet.count
-    let c2 = s2 |> ValueSet.count
-
-    if (not onlyMinIncrMax
-        && (c1 = 1
-            || c2 = 1
-            || c1 <= Constants.MAX_CALC_COUNT / (max c2 1)))
-       || (onlyMinIncrMax && c1 = 1 && c2 = 1) then
-        ValueSet.calc op s1 s2 |> ValSet
-    else
-        let min1, max1 = vr1 |> getMin, vr1 |> getMax
-        let min2, max2 = vr2 |> getMin, vr2 |> getMax
-        let min, max = calcMinMax min1 max1 min2 max2
-        match min, max with
-        | None, None -> unrestricted
-        | _ -> create min None max None
-```
-
-Note: The guard uses `c1 <= MAX_CALC_COUNT / (max c2 1)` instead of `c1 * c2 <= MAX_CALC_COUNT` to avoid `int32` overflow. Division-based comparison is always safe regardless of input sizes.
-
-#### Logic Explanation
-
-The condition `(not onlyMinIncrMax && (c1 = 1 || c2 = 1 || c1 <= Constants.MAX_CALC_COUNT / (max c2 1)))` means:
-
-- When in full value mode (`onlyMinIncrMax=false`):
-  - If either operand has exactly 1 value → always safe to compute (result = other operand's size)
-  - If the combined product is ≤ 500 → compute the cartesian product (using overflow-safe division check)
-  - Otherwise → fall back to min/max bounds
-- When in min/max mode (`onlyMinIncrMax=true`):
-  - Only compute cartesian product when both operands have exactly 1 value (existing behavior preserved)
-
-#### Why MAX_CALC_COUNT (500) as Threshold
-
-- The existing `Increment.calcOpt` uses a threshold of 10 for increments
-- The existing `ValueSet.create` uses `MAX_CALC_COUNT²` (250,000) as a hard error limit
-- `MAX_CALC_COUNT` (500) is a balanced middle ground: large enough to allow normal equation solving but small enough to prevent the runaway accumulation seen in the overflow scenario
-- When the cap triggers, the min/max fallback still constrains the variable correctly — it just does not enumerate all discrete values
+Precision is deliberately traded for termination: the result is a bound rather than an enumerated
+set, which the solver can still propagate. The alternative — letting the product build and then
+failing on `ValueSetOverflow` — turns a solvable order into an error the clinician cannot act on.
 
 ### Consequences
 
@@ -382,19 +266,11 @@ The fix was validated by:
 3. **GenORDER integration tests**: 39 tests passed (no regressions)
 4. **Live order test**: Kaliumchloride continuous IV order for 24 kg patient solved successfully — 994 equations solved, 0 errors in log (previously failed with `ValueSetOverflow 355037`)
 
-### Implementation
-
-| File | Line | Change |
-|---|---|---|
-| `Variable.fs` | 2900-2913 | Added `c1 * c2 <= Constants.MAX_CALC_COUNT` pre-check to `ValueRange.calc`. Falls back to min/max when cartesian product would be too large. |
-
----
-
 ## Summary of All Value Explosion Defenses
 
 | Defense | Layer | Location | Threshold | Behavior |
 |---|---|---|---|---|
 | Staged value expansion | GenORDER pipeline | `Order.fs`, `OrderProcessor.fs` | N/A (structural) | Expands dose qty before rate for timed orders |
-| ValueRange cartesian product cap | GenSOLVER solver | Variable.fs:2900-2913 | `c1 * c2 > MAX_CALC_COUNT` (500) | Falls back to min/max bounds |
-| Increment calcOpt cap | GenSOLVER solver | Variable.fs:220-224 | `c1 * c2 > 10` | Returns `None` (no increment) |
-| ValueSet.create hard limit | GenSOLVER solver | Variable.fs:970 | `> MAX_CALC_COUNT²` (250,000) | Raises `ValueSetOverflow` error (last resort) |
+| ValueRange cartesian product cap | GenSOLVER solver | `Variable.fs`, `ValueRange.calc` | `c1 * c2 > MAX_CALC_COUNT` (500) | Falls back to min/max bounds |
+| Increment calcOpt cap | GenSOLVER solver | `Variable.fs`, `Increment.calcOpt` | `c1 * c2 > 10` | Returns `None` (no increment) |
+| ValueSet.create hard limit | GenSOLVER solver | `Variable.fs`, `ValueSet.create` | `> MAX_CALC_COUNT²` (250,000) | Raises `ValueSetOverflow` error (last resort) |

--- a/docs/mdr/design-history/0016-gstand-dose-rule-fallback.md
+++ b/docs/mdr/design-history/0016-gstand-dose-rule-fallback.md
@@ -11,7 +11,7 @@
 ## Context
 
 GenPRES dose rules are sourced primarily from Google Spreadsheets managed by
-clinical pharmacists (`GenFORM.DoseRule.get`). This crowd-sourced dataset
+clinical pharmacists (`GenFORM.Api.getDoseRules`). This crowd-sourced dataset
 provides excellent coverage for paediatric patients but often lacks rules for
 the *adult* patient category because GenPRES is a paediatric system and adult
 rules have historically not been entered.


### PR DESCRIPTION
## Overview

Part 2 of 5 of a `docs/` consistency pass driven by issue #411 — the part that acts on #411 directly.

Related: #411. Companion PRs: #490 (library ledger), #492 (domain docs), #493 (guides and references), #494 (roadmap).

## What was changed

Three ADRs were mostly code maps, implementation plans and before/after diffs rather than decision records. Each is trimmed to Context / Decision / Consequences / Alternatives.

**ADR-0001, 232 → 44 lines.** Dropped sections 2–10, a developer-reference code map duplicating `DEVELOPMENT.md`. Deleting it disposed of four false statements rather than repairing them:

- `ServerApi.fs` — since split into eight `ServerApi.*.fs` files.
- The cache README path — moved to `data/cache/` under the unified `AppPath` resolver.
- `halcwb/genpres` — now `ghcr.io/informedica/genpres` per ADR-0021.
- *"MailboxProcessor … NOT IMPLEMETENTED YET"* — disproved by `Informedica.Agents.Lib` and `ServerApi.AgentAdapters.fs` (and misspelled).

The SAFE Stack decision, its consequences, and a retrospectively written alternatives section remain.

**ADR-0009, 337 → 77 lines.** Dropped the implementation plan and the Architecture Status table, which was wrong in **every row**: the MCP server shipped in `ab0c9578` on 2026-03-30, five months before the ADR was last edited. Source migration is done, stdio transport exists (`McpServer.fs` calls `.WithStdioServerTransport()`), and the tools are live. Kept: the decision, the transport choice, the safety constraints, the excluded-libraries rationale, the pinned-dependency decision.

**ADR-0014, 400 → 264 lines.** Dropped the "Files to Modify" table with before/after F# diffs (commit-message content) and the prototype-verification tables, which cite a `StagedExpansion.fsx` that no longer exists. Line numbers replaced with file and symbol names.

Also corrected ADR-0016: `GenFORM.DoseRule.get` does not exist; the accessor is `Api.getDoseRules`.

## Why

Issue #411 asks that ADRs be reserved for decisions that are hard to reverse, and that anything better served by a code comment, a test or a commit message be left out. These three were the clearest remaining cases after the earlier cleanup in #440 — and, as #411 predicts, the code-structure sections were exactly the parts that had gone stale.

ADRs 0015, 0018, 0019 and 0021 are well-formed and untouched.

## Verification

Checked mechanically across the whole `docs/` tree, not just the changed files:

- Every relative Markdown link resolves (273 links, 0 broken).
- Every `src/...` path named in the docs exists, or is explicitly marked as removed.
- Every `Informedica.*.Lib` named in `DEVELOPMENT.md` resolves to a directory **and** to a project in `GenPRES.sln`.
- Every anchor into the GenSOLVER document resolves to a real heading.
- `npx markdownlint-cli2` warning counts compared against the pre-change baseline per file: no new warnings (one fewer in the Dutch guide).
- `dotnet run ServerTests`: build clean, 6101 passed / 0 failed / 2 skipped. Markdown-only change, so this only confirms no build input was touched.

## Author checklist

I confirm that these changes:

- [x] Follow the process described in [CONTRIBUTING.md](../CONTRIBUTING.md#Pull_Request_Process).
- [x] Are limited to documentation (no source code changes).
- [x] Are accurate and up to date.
- [x] Are clearly written and understandable by the intended audience.
- [x] Don't introduce broken links or formatting issues.

## AI assistance disclosure

Per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-contributions): **this PR is vibe coded.** All prose was written by Claude Opus 5 in Claude Code, working from an audit of `docs/` against the codebase. No `.fs` source is touched.

Every factual claim was verified against the code before being written, and the checks above are reproducible. Two findings from the audit turned out to be wrong and were corrected rather than applied:

- The FTK extraction pipeline was reported as non-existent. It was renamed (`ftk_extract_v2.fsx` → `Informedica.NLP.Lib.fsx`) and lives in a gitignored directory, so a git-based search finds nothing.
- A "repo-wide library casing error" was reported and briefly applied before being reverted: namespaces are `Informedica.GenUnits.Lib` while directories are `Informedica.GenUNITS.Lib`. Both are correct in context.

Reviewers should still treat the prose as needing a human read, particularly the clinical wording in the user guides.
