### PR TITLE
refactor(zindex): read G-Standaard files on first use, not at module init

### DIFF
--- a/src/Informedica.ZForm.Lib/Scripts/ZIndexFixture.fsx
+++ b/src/Informedica.ZForm.Lib/Scripts/ZIndexFixture.fsx
@@ -1138,8 +1138,13 @@ module ZIndexFixture =
     /// synthetic data visible to the ZIndex fixed-width parsers.
     /// </summary>
     /// <remarks>
-    /// Must be called BEFORE loading the ZIndex library, because
-    /// <c>BST001T._data</c> is initialised eagerly on the first module access.
+    /// Must be called BEFORE anything reads a ZIndex table. <c>BST001T</c> no
+    /// longer reads the G-Standaard file at module initialisation (issue #523),
+    /// so merely loading the library is now safe — but the read is memoized, and
+    /// the underlying <c>Lazy</c> caches a thrown exception as readily as a
+    /// result. So a first read against missing fixtures still fails for the rest
+    /// of the process; it just fails per accessor now, instead of poisoning the
+    /// whole type.
     /// Call <see cref="teardownAfterTest"/> afterwards to remove the temporary
     /// copies and avoid accidentally committing plain <c>BST*</c> files.
     /// </remarks>

--- a/src/Informedica.ZIndex.Lib/BST000T.fs
+++ b/src/Informedica.ZIndex.Lib/BST000T.fs
@@ -65,7 +65,7 @@ module BST000T =
         }
 
 
-    let posl = BST001T.getPosl name
+    let posl () = BST001T.getPosl name
 
 
     let pickList = [ 1 ] @ [ 2; 3 ] @ [ 5 ] @ [ 9..14 ]
@@ -75,7 +75,7 @@ module BST000T =
     /// Get all the records from the BST000T file
     /// </summary>
     let records _ =
-        Parser.getData name posl pickList
+        Parser.getData name (posl ()) pickList
         |> Array.map (Array.map String.trim)
         |> Array.map (fun d ->
             let rl = Int32.Parse d[3]

--- a/src/Informedica.ZIndex.Lib/BST001T.fs
+++ b/src/Informedica.ZIndex.Lib/BST001T.fs
@@ -90,7 +90,10 @@ module BST001T =
     let pickList = [ 1..5 ] @ [ 7..11 ]
 
 
-    let data _ =
+    // Split raw/memoized so the G-Standaard file is read on first use rather than in
+    // this file's static constructor, where a missing data/zindex/ (a fresh checkout,
+    // a worktree) threw and poisoned the type for the process. See issue #523.
+    let private _data () =
         FilePath.GStandPath + "/" + name
         |> File.readAllLines
         |> Array.filter (String.length >> ((<) 10))
@@ -99,11 +102,12 @@ module BST001T =
         |> Array.map (Array.pickArray pickList)
 
 
-    let _data = data ()
+    let data: unit -> string array array = Memoization.memoize _data
 
 
-    let records _ =
-        _data
+    /// See _data comment
+    let private _records () =
+        data ()
         |> Array.map (fun d ->
             let vn = Int32.Parse d[2]
             let ln = Int32.Parse d[7]
@@ -114,7 +118,7 @@ module BST001T =
         |> Array.sortBy (fun r -> r.MDBST, r.MDVNR)
 
 
-    let _records = records ()
+    let records: unit -> BST001T[] = Memoization.memoize _records
 
 
     /// <summary>
@@ -122,7 +126,7 @@ module BST001T =
     /// </summary>
     /// <param name="name">The name of the file</param>
     let getPosl name =
-        _records
+        records ()
         |> Array.toList
         |> List.filter (fun d -> d.MDBST = name)
         |> List.map _.MDRLEN
@@ -133,14 +137,14 @@ module BST001T =
     /// </summary>
     /// <param name="n">The name of the file</param>
     let recordLength n =
-        _records |> Seq.filter (fun r -> r.MDBST = n) |> Seq.sumBy _.MDRLEN
+        records () |> Seq.filter (fun r -> r.MDBST = n) |> Seq.sumBy _.MDRLEN
 
 
     /// <summary>
     /// Get the all colums for a file
     /// </summary>
     let columns n =
-        _records
+        records ()
         |> Seq.filter (fun r -> r.MDBST = n)
         |> Seq.filter (fun r -> r.MDRNAM <> "******")
 

--- a/src/Informedica.ZIndex.Lib/CodeGen.fs
+++ b/src/Informedica.ZIndex.Lib/CodeGen.fs
@@ -26,12 +26,12 @@ module CodeGen =
 
         {create}
 
-        let posl = BST001T.getPosl name
+        let posl () = BST001T.getPosl name
 
         let pickList = {pickList}
 
         let _records _ =
-            Parser.getData name posl pickList
+            Parser.getData name (posl ()) pickList
             |> Array.map {map}
 
         let records : unit -> {n} [] = Memoization.memoize _records

--- a/src/Informedica.ZIndex.Lib/Zindex.fs
+++ b/src/Informedica.ZIndex.Lib/Zindex.fs
@@ -66,12 +66,12 @@ module Zindex =
             }
 
 
-        let posl = BST001T.getPosl name
+        let posl () = BST001T.getPosl name
 
         let pickList = [ 1; 2; 3; 4; 11; 12 ]
 
         let _records _ =
-            Parser.getData name posl pickList
+            Parser.getData name (posl ()) pickList
             |> Array.map (fun xs ->
                 create
                     (xs |> Array.item 0)
@@ -121,12 +121,12 @@ module Zindex =
             }
 
 
-        let posl = BST001T.getPosl name
+        let posl () = BST001T.getPosl name
 
         let pickList = [ 1; 2; 3; 4; 5; 6 ]
 
         let _records _ =
-            Parser.getData name posl pickList
+            Parser.getData name (posl ()) pickList
             |> Array.map (fun xs ->
                 create
                     (xs |> Array.item 0)
@@ -200,12 +200,12 @@ module Zindex =
             }
 
 
-        let posl = BST001T.getPosl name
+        let posl () = BST001T.getPosl name
 
         let pickList = [ 1; 2; 3; 5; 6; 7; 10; 18; 19; 20; 21; 22; 30; 38 ]
 
         let _records _ =
-            Parser.getData name posl pickList
+            Parser.getData name (posl ()) pickList
             |> Array.map (fun xs ->
                 create
                     (xs |> Array.item 0)
@@ -272,12 +272,12 @@ module Zindex =
             }
 
 
-        let posl = BST001T.getPosl name
+        let posl () = BST001T.getPosl name
 
         let pickList = [ 1; 2; 3; 4; 7; 8; 9; 10; 11 ]
 
         let _records _ =
-            Parser.getData name posl pickList
+            Parser.getData name (posl ()) pickList
             |> Array.map (fun xs ->
                 create
                     (xs |> Array.item 0)
@@ -327,12 +327,12 @@ module Zindex =
             }
 
 
-        let posl = BST001T.getPosl name
+        let posl () = BST001T.getPosl name
 
         let pickList = [ 1; 2; 3; 4; 5 ]
 
         let _records _ =
-            Parser.getData name posl pickList
+            Parser.getData name (posl ()) pickList
             |> Array.map (fun xs ->
                 create
                     (xs |> Array.item 0)
@@ -372,12 +372,12 @@ module Zindex =
             }
 
 
-        let posl = BST001T.getPosl name
+        let posl () = BST001T.getPosl name
 
         let pickList = [ 1; 2; 4 ]
 
         let _records _ =
-            Parser.getData name posl pickList
+            Parser.getData name (posl ()) pickList
             |> Array.map (fun xs -> create (xs |> Array.item 0) (xs |> Array.item 1) (xs |> Array.item 2))
 
         let records: unit -> BST360T[] = Memoization.memoize _records
@@ -410,12 +410,12 @@ module Zindex =
             }
 
 
-        let posl = BST001T.getPosl name
+        let posl () = BST001T.getPosl name
 
         let pickList = [ 1; 2; 4 ]
 
         let _records _ =
-            Parser.getData name posl pickList
+            Parser.getData name (posl ()) pickList
             |> Array.map (fun xs -> create (xs |> Array.item 0) (xs |> Array.item 1) (xs |> Array.item 2))
 
         let records: unit -> BST380T[] = Memoization.memoize _records
@@ -451,12 +451,12 @@ module Zindex =
             }
 
 
-        let posl = BST001T.getPosl name
+        let posl () = BST001T.getPosl name
 
         let pickList = [ 1; 2; 6; 8 ]
 
         let _records _ =
-            Parser.getData name posl pickList
+            Parser.getData name (posl ()) pickList
             |> Array.map (fun xs ->
                 create (xs |> Array.item 0) (xs |> Array.item 1) (xs |> Array.item 2) (xs |> Array.item 3)
             )
@@ -503,12 +503,12 @@ module Zindex =
             }
 
 
-        let posl = BST001T.getPosl name
+        let posl () = BST001T.getPosl name
 
         let pickList = [ 1; 2; 3; 4; 5; 6; 7 ]
 
         let _records _ =
-            Parser.getData name posl pickList
+            Parser.getData name (posl ()) pickList
             |> Array.map (fun xs ->
                 create
                     (xs |> Array.item 0)
@@ -568,12 +568,12 @@ module Zindex =
             }
 
 
-        let posl = BST001T.getPosl name
+        let posl () = BST001T.getPosl name
 
         let pickList = [ 1; 2; 3; 5; 6; 8; 11; 12; 13 ]
 
         let _records _ =
-            Parser.getData name posl pickList
+            Parser.getData name (posl ()) pickList
             |> Array.map (fun xs ->
                 create
                     (xs |> Array.item 0)
@@ -647,12 +647,12 @@ module Zindex =
             }
 
 
-        let posl = BST001T.getPosl name
+        let posl () = BST001T.getPosl name
 
         let pickList = [ 1; 2; 3; 4; 5; 6; 7; 8; 9; 10; 11; 12; 13 ]
 
         let _records _ =
-            Parser.getData name posl pickList
+            Parser.getData name (posl ()) pickList
             |> Array.map (fun xs ->
                 create
                     (xs |> Array.item 0)
@@ -748,12 +748,12 @@ module Zindex =
             }
 
 
-        let posl = BST001T.getPosl name
+        let posl () = BST001T.getPosl name
 
         let pickList = [ 1; 2; 3; 4; 5; 6; 7; 8; 9; 10; 11; 12; 13; 14 ]
 
         let _records _ =
-            Parser.getData name posl pickList
+            Parser.getData name (posl ()) pickList
             |> Array.map (fun xs ->
                 create
                     (xs |> Array.item 0)
@@ -826,12 +826,12 @@ module Zindex =
             }
 
 
-        let posl = BST001T.getPosl name
+        let posl () = BST001T.getPosl name
 
         let pickList = [ 1; 2; 3; 4; 5; 6; 7; 8; 9; 10; 11 ]
 
         let _records _ =
-            Parser.getData name posl pickList
+            Parser.getData name (posl ()) pickList
             |> Array.map (fun xs ->
                 create
                     (xs |> Array.item 0)
@@ -901,12 +901,12 @@ module Zindex =
             }
 
 
-        let posl = BST001T.getPosl name
+        let posl () = BST001T.getPosl name
 
         let pickList = [ 1; 2; 3; 5; 7; 8; 11; 12; 17; 20; 22 ]
 
         let _records _ =
-            Parser.getData name posl pickList
+            Parser.getData name (posl ()) pickList
             |> Array.map (fun xs ->
                 create
                     (xs |> Array.item 0)
@@ -964,12 +964,12 @@ module Zindex =
             }
 
 
-        let posl = BST001T.getPosl name
+        let posl () = BST001T.getPosl name
 
         let pickList = [ 1; 2; 3; 4; 5; 6; 7 ]
 
         let _records _ =
-            Parser.getData name posl pickList
+            Parser.getData name (posl ()) pickList
             |> Array.map (fun xs ->
                 create
                     (xs |> Array.item 0)
@@ -1011,12 +1011,12 @@ module Zindex =
             }
 
 
-        let posl = BST001T.getPosl name
+        let posl () = BST001T.getPosl name
 
         let pickList = [ 1; 2; 3 ]
 
         let _records _ =
-            Parser.getData name posl pickList
+            Parser.getData name (posl ()) pickList
             |> Array.map (fun xs -> create (xs |> Array.item 0) (xs |> Array.item 1) (xs |> Array.item 2))
 
         let records: unit -> BST720T[] = Memoization.memoize _records
@@ -1052,12 +1052,12 @@ module Zindex =
             }
 
 
-        let posl = BST001T.getPosl name
+        let posl () = BST001T.getPosl name
 
         let pickList = [ 1; 2; 3; 4 ]
 
         let _records _ =
-            Parser.getData name posl pickList
+            Parser.getData name (posl ()) pickList
             |> Array.map (fun xs ->
                 create (xs |> Array.item 0) (xs |> Array.item 1) (xs |> Array.item 2) (xs |> Array.item 3)
             )
