### PR TITLE
test(genform): defer fixture work out of test discovery

### DIFF
--- a/tests/Informedica.GenFORM.Tests/Tests.fs
+++ b/tests/Informedica.GenFORM.Tests/Tests.fs
@@ -1359,14 +1359,20 @@ module DoseRuleRoundtripTests =
         |> File.ReadAllText
         |> FixtureJson.deSerialize<'T>
 
-    let private data = load<DoseRuleData[]> "doserules.json"
-    let private rm = load<RouteMapping[]> "routemappings.json"
-    let private prods = load<ProductComponent[]> "products.json"
+    // `lazy`, not plain values: a module-level binding runs in this module's static
+    // constructor, i.e. during Expecto's test discovery. Anything that throws there
+    // takes down the whole assembly, which then reports zero tests instead of one
+    // failure — exactly how issue #523 hid a red build behind "0 failed". Lazy is
+    // thread-safe by default, so each is still computed at most once even though
+    // Expecto runs tests in parallel.
+    let private data = lazy (load<DoseRuleData[]> "doserules.json")
+    let private rm = lazy (load<RouteMapping[]> "routemappings.json")
+    let private prods = lazy (load<ProductComponent[]> "products.json")
 
     // fr = [||]: fromData uses FormRoute only for FormLimit, which toData does not
     // emit and the round-trip does not compare (as DoseRuleProductTests do).
     let private forward (d: DoseRuleData[]) =
-        DoseRuleLoader.fromData rm [||] prods d |> fst
+        DoseRuleLoader.fromData rm.Value [||] prods.Value d |> fst
 
 
     // ---- comparison machinery (mirrors the scratch Analyse module) ----
@@ -1549,9 +1555,10 @@ module DoseRuleRoundtripTests =
             | _ -> true
         )
 
-    // computed once
-    let private g1 = generate data
-    let private g2 = generate g1
+    // Computed once, on first use rather than at test-discovery time (see the note
+    // on the fixture bindings above).
+    let private g1 = lazy (generate data.Value)
+    let private g2 = lazy (generate g1.Value)
 
 
     // NOTE: the literal counts below (206/52/299/202) are INTENTIONAL snapshot
@@ -1567,18 +1574,20 @@ module DoseRuleRoundtripTests =
             "DoseRule round-trip (offline fixtures)"
             [
                 test "fixtures load and forward builds rules" {
-                    data.Length |> Expect.equal "subset dose-rule rows" 206
-                    prods.Length |> Expect.equal "subset products" 52
-                    (data |> forward |> Array.length) |> Expect.equal "PASS 1 forward rules" 299
+                    data.Value.Length |> Expect.equal "subset dose-rule rows" 206
+                    prods.Value.Length |> Expect.equal "subset products" 52
+
+                    (data.Value |> forward |> Array.length)
+                    |> Expect.equal "PASS 1 forward rules" 299
                 }
 
                 test "PASS 1 round-trips the source-derived fixture (frozen counts)" {
-                    g1.Length |> Expect.equal "PASS 1 generated (distinct)" 202
-                    (missing data g1).Length |> Expect.equal "PASS 1 missing" 0
+                    g1.Value.Length |> Expect.equal "PASS 1 generated (distinct)" 202
+                    (missing data.Value g1.Value).Length |> Expect.equal "PASS 1 missing" 0
                 }
 
                 test "PASS 2 is a 100% containment fixpoint" {
-                    (missing g1 g2).Length
+                    (missing g1.Value g2.Value).Length
                     |> Expect.equal "PASS 2 missing (every input contained)" 0
                 }
             ]
@@ -3319,11 +3328,16 @@ module Tests =
             |> System.IO.File.ReadAllText
             |> FixtureJson.deSerialize<'T>
 
+        // `lazy` for the same reason as DoseRuleRoundtripTests' fixtures: as a plain
+        // value this reads three files and runs the loader in this module's static
+        // constructor, during test discovery, where a throw costs the whole assembly
+        // its results rather than failing the one test that needs this (issue #523).
         let private sampleDoseRule =
-            let data = fixture<DoseRuleData[]> "doserules.json"
-            let rm = fixture<RouteMapping[]> "routemappings.json"
-            let prods = fixture<ProductComponent[]> "products.json"
-            DoseRuleLoader.fromData rm [||] prods data |> fst |> Array.head
+            lazy
+                (let data = fixture<DoseRuleData[]> "doserules.json"
+                 let rm = fixture<RouteMapping[]> "routemappings.json"
+                 let prods = fixture<ProductComponent[]> "products.json"
+                 DoseRuleLoader.fromData rm [||] prods data |> fst |> Array.head)
 
         let tests =
             testList
@@ -3510,7 +3524,7 @@ module Tests =
                                 Seq.empty
 
                         let result =
-                            Check.checkDoseRuleWithProvider fakeProvider Patient.patient sampleDoseRule
+                            Check.checkDoseRuleWithProvider fakeProvider Patient.patient sampleDoseRule.Value
 
                         calls > 0 |> Expect.isTrue "injected provider was invoked"
 


### PR DESCRIPTION
## Overview

