### PR TITLE
build: name test-discovery failures in the ServerTests target

### DIFF
--- a/Build.fs
+++ b/Build.fs
@@ -249,18 +249,20 @@ Target.create
                 printfn "-------------------------------------------------------------------------"
 
                 if totalFailed.Value = 0 then
-                    // The signature of a test DISCOVERY failure: a non-zero exit while
-                    // every assembly that did load reports 0 failures. An assembly whose
-                    // static initializer throws produces no results at all, so it adds
-                    // nothing to these counters and the summary reads green on a red
-                    // build. See issue #523.
+                    // Results are missing rather than failing: every assembly that did report
+                    // reported no failures, so whatever went wrong produced no summary at all.
+                    // A discovery failure does this (a static initializer that throws yields no
+                    // results — see issue #523), but so does a crashed or cancelled test host,
+                    // so name the likely cause without asserting it.
                     failwithf
-                        $"dotnet test exited %i{result.ExitCode} with 0 reported failures \
-                          (%i{totalPassed.Value} passed). This is the signature of a test \
-                          DISCOVERY failure: an assembly's static initializer threw before \
-                          Expecto could enumerate its tests. Search the dumped output above \
-                          for TypeInitializationException, and look for a top-level `let` \
-                          VALUE binding that performs IO — see issue #523."
+                        $"dotnet test exited %i{result.ExitCode}, but no assembly reported a \
+                          failing test (%i{totalPassed.Value} passed). Results are missing \
+                          rather than failing. Most often an assembly threw during discovery, \
+                          before Expecto could enumerate its tests — look for a top-level \
+                          `let` VALUE binding that performs IO, and search the dumped output \
+                          above for TypeInitializationException (see issue #523). A crashed \
+                          or cancelled test host looks the same, so check the output above \
+                          for a project that reported no summary line at all."
                 else
                     failwithf "Tests failed with exit code %d" result.ExitCode
 

--- a/Build.fs
+++ b/Build.fs
@@ -248,11 +248,25 @@ Target.create
                 captured |> Seq.iter (printfn "%s")
                 printfn "-------------------------------------------------------------------------"
 
-                failwithf "Tests failed with exit code %d" result.ExitCode
+                if totalFailed.Value = 0 then
+                    // The signature of a test DISCOVERY failure: a non-zero exit while
+                    // every assembly that did load reports 0 failures. An assembly whose
+                    // static initializer throws produces no results at all, so it adds
+                    // nothing to these counters and the summary reads green on a red
+                    // build. See issue #523.
+                    failwithf
+                        $"dotnet test exited %i{result.ExitCode} with 0 reported failures \
+                          (%i{totalPassed.Value} passed). This is the signature of a test \
+                          DISCOVERY failure: an assembly's static initializer threw before \
+                          Expecto could enumerate its tests. Search the dumped output above \
+                          for TypeInitializationException, and look for a top-level `let` \
+                          VALUE binding that performs IO — see issue #523."
+                else
+                    failwithf "Tests failed with exit code %d" result.ExitCode
 
             if totalTests.Value = 0 then
                 failwith
-                    "No tests were discovered or run. The solution was likely not built/restored before 'dotnet test'."
+                    "No tests were discovered or run. The solution was likely not built/restored before `dotnet test`."
     )
 
 Target.create "CheckVersions" (fun _ -> run dotnet [ "fsi"; "scripts/CheckSolutionVersions.fsx" ] ".")


### PR DESCRIPTION
## Overview

Makes the `ServerTests` FAKE target say something useful when a test assembly's results go missing.

A test assembly whose static initializer throws produces no results at all. It contributes nothing
to the pass/fail counters, so `dotnet test` exits non-zero while the summary reads `0 failed`
alongside thousands of passes. That is how #523 stayed opaque through a full CI matrix:

```
Test Summary: 5717 passed, 0 failed, 6 skipped, 5723 total
```

on a red build, with no indication that `Informedica.GenFORM.Tests` had vanished.

The existing `totalTests = 0` guard did not help, because it only fires when *every* project
reports zero. Here fifteen other assemblies reported normally, so the total was large.

This splits the non-zero-exit branch in two:

- no assembly reported a failure → say that results are missing rather than failing, and give the
  likely causes
- anything else → the existing "Tests failed with exit code N"

The separate `totalTests = 0` guard is unchanged. It covers the opposite case, a **zero** exit with
nothing run, which is the regression commit `8617f7a6` added it for.

Fixes #531

## Further information