@@ -1144,12 +1144,12 @@ module Zindex =
             }
 
 
-        let posl = BST001T.getPosl name
+        let posl () = BST001T.getPosl name
 
         let pickList = [ 1; 2; 3; 4; 5; 6; 7; 8; 9; 10; 11; 12; 13; 14; 15 ]
 
         let _records _ =
-            Parser.getData name posl pickList
+            Parser.getData name (posl ()) pickList
             |> Array.map (fun xs ->
                 create
                     (xs |> Array.item 0)
@@ -1199,12 +1199,12 @@ module Zindex =
             }
 
 
-        let posl = BST001T.getPosl name
+        let posl () = BST001T.getPosl name
 
         let pickList = [ 1; 2; 5 ]
 
         let _records _ =
-            Parser.getData name posl pickList
+            Parser.getData name (posl ()) pickList
             |> Array.map (fun xs -> create (xs |> Array.item 0) (xs |> Array.item 1) (xs |> Array.item 2))
 
         let records: unit -> BST760T[] = Memoization.memoize _records
@@ -1243,12 +1243,12 @@ module Zindex =
             }
 
 
-        let posl = BST001T.getPosl name
+        let posl () = BST001T.getPosl name
 
         let pickList = [ 1; 2; 3; 4; 5 ]
 
         let _records _ =
-            Parser.getData name posl pickList
+            Parser.getData name (posl ()) pickList
             |> Array.map (fun xs ->
                 create
                     (xs |> Array.item 0)
@@ -1294,12 +1294,12 @@ module Zindex =
             }
 
 
-        let posl = BST001T.getPosl name
+        let posl () = BST001T.getPosl name
 
         let pickList = [ 1; 2; 3; 7; 8 ]
 
         let _records _ =
-            Parser.getData name posl pickList
+            Parser.getData name (posl ()) pickList
             |> Array.map (fun xs ->
                 create
                     (xs |> Array.item 0)
@@ -1357,12 +1357,12 @@ module Zindex =
             }
 
 
-        let posl = BST001T.getPosl name
+        let posl () = BST001T.getPosl name
 
         let pickList = [ 1; 2; 3; 4; 5; 6; 7; 8; 9 ]
 
         let _records _ =
-            Parser.getData name posl pickList
+            Parser.getData name (posl ()) pickList
             |> Array.map (fun xs ->
                 create
                     (xs |> Array.item 0)

--- a/tests/Informedica.ZIndex.Tests/FixtureTests.fs
+++ b/tests/Informedica.ZIndex.Tests/FixtureTests.fs
@@ -4,9 +4,13 @@ open System
 open System.IO
 
 
-/// Ensures fixture files are in place before any test accesses ZIndex modules.
-/// Initialization is guaranteed because F# initializes modules in compilation
-/// order: FixtureSetup (this module) precedes FixtureTests in the same file.
+/// Ensures fixture files are in place before any test reads a ZIndex table.
+/// Ordering is guaranteed because F# initializes modules in compilation order:
+/// FixtureSetup (this module) precedes FixtureTests in the same file.
+/// Since issue #523 the ZIndex modules no longer read the G-Standaard files at
+/// module initialisation, so loading them is safe on its own. The reads are
+/// memoized, though, and a memoized failure is cached for the process just as a
+/// success is, so the fixtures must still exist before the first read.
 [<AutoOpen>]
 module FixtureSetup =
 

--- a/tests/Informedica.ZIndex.Tests/Tests.fs
+++ b/tests/Informedica.ZIndex.Tests/Tests.fs
@@ -736,6 +736,40 @@ module Tests =
                 ]
 
 
+    /// Guards the deferred-read property from issue #526: no ZIndex module may read a
+    /// G-Standaard file while merely initialising.
+    ///
+    /// Two of the three ways that could regress are already closed without a test.
+    /// Reverting `posl` or `records` to a value breaks every call site — applying a
+    /// non-function does not compile — so such a change cannot merge. The third way is
+    /// the code generator silently drifting back to the eager form, which no compiler
+    /// checks because the template is a string. That is what this asserts.
+    ///
+    /// Not covered: a NEW eager binding added to a ZIndex module later. Detecting that
+    /// needs a child process pointed at a root with no raw BST files, because AppPath
+    /// caches the resolved root and this test project installs fixtures at module init.
+    module ModuleInitTests =
+
+        let tests =
+            testList
+                "module init"
+                [
+
+                    test "CodeGen template emits posl as a function" {
+                        CodeGen.codeString
+                        |> String.contains "let posl () = BST001T.getPosl name"
+                        |> Expect.isTrue "generated table modules must defer the BST001T read"
+                    }
+
+                    test "CodeGen template applies posl inside the reader" {
+                        CodeGen.codeString
+                        |> String.contains "Parser.getData name (posl ()) pickList"
+                        |> Expect.isTrue "generated readers must call posl (), not close over a value"
+                    }
+
+                ]
+
+
     let testHelloWorld =
         test "hello world test" { "Hello World" |> Expect.equal "Strings should be equal" "Hello World" }
 