Removes the mechanism by which one failure in the GenFORM library erases every test result in
`Informedica.GenFORM.Tests`.

Module-level bindings run in the module's static constructor, which Expecto triggers while
*discovering* tests — before any test body executes. Two modules did substantial work there:

- `DoseRuleRoundtripTests` read three fixture JSON files (`:1362-1364`) and ran the full
  forward/reverse round-trip over all 206 rows (`g1`/`g2`, `:1553-1554`).
- `CheckTests.sampleDoseRule` (`:3331`) read the same three files and ran `DoseRuleLoader.fromData`.

If any of that throws, the assembly cannot load, so it reports **zero** tests instead of one
failure. That is precisely how #523 hid a red build behind `0 failed`: the throw happened inside
`DoseRuleLoader.fromData`, reached from `g1`, at discovery time.

Both sets are now wrapped in `lazy` and read through `.Value`. Same computation, same once-only
semantics — `Lazy` is thread-safe by default, which matters because Expecto runs tests in parallel
— just deferred until a test actually asks for it.

The frozen snapshot counts (206/52/299/202) and the `missing … = 0` containment invariants are
untouched.

Fixes #525

## Divergence from plan

**Wider than the issue described.** #525 named only `DoseRuleRoundtripTests` and estimated "roughly
nine places". While verifying the fix I deleted a fixture file to check the new behaviour, and the
assembly still failed to load — the stack pointed at `CheckTests.sampleDoseRule` (`:3331`), a
second module-level binding doing the same thing in a different module. Fixing only the module the
issue named would have left the assembly just as fragile, so `CheckTests` is included here.

That is why the diff touches two modules and 32 lines rather than the ~9 the issue anticipated, and
why the verification below shows **4** failures rather than 3.

## Verification

The point of this change is behaviour under failure, so I tested that directly rather than relying
on the suite still passing.

Deleted `fixtures/doserules.json` from the test project's build output and ran
`dotnet test tests/Informedica.GenFORM.Tests/ --no-build`:

| | Result |
|---|---|
| **before** | assembly reports **no tests at all** — `TypeInitializationException` out of `$Tests..cctor()` |
| **after** | **`Failed: 4, Passed: 396, Total: 400`** |

The four failures are the three round-trip tests plus the one `CheckTests` case that needs
`sampleDoseRule`. Every other test in the assembly still runs and reports. That is the whole point:
a library-side failure now costs you the tests that depend on it, not the other 396.

The fixture was restored afterwards and the working tree confirmed clean.

Normal runs, unchanged:

- `dotnet test tests/Informedica.GenFORM.Tests/` — **400 passed, 0 failed**
- `dotnet run ServerTests` — `Status: Ok`
- `dotnet build` — 0 errors, 0 warnings
- `dotnet fantomas --check` — clean

To reproduce: delete `tests/Informedica.GenFORM.Tests/bin/Debug/net10.0/fixtures/doserules.json`
and run the test project with `--no-build`.

## Further information

Test-only change. Nothing under `src/` is touched, so there is no clinical exposure — the worst
case is a red build.

Both `lazy` bindings carry a comment explaining why they are deferred, so the next reader does not
unwrap them for tidiness. `tests/Informedica.ZIndex.Tests/Tests.fs:585-597` already applies the
same defensive thinking with `try/with`, for the same reason.

This is defensive rather than corrective: the fixtures are local JSON that will not realistically
fail, so nothing observable changes today. What it removes is the coupling that made #523 so hard
to read.

## Author checklist

I confirm that these changes:

- [x] Follow the process described in [CONTRIBUTING.md](../CONTRIBUTING.md#Pull_Request_Process).
- [x] Make the changes proposed in the linked issue (if applicable): #525 — see Divergence from plan
- [x] Follow the approach documented in the linked implementation plan (if applicable): n/a — test-only change
- [x] Are no more than 200 lines of changed code, ideally 25-100.
- [x] Are not more complex than necessary.
- [x] Cannot easily be split in a way that would make reviewing them significantly easier.
- [x] Follow the guidelines specified in [DEVELOPMENT.md](../../DEVELOPMENT.md).
- [x] Have been thoroughly tested.
- [x] Don't introduce new security vulnerabilities.
- [x] Follow the [AI/LLM Usage Policy](../../AGENTS.md#aillm-usage-policy) — LLMs were not given direct write access to `.fs` source files (except client-side UI code).

### AI/Vibe Coding Disclosure

- [x] Some or all code in this PR is **vibe coded** (substantially AI-generated). If checked, describe below which parts were AI-generated, which tool was used, and how the code was verified.

Tool: Claude Code.

I asked Claude to make this change directly. It applied the `lazy` wrapping and `.Value` reads,
found the second instance in `CheckTests` by running the missing-fixture experiment, and ran the
verification reproduced above. I reviewed the result.

The file is test code under `tests/`; nothing under `src/` was touched, so no library or clinical
code was involved.

I confirm that I have:

- [ ] Added appropriate automated tests.
- [x] Updated documentation appropriately.
- [x] Added comments that highlight important changes and add justification, where necessary.