**On what the check can and cannot prove.** A non-zero exit with no reported failures shows that
results are *missing*, not *why*. A crashed or cancelled test host produces the same shape. The
first version of this message asserted that a static initializer had thrown and told the reader to
search for a `TypeInitializationException`, which would be a wild goose chase in those cases —
raised by Greptile and fixed in `ae76ae9e`. The message now states what is certain, names a
discovery failure as the most common cause, and points at the alternative. It also gives a way to
tell them apart: a discovery failure leaves one project with no summary line in the output the
target already dumps.

An alternative design would be to assert that all sixteen test projects reported results, which
would also have caught #523. I did not, because that count goes stale the moment a test project is
added. The exit-code-with-no-failures signature needs no maintenance.

The `fail-fast: false` half of this work, which stopped one failing matrix leg from cancelling the
other two, went in with #524.

**Note for the reviewer:** this branch is off `master`, so it still contains the eager
Kinderformularium fetch that #524 fixes. If CI runs here while kinderformularium.nl is unreachable,
the new guard will fire on this very PR. That is the guard working, not a defect. Merging #524
first removes the ambiguity.

## Divergence from plan

None. Under 25 lines of code changed, so no implementation plan was required.

## Verification

Both new branches only run on failure, so I exercised each one deliberately rather than relying on
inspection. Both were re-run after the `ae76ae9e` wording change.

**Results missing** — pointed `kinderFormUrl` (`DoseRule.fs:83`) at `http://127.0.0.1:9` on a
throwaway edit and ran `dotnet run ServerTests`:

```
ServerTests  (dotnet test exited 1, but no assembly reported a failing test (5721 passed).
Results are missing rather than failing. Most often an assembly threw during discovery, before
Expecto could enumerate its tests — look for a top-level `let` VALUE binding that performs IO,
and search the dumped output above for TypeInitializationException (see issue #523). A crashed
or cancelled test host looks the same, so check the output above for a project that reported no
summary line at all.)
```

That reproduces #523's signature exactly: exit 1, thousands passed, zero failed.

**Ordinary test failure** — changed one expected value in
`tests/Informedica.GenUNITS.Tests/Tests.fs:236` (`0.4m` → `0.5m`) and ran `dotnet run ServerTests`:

```
ServerTests  (Tests failed with exit code 1)
```

Generic message, the missing-results message correctly suppressed.

Both scratch edits were reverted and the working tree confirmed clean before committing.

Also: `dotnet build Build.fsproj` — 0 errors, 0 warnings; `dotnet fantomas --check Build.fs` — clean.

To reproduce either case, apply the corresponding one-line edit above and run
`dotnet run ServerTests`.

## Author checklist

I confirm that these changes:

- [x] Follow the process described in [CONTRIBUTING.md](../CONTRIBUTING.md#Pull_Request_Process).
- [x] Make the changes proposed in the linked issue (if applicable): #531
- [x] Follow the approach documented in the linked implementation plan (if applicable): n/a — 18 lines changed, under the 25-line threshold
- [x] Are no more than 200 lines of changed code, ideally 25-100.
- [x] Are not more complex than necessary.
- [x] Cannot easily be split in a way that would make reviewing them significantly easier.
- [x] Follow the guidelines specified in [DEVELOPMENT.md](../../DEVELOPMENT.md).
- [x] Have been thoroughly tested.
- [x] Don't introduce new security vulnerabilities.
- [x] Follow the [AI/LLM Usage Policy](../../AGENTS.md#aillm-usage-policy) — LLMs were not given direct write access to `.fs` source files (except client-side UI code).

### AI/Vibe Coding Disclosure

- [x] Some or all code in this PR is **vibe coded** (substantially AI-generated). If checked, describe below which parts were AI-generated, which tool was used, and how the code was verified.

Tool: Claude Code.

`Build.fs` is build tooling, not library or clinical code. I wrote the first version myself; after
three rounds of review in which Claude found the logic unreachable (the new check sat after a
`failwithf` that always throws) and flagged that I had deleted the existing `totalTests = 0` guard,
I asked Claude to make the edit directly. It restructured the branch and wrote the message string,
and later rewrote that string in response to Greptile's review.

I reviewed the result, and both branches were verified by real runs, reproduced above.

Note this is an explicit, narrowly scoped exception to the usual `.fs` rule under the "targeted
refactoring of a single function when explicitly requested" clause in AGENTS.md. No library or
clinical code was touched.

I confirm that I have:

- [ ] Added appropriate automated tests.
- [x] Updated documentation appropriately.
- [x] Added comments that highlight important changes and add justification, where necessary.