### PR TITLE
fix(genform): fix eager evaluation that perform IO (issue #523)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   build:
     strategy:
+      # Without this, one leg's failure cancels the other two and you cannot tell a
+      # platform-specific break from a universal one. Issue #523 failed on ubuntu and
+      # reported the macOS and Windows legs only as "The operation was canceled".
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     runs-on: ${{ matrix.os }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,51 @@ The same applies to the docker ignore file.
 - IO and parsing functions should return `GenFormResult<'T>` (i.e., Result). Use `FsToolkit.ErrorHandling.ResultCE` computation expression for readability (`result { let! x = ... }`).
 - When editing `ResourceConfig` or callers, make sure to handle `Result` values consistently; use `Result.bind`, CE, or `delay` for unit-returning getters.
 
+## Never Perform IO in a Top-Level `let` Value
+
+F# packs every top-level `let` **value** binding of a compilation unit into a single static
+initializer (`<StartupCode$X>.$File..cctor()`). So a value whose right-hand side performs IO runs
+that IO the first time *anything* in the file is touched — and .NET caches a failed type
+initializer for the life of the process, so one touch poisons the type permanently. Under Expecto
+this kills test *discovery* for the whole assembly: it produces zero results while `dotnet test`
+still exits non-zero, so the summary reads "0 failed" on a red build.
+
+The distinction is **value vs. function**, and it is easy to miss when the IO hides behind a
+partial application:
+
+```fsharp
+// BAD — a VALUE. `getKFMedications ()` is applied here, so the HTTP fetch runs in the
+// file's static constructor, triggered by any unrelated binding in the same file.
+let getLink = Source.getLink (getKFMedications ())
+
+// GOOD — a FUNCTION. The fetch happens on first actual use; `getKFMedications` is
+// memoized, so it still runs at most once per process.
+let getLink source gen = Source.getLink (getKFMedications ()) source gen
+```
+
+Nesting inside a sub-module does **not** isolate it — the cctor is per file, not per module.
+
+Two idioms already in the codebase do this correctly; follow them:
+
+- **Memoized accessor** — `src/Informedica.NKF.Lib/WebSiteParser.fs`:
+  `let medications : unit -> Drug.Drug list = memoizeN _medications` (memoized, *not* applied).
+  The same shape appears ~40 times in `src/Informedica.ZIndex.Lib/Zindex.fs`.
+  `Memoization.memoize` is `ConcurrentDictionary + Lazy`, so `f` runs at most once per key even
+  under concurrent access.
+- **Explicit `lazy`** — `src/Informedica.Utils.Lib/AppPath.fs`:
+  `let root = lazy (resolveRoot ())` with `let rootPath () = root.Value`, deliberately deferred so
+  that an `Env.loadDotEnv ()` setting `GENPRES_ROOT` runs first.
+
+This applies to network calls, file reads, `.env` loading, `Web.getDataFromSheet`, and anything
+under `Async.RunSynchronously`. It applies to test files too: work done at module level in a test
+module runs at discovery time, so wrap expensive or fallible fixtures in `lazy`, or guard them with
+`try/with` as `tests/Informedica.ZIndex.Tests/Tests.fs` does.
+
+Incidents caused by this exact pattern: [#523](https://github.com/informedica/GenPRES/issues/523)
+(HTTP fetch in `GenFORM.Lib/DoseRule.fs`), commit `8617f7a6` (ZIndex tables touched before the test
+fixtures existed), and the Google-sheet fetch since replaced by injection in
+`tests/Informedica.GenORDER.Tests/Tests.fs`.
+
 ## BigRational & ValueUnit Semantics
 
 - BigRational operations are used broadly for dosing math. Respect existing helpers in `Informedica.GenUnits.Lib`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,7 +161,7 @@ Two idioms already in the codebase do this correctly; follow them:
 
 - **Memoized accessor** — `src/Informedica.NKF.Lib/WebSiteParser.fs`:
   `let medications : unit -> Drug.Drug list = memoizeN _medications` (memoized, *not* applied).
-  The same shape appears ~40 times in `src/Informedica.ZIndex.Lib/Zindex.fs`.
+  Every BST table module in `src/Informedica.ZIndex.Lib/Zindex.fs` uses the same shape.
   `Memoization.memoize` is `ConcurrentDictionary + Lazy`, so `f` runs at most once per key even
   under concurrent access.
 - **Explicit `lazy`** — `src/Informedica.Utils.Lib/AppPath.fs`:

--- a/src/Informedica.GenFORM.Lib/DoseRule.fs
+++ b/src/Informedica.GenFORM.Lib/DoseRule.fs
@@ -83,10 +83,6 @@ module DoseRule =
         let kinderFormUrl = "https://www.kinderformularium.nl/geneesmiddelen.json"
 
 
-        let farmocoTherapeutischKompas =
-            "https://www.farmacotherapeutischkompas.nl/bladeren/preparaatteksten/n/GENERIEK#doseringen"
-
-
         let private _medications () =
             let res = JsonValue.Load kinderFormUrl
 
@@ -103,7 +99,15 @@ module DoseRule =
         let getKFMedications = Memoization.memoize _medications
 
 
-        let getLink = Source.getLink (getKFMedications ())
+        /// <summary>
+        /// Find the Kinderformularium link for a <c>Source</c> / <c>GenericLabel</c> pair.
+        /// </summary>
+        /// <remarks>
+        /// Without parameters, the right will be a value and will be evaluated eagerly. See
+        /// "Never Perform IO in a Top-Level `let` Value" in AGENTS.md.
+        /// </remarks>
+        let getLink source gen =
+            Source.getLink (getKFMedications ()) source gen
 
 
         /// See for use of anonymous record in


### PR DESCRIPTION
## Overview

`Print.getLink` in `src/Informedica.GenFORM.Lib/DoseRule.fs` was a top-level **value** whose
right-hand side eagerly applied `getKFMedications ()`, fetching
`https://www.kinderformularium.nl/geneesmiddelen.json`.

F# packs every top-level value binding of a compilation unit into a single static constructor
(`<StartupCode$X>.$DoseRule..cctor()`), so this HTTP call ran the first time *anything* in
`DoseRule.fs` was touched — including pure mapping code that has nothing to do with links.
Nesting the binding inside `module Print` did not isolate it: the constructor is per file, not
per module. .NET caches a failed type initializer for the life of the process, so a single
failure poisons the type permanently.

When kinderformularium.nl reset the connection on a GitHub runner, this killed Expecto test
*discovery* for the whole `Informedica.GenFORM.Tests` assembly. The result was the confusing part:

> `Test Summary: 5717 passed, 0 failed, 6 skipped` — on a **red** build.

No test failed. The assembly produced zero results, `dotnet test` still exited 1, the FAKE
`ServerTests` target failed, and the matrix default `fail-fast: true` cancelled the macOS and
Windows legs with only "The operation was canceled".

Changes:

- **`getLink` takes explicit parameters**, so the fetch happens on first actual lookup instead of
  at module initialization. `getKFMedications` remains memoized (`Memoization.memoize` is
  `ConcurrentDictionary + Lazy`), so the fetch still runs at most once per process. The call site
  at `DoseRule.fs:176` relies on partial application and is unchanged.
- **Removed the unused `farmocoTherapeutischKompas` constant** — dead, zero references repo-wide.
- **`fail-fast: false` on the CI matrix**, so one leg's failure stops hiding whether a break is
  platform-specific.
- **Documented the rule in AGENTS.md** (*"Never Perform IO in a Top-Level `let` Value"*), with the
  value-vs-function distinction, the two correct idioms already in the codebase, and the note that
  it applies to test files too.

Fixes #523

## Further information

This pattern has now caused three separate incidents in this repo:

1. #523 — this one.
2. Commit `8617f7a6` — ZIndex tables touched at module init before the synthetic test fixtures
   existed. The comments at `tests/Informedica.ZIndex.Tests/Tests.fs:19-26` and `:585-597` already
   spell out this exact failure mode.
3. A live Google-sheet fetch at module init in the GenORDER tests, since replaced by injection
   (see `tests/Informedica.GenORDER.Tests/Tests.fs:175-204`).

The lesson was documented in test-file comments but not anywhere an author of *library* code would
look, which is why the AGENTS.md section is part of this PR rather than a follow-up.

A wider audit found the same class of bug in four more places, none of them currently breaking:
`ZIndex.Lib/BST001T.fs:102,117` (eager G-Standaard file read), the 22 eager
`let posl = BST001T.getPosl name` bindings in `ZIndex.Lib/Zindex.fs` (which defeat the otherwise
correct memoisation across all the BST table modules), `ZIndex.Lib/FilePath.fs:53` (forces
`AppPath`'s deliberate `lazy`), and `ZForm.Lib/Utils.fs:70` (eager `.env` read). These are latent
rather than breaking and are deliberately left out to keep this PR small; they will be raised as
follow-up issues on #523.

## Divergence from plan

None.

Per CONTRIBUTING.md, changes under 25 lines of code may go straight to an implementation PR without
an issue and plan. The code change here is 14 lines in one file; the remaining diff is documentation
(AGENTS.md) and CI config (build.yml). An issue (#523) exists regardless.

## Verification

**The fix was proved, not assumed.** I compared the built DLL before and after by touching a pure
binding (`DoseRule.fromTupleInclExcl`) with the fetch made to fail, and inspecting the stack:

| | Result |
|---|---|
| **before** | `TypeInitializationException` → `<StartupCode$Informedica-GenFORM-Lib>.$DoseRule..cctor()` at `DoseRule.fs:106` |
| **after** | plain exception originating from the explicit caller — no `TypeInitializationException`, no `cctor` in the stack |

That is the behaviour change: the failure is now attributable to the caller and catchable, instead
of permanently poisoning the type and taking discovery down with it.

Automated:

- `dotnet run build` — 0 errors, 0 warnings
- `dotnet run ServerTests` — <fill in>
- `dotnet test tests/Informedica.GenFORM.Tests/` — **400 passed, 0 failed**
- `dotnet fantomas --check .` — clean

Edge cases considered:

- **Arity at the call site.** `DoseRule.fs:176` calls `getLink dr.Source` and relies on the result
  being a `GenericLabel -> string option`. The two-parameter form preserves that; it compiles and
  the round-trip tests exercise the path.
- **Once-only semantics.** The `unit` key goes through `Memoization.memoize`'s dedicated null-key
  path (`Memoization.fs:33`), a `Lazy` with `ExecutionAndPublication`, so `_medications` runs
  exactly once per process even under concurrent access.
- **Behaviour on outage.** A network failure now surfaces from `Print.toMarkdown` at render time
  rather than at an arbitrary earlier point. That is strictly better attribution, but it does mean
  `ServerApi.Services.fs:200` and `PrescriptionRule.fs:388` can now see it at request time. Whether
  `_medications` should also degrade gracefully to `[]` (falling back to the existing `"*Lokaal*"`
  at `DoseRule.fs:178`) is a separate question and will be raised as its own issue.

To see it locally: `dotnet run build && dotnet run ServerTests`. To observe the original failure,
temporarily point `kinderFormUrl` (`DoseRule.fs:83`) at an unreachable host and run
`dotnet test tests/Informedica.GenFORM.Tests/` — before this change the assembly reports zero tests;
after it, the suite passes, because none of those tests ever needed a formulary link.

## Author checklist

I confirm that these changes:

- [x] Follow the process described in [CONTRIBUTING.md](../CONTRIBUTING.md#Pull_Request_Process).
- [x] Make the changes proposed in the linked issue (if applicable): #523
- [x] Follow the approach documented in the linked implementation plan (if applicable): n/a — 14 lines of code changed, under the 25-line threshold
- [x] Are no more than 200 lines of changed code, ideally 25-100.
- [x] Are not more complex than necessary.
- [x] Cannot easily be split in a way that would make reviewing them significantly easier.
- [x] Follow the guidelines specified in [DEVELOPMENT.md](../../DEVELOPMENT.md).
- [x] Have been thoroughly tested.
- [x] Don't introduce new security vulnerabilities.
- [x] Follow the [AI/LLM Usage Policy](../../AGENTS.md#aillm-usage-policy) — LLMs were not given direct write access to `.fs` source files (except client-side UI code).

### AI/Vibe Coding Disclosure

- [x] Some or all code in this PR is **vibe coded** (substantially AI-generated). If checked, describe below which parts were AI-generated, which tool was used, and how the code was verified.

Tool: Claude Code.

- **`src/Informedica.GenFORM.Lib/DoseRule.fs`** — written and applied by me (the human author).
  Claude diagnosed the CI failure, produced a plan with the proposed before/after, and reviewed the
  result; it was not given write access to the file, per the AI/LLM Usage Policy.
- **`AGENTS.md`** and **`.github/workflows/build.yml`** — drafted by Claude at my request. Neither
  is an `.fs` source file. I reviewed both before committing.
- **Verification** — the before/after type-initializer probe, the build, the Fantomas check and the
  GenFORM test run were carried out by Claude and are reproduced above; I confirmed the results.

I confirm that I have:

- [ ] Added appropriate automated tests.
- [x] Updated documentation appropriately.
- [x] Added comments that highlight important changes and add justification, where necessary.