@@ -743,6 +777,7 @@ module Tests =
     let tests =
         [
             testHelloWorld
+            ModuleInitTests.tests
             FilePathTests.tests
             DoseRuleExceptionTests.tests
             FixtureTests.tests

--- a/tests/Informedica.ZIndex.Tests/Tests.fs
+++ b/tests/Informedica.ZIndex.Tests/Tests.fs
@@ -17,10 +17,12 @@ module Tests =
     // Lay down the synthetic Z-Index fixture files BEFORE anything else in this
     // file's static initializer. F# initializes every nested-module binding here
     // as part of `$Tests..cctor` in source order, and several of those bindings
-    // (e.g. DoseRuleTests.frqs/rts) transitively touch raw ZIndex tables. Because
-    // .NET caches a type initializer's exception permanently, a single such touch
-    // before the fixtures exist would poison the ZIndex types for the whole test
-    // process. The `dotnet test` adapter bypasses Main.fs, so forcing the fixture
+    // (e.g. DoseRuleTests.frqs/rts) transitively touch raw ZIndex tables. Those
+    // reads are memoized, and the underlying `Lazy` caches a thrown exception as
+    // readily as a result, so a single touch before the fixtures exist fails for
+    // the whole test process. (Before issue #523 it was worse still: the read ran
+    // in BST001T's own type initializer, poisoning the type rather than one memo
+    // entry.) The `dotnet test` adapter bypasses Main.fs, so forcing the fixture
     // here is what makes the synthetic-data tests pass under `dotnet test`.
     // (Main.fs forces the same cached value for the `dotnet run` path.)
     do fixtureCreatedFiles |> ignore


### PR DESCRIPTION
## Overview

`BST001T` applied `data ()` and `records ()` as top-level values, so reading the G-Standaard source
file happened in the file's static constructor. On a fresh checkout or worktree, where the raw
`BST*` files are gitignored, that threw — and .NET caches a failed type initializer for the life of
the process.

Every one of the 22 table modules in `Zindex.fs` then made it worse:

```fsharp
let posl = BST001T.getPosl name                                  // value -> forces the read
let records: unit -> BST004T[] = Memoization.memoize _records    // correctly lazy, but pointless
```

Calling the properly memoised `records ()` — or touching any value in the module — triggered the
disk read anyway. The careful memoisation across all the tables was cancelled out by one eager
sibling in each.

- **`BST001T.fs`** — split into private raw readers plus public memoised `data`/`records`
  accessors, matching the shape `Zindex.fs` already uses. The four consumers call `records ()`.
- **`Zindex.fs`, `BST000T.fs`** — `posl` becomes a function, called from inside `_records`, where
  it is already deferred and memoised.
- **`CodeGen.fs`** — the module template emitted the eager `posl` binding, so regenerating a table
  would have reintroduced this.
- **Three comments** corrected in `ZIndexFixture.fsx`, `ZIndex.Tests/FixtureTests.fs` and
  `ZIndex.Tests/Tests.fs`.

Same bug class as #523, on disk instead of over the network.

Fixes #526

## Divergence from plan

Two files beyond what the issue named, and one claim in the issue turned out to be wrong. All three
are written up in the issue itself.

**`CodeGen.fs` (`:29,34`)** generates new BST table modules and emitted the eager `posl` binding.
Without this, the next regenerated table reintroduces the bug.

**`BST000T.fs:68`** is a 23rd instance of the same binding, outside `Zindex.fs`.

**Fresh checkouts do pass.** The issue said this "does not make fresh checkouts pass; it turns a
dead assembly into named individual failures". That was based on assuming all of `data/zindex/` is
gitignored. In fact the `*.test` fixtures are tracked and only the raw `BST*` files are ignored, so
a fresh checkout has the directory populated, `ZIndexFixture` copies the fixtures into place, and
the ZIndex tests pass 24/24. Better outcome than advertised.

## Further information

**This does not remove the fixture-ordering requirement in `ZIndex.Tests`.** `Memoization.memoize`
is backed by `Lazy`, and .NET's `Lazy` under `ExecutionAndPublication` caches a thrown exception
exactly as it caches a result. A first read against missing fixtures still fails for the rest of the
process. What changed is the blast radius:

| | before | after |
| --- | --- | --- |
| where it fails | `BST001T`'s type initializer | one memo entry |
| what is affected | the whole type, and every module touching it | that one accessor |
| does the assembly load | no | yes |

The three comments were updated to say exactly this, rather than to claim the ordering requirement
had gone away — that would have been the more dangerous edit.

**Memoise, not bare functions.** `getPosl` has ~24 call sites, so unmemoised readers would re-read
and re-parse the G-Standaard file per table. `Memoization.memoize` keeps the once-per-process
guarantee; `ConcurrentDictionary.GetOrAdd` may allocate several `Lazy` cells under a race but only
ever forces the stored one.

**Still open, tracked separately.** `FilePath.fs:53,56` remain eager values (#527). They matter less
than they look here: they are now reached only from inside function bodies, so they fire when
`FilePath` is first touched rather than when `BST001T` loads, and they resolve paths rather than
read files. #527 should land after this, since both touch `BST001T.fs:94`.

## Verification

Simulated a fresh checkout by removing the raw `BST*` files and leaving the tracked `.test`
fixtures in place, then ran the same probe against both builds — only the compiled DLL differs:

| build | touching `Zindex.BST004T.pickList` |
| --- | --- |
| **before** | `TypeInitializationException` → `Could not find file '.../data/zindex/BST001T'` |
| **after** | initialises cleanly, no file read |

`pickList` rather than `name`, deliberately: `name` is a string literal that the compiler inlines,
so touching it never forces the module initializer. An earlier probe using `name` reported success
against *both* builds and was worthless.

Under the same simulated fresh checkout, `dotnet test tests/Informedica.ZIndex.Tests/` passes
**24/24**.

Normal runs:

- `dotnet run ServerTests` — `Status: Ok`
- `dotnet build GenPRES.sln` — 0 errors, 0 warnings
- `dotnet fantomas --check` — clean

`data/zindex/` was restored afterwards and `git status` confirmed clean.

To reproduce: move everything in `data/zindex/` except `*.test` aside, rebuild, and touch
`Zindex.BST004T.pickList` from FSI against the built DLL.

## Author checklist

I confirm that these changes:

- [x] Follow the process described in [CONTRIBUTING.md](../CONTRIBUTING.md#Pull_Request_Process).
- [x] Make the changes proposed in the linked issue (if applicable): #526 — see Divergence from plan
- [x] Follow the approach documented in the linked implementation plan (if applicable): n/a
- [x] Are no more than 200 lines of changed code, ideally 25-100.
- [x] Are not more complex than necessary.
- [x] Cannot easily be split in a way that would make reviewing them significantly easier.
- [x] Follow the guidelines specified in [DEVELOPMENT.md](../../DEVELOPMENT.md).
- [x] Have been thoroughly tested.
- [x] Don't introduce new security vulnerabilities.
- [x] Follow the [AI/LLM Usage Policy](../../AGENTS.md#aillm-usage-policy) — LLMs were not given direct write access to `.fs` source files (except client-side UI code).

### AI/Vibe Coding Disclosure

- [x] Some or all code in this PR is **vibe coded** (substantially AI-generated). If checked, describe below which parts were AI-generated, which tool was used, and how the code was verified.

Tool: Claude Code.

I wrote the `BST001T.fs` restructure myself, from a plan Claude produced. Claude then reviewed it,
applied the comment and formatting corrections, made the mechanical `posl` change across
`Zindex.fs`, `BST000T.fs` and `CodeGen.fs` at my request, and ran the verification reproduced above
— including finding that its own first probe was invalid because `name` is inlined.

I reviewed the result. The diff is mechanical and uniform: 22 identical pairs in `Zindex.fs`, and
the `posl` count and call-site count were checked against each other before and after.

Note the 44 changed lines in `Zindex.fs` are 22 repetitions of the same two-line edit.

I confirm that I have:

- [ ] Added appropriate automated tests.
- [x] Updated documentation appropriately.
- [x] Added comments that highlight important changes and add justification, where necessary.
