### PR TITLE
fix(genform): degrade gracefully when Kinderformularium is unreachable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,14 +146,18 @@ The distinction is **value vs. function**, and it is easy to miss when the IO hi
 partial application:
 
 ```fsharp
-// BAD — a VALUE. `getKFMedications ()` is applied here, so the HTTP fetch runs in the
-// file's static constructor, triggered by any unrelated binding in the same file.
-let getLink = Source.getLink (getKFMedications ())
+// BAD — a VALUE. `fetch ()` is applied at binding time, so the IO runs in the file's
+// static constructor, triggered by any unrelated binding in the same file.
+let index = fetch () |> Result.defaultValue []
 
-// GOOD — a FUNCTION. The fetch happens on first actual use; `getKFMedications` is
-// memoized, so it still runs at most once per process.
-let getLink source gen = Source.getLink (getKFMedications ()) source gen
+// GOOD — a FUNCTION. Nothing runs until a caller asks; the caller (a resource
+// registry, a request handler) decides when, how often, and what a failure means.
+let index () = fetch () |> Result.defaultValue []
 ```
+
+The test: no parameters, not `lazy`, and the right-hand side reaches IO — then it runs at type
+initialisation. Give it a `()` parameter or wrap it in `lazy`, keep the IO leaf returning a
+`Result`, and let the composition site own the failure policy.
 
 Nesting inside a sub-module does **not** isolate it — the cctor is per file, not per module.
 

--- a/src/Informedica.GenFORM.Lib/Api.fs
+++ b/src/Informedica.GenFORM.Lib/Api.fs
@@ -43,6 +43,22 @@ module Api =
     let getGStandProvider (provider: IResourceProvider) = provider.GetGStandProvider()
 
 
+    /// <summary>
+    /// The Nederlands Kinder Formularium link lookup, for `DoseRule.Print.toMarkdown`.
+    /// </summary>
+    /// <remarks>
+    /// When only the NKF fetch failed the registry already serves `Source.getLink []`
+    /// (FK links intact, NKF links gone); see `Keys.nkfLinkProvider`. When the whole
+    /// resource load failed nothing is registered at all and `Get` would throw, so serve
+    /// that same degraded provider here: a decorative link must never fail a request.
+    /// </remarks>
+    let getNKFLinkProvider (provider: IResourceProvider) : Source.LinkProvider =
+        if provider.GetResourceInfo().IsLoaded then
+            provider.Get Keys.nkfLinkProvider
+        else
+            Source.getLink []
+
+
     let getDoseRules (provider: IResourceProvider) = provider.GetDoseRules()
 
 

--- a/src/Informedica.GenFORM.Lib/Api.fs
+++ b/src/Informedica.GenFORM.Lib/Api.fs
@@ -49,13 +49,16 @@ module Api =
     /// <remarks>
     /// When only the NKF fetch failed the registry already serves `Source.getLink []`
     /// (FK links intact, NKF links gone); see `Keys.nkfLinkProvider`. When the whole
-    /// resource load failed nothing is registered at all and `Get` would throw, so serve
-    /// that same degraded provider here: a decorative link must never fail a request.
+    /// resource load failed nothing is registered at all and `Get` raises
+    /// `KeyNotFoundException`, so serve that same degraded provider here: a decorative
+    /// link must never fail a request. One provider call, not an `IsLoaded` check followed
+    /// by `Get`: a `CachedResourceProvider` takes its lock per call, so a reload failing
+    /// between the two would still throw.
     /// </remarks>
     let getNKFLinkProvider (provider: IResourceProvider) : Source.LinkProvider =
-        if provider.GetResourceInfo().IsLoaded then
+        try
             provider.Get Keys.nkfLinkProvider
-        else
+        with :? System.Collections.Generic.KeyNotFoundException ->
             Source.getLink []
 
 

--- a/src/Informedica.GenFORM.Lib/DoseRule.fs
+++ b/src/Informedica.GenFORM.Lib/DoseRule.fs
@@ -6,9 +6,6 @@ module DoseRule =
     open System
     open Informedica.Utils.Lib.BCL
 
-    open FSharp.Data
-    open FSharp.Data.JsonExtensions
-
     open Informedica.Utils.Lib
     open Informedica.GenCore.Lib.Ranges
 
@@ -79,40 +76,28 @@ module DoseRule =
             )
 
 
-        // get all medications from Kinderformularium
-        let kinderFormUrl = "https://www.kinderformularium.nl/geneesmiddelen.json"
-
-
-        let private _medications () =
-            let res = JsonValue.Load kinderFormUrl
-
-            [
-                for v in res do
-                    {|
-                        id = v?id.AsString()
-                        generic = v?generic_name.AsString().Trim().ToLower()
-                    |}
-            ]
-            |> List.distinct
-
-
-        let getKFMedications = Memoization.memoize _medications
-
-
         /// <summary>
-        /// Find the Kinderformularium link for a <c>Source</c> / <c>GenericLabel</c> pair.
+        /// Render the dose rules of <b>one</b> generic as markdown: a generic heading, then
+        /// per route the products and synonyms, per patient category and indication the
+        /// dose type, schedule, formulary link and dose limits.
         /// </summary>
         /// <remarks>
-        /// Without parameters, the right will be a value and will be evaluated eagerly. See
-        /// "Never Perform IO in a Top-Level `let` Value" in AGENTS.md.
+        /// Per-generic by contract: the outer fold keeps the last generic it sees, so a
+        /// multi-generic array yields only the last one. Use <c>printGenerics</c> for
+        /// several. On the anonymous record in the fold, see
+        /// https://github.com/dotnet/fsharp/issues/6699.
         /// </remarks>
-        let getLink source gen =
-            Source.getLink (getKFMedications ()) source gen
-
-
-        /// See for use of anonymous record in
-        /// fold: https://github.com/dotnet/fsharp/issues/6699
-        let toMarkdown (rules: DoseRule array) =
+        /// <param name="getLink">
+        /// Resolves the external formulary link per dose rule. Passed in rather than
+        /// looked up here: the Nederlands Kinder Formularium index it needs is a registered
+        /// resource (<c>Resources.Keys.nkfLinkProvider</c>), so a failed fetch degrades to
+        /// an empty index — rendered below as the existing "*Lokaal*" fallback — is
+        /// reported as a resource <c>Warning</c>, and is refreshed by an admin
+        /// ReloadResources. Keeping the fetch here made this module impure and its cache
+        /// unreachable by that reload. See issue #529.
+        /// </param>
+        /// <param name="rules">The dose rules to render.</param>
+        let toMarkdown (getLink: Source.LinkProvider) (rules: DoseRule array) =
             let generic_md generic = $"\n\n# %s{generic}\n\n---\n"
 
             let route_md route products synonyms =
@@ -299,11 +284,11 @@ module DoseRule =
             |> _.md
 
 
-        let printGenerics generics (doseRules: DoseRule[]) =
+        let printGenerics (getLink: Source.LinkProvider) generics (doseRules: DoseRule[]) =
             doseRules
             |> generics
             |> Array.sort
-            |> Array.map (fun g -> doseRules |> Array.filter (fun dr -> dr.Generic = g) |> toMarkdown)
+            |> Array.map (fun g -> doseRules |> Array.filter (fun dr -> dr.Generic = g) |> toMarkdown getLink)
 
 
     open Informedica.GenUnits.Lib

--- a/src/Informedica.GenFORM.Lib/Informedica.GenFORM.Lib.fsproj
+++ b/src/Informedica.GenFORM.Lib/Informedica.GenFORM.Lib.fsproj
@@ -23,6 +23,7 @@
     <Compile Include="DoseRule.fs" />
     <Compile Include="DoseRuleData.fs" />
     <Compile Include="DoseRuleLoader.fs" />
+    <Compile Include="SourceLoader.fs" />
     <Compile Include="Check.fs" />
     <Compile Include="SolutionLimit.fs" />
     <Compile Include="SolutionRule.fs" />

--- a/src/Informedica.GenFORM.Lib/PrescriptionRule.fs
+++ b/src/Informedica.GenFORM.Lib/PrescriptionRule.fs
@@ -378,14 +378,16 @@ module PrescriptionRule =
         }
 
 
-    /// Get the string representation of an array of PrescriptionRules.
-    let toMarkdown (prs: PrescriptionRule[]) =
+    /// Get the string representation of an array of PrescriptionRules. `getLink` is
+    /// forwarded to `DoseRule.Print.toMarkdown`; pass `Api.getNKFLinkProvider provider`,
+    /// or `Source.noLinks` when no external links are wanted.
+    let toMarkdown (getLink: Source.LinkProvider) (prs: PrescriptionRule[]) =
         [
             yield!
                 prs
                 |> Array.collect (fun x ->
                     [|
-                        [| x.DoseRule |] |> DoseRule.Print.toMarkdown
+                        [| x.DoseRule |] |> DoseRule.Print.toMarkdown getLink
                         x.SolutionRules |> SolutionRule.Print.toMarkdown "verdunnen"
                     |]
                 )

--- a/src/Informedica.GenFORM.Lib/Resources.fs
+++ b/src/Informedica.GenFORM.Lib/Resources.fs
@@ -171,6 +171,33 @@ module Resources =
             Ok(box v, ws)
 
 
+    let private messageText =
+        function
+        | Info s
+        | Warning s -> s
+        | ErrorMsg(s, _) -> s
+
+
+    /// <summary>
+    /// An <b>optional</b> IO leaf resource: one whose failure must not fail the whole
+    /// load, and so empty every other resource with it.
+    /// </summary>
+    /// <remarks>
+    /// On error the load succeeds with <paramref name="fallback"/>, and each error
+    /// becomes a <c>Warning</c> prefixed with <paramref name="note"/> — so the failure
+    /// still surfaces in <c>ResourceInfo.Messages</c> where an admin can see it, and an
+    /// admin ReloadResources retries the fetch.
+    /// </remarks>
+    /// <param name="note">Prefix explaining what was not loaded and what the effect is.</param>
+    /// <param name="fallback">The degraded value to serve instead.</param>
+    /// <param name="f">The fetch.</param>
+    let ofResultOrDefault (note: string) (fallback: 'T) (f: unit -> Result<'T, Message list>) : ResourceLoader =
+        fun _ ->
+            match f () with
+            | Ok v -> Ok(box v, [])
+            | Error msgs -> Ok(box fallback, msgs |> List.map (fun m -> Warning $"%s{note}: %s{messageText m}"))
+
+
     /// Typed keys — one per resource. Adding a resource adds a key here.
     module Keys =
         let unitMappings = ResourceKey.create<UnitMapping[]> "unitMappings"
@@ -195,6 +222,9 @@ module Resources =
         let renalRules = ResourceKey.create<RenalRule[]> "renalRules"
         // G-Standaard dose-rule capability, served as a function-valued resource.
         let gStandProvider = ResourceKey.create<Check.GStandProvider> "gStandProvider"
+
+        // Nederlands Kinder Formularium link lookup, likewise function-valued.
+        let nkfLinkProvider = ResourceKey.create<Source.LinkProvider> "nkfLinkProvider"
 
 
     /// Default resource registry using the standard v2 get functions.
@@ -245,21 +275,10 @@ module Resources =
                 // Totals is an optional intake-reference resource: a load failure must
                 // not empty the others, so swallow to [||] and surface a Warning.
                 Keys.totalsData.Name,
-                (fun _ ->
-                    match Mapping.getTotals dataUrlId with
-                    | Ok d -> Ok(box d, [])
-                    | Error msgs ->
-                        let text =
-                            function
-                            | Info s
-                            | Warning s -> s
-                            | ErrorMsg(s, _) -> s
-
-                        Ok(
-                            box ([||]: TotalsData[]),
-                            msgs |> List.map (fun m -> Warning $"Totals resource not loaded: {text m}")
-                        )
-                )
+                ofResultOrDefault
+                    "Totals resource not loaded"
+                    ([||]: TotalsData[])
+                    (fun () -> Mapping.getTotals dataUrlId)
 
                 // Narrow the raw ZIndex products to those referenced by dose rules
                 // BEFORE building, so discarded products are never constructed.
@@ -311,6 +330,25 @@ module Resources =
                 // closure depends only on routeMappings; ZIndex caches stay memoised
                 // in ZIndex.Lib and patient filtering (RuleFinder) is untouched.
                 Keys.gStandProvider.Name, derive (fun r -> Check.gStandProvider (r.Get Keys.routeMappings))
+
+                // The NKF link lookup is decoration on a rendered dose rule, and it is the
+                // only resource fetched from a third party rather than a sheet, so it is
+                // optional in exactly the sense totalsData is. Registering it here rather
+                // than caching inside DoseRule.Print keeps that module pure, puts the
+                // failure in ResourceInfo where an admin can see it, and lets
+                // ReloadResources retry.
+                //
+                // Degrade to `getLink []`, not `Source.noLinks`: an empty index costs the
+                // NKF links, which is the outage, but FTK links are built from the generic
+                // name alone and must survive it.
+                Keys.nkfLinkProvider.Name,
+                ofResultOrDefault
+                    "NKF links not loaded, falling back to \"*Lokaal*\""
+                    (Source.getLink []: Source.LinkProvider)
+                    (fun () ->
+                        SourceLoader.fetchNKFMedications ()
+                        |> Result.map (fun meds -> (Source.getLink meds: Source.LinkProvider))
+                    )
             ]
 
 

--- a/src/Informedica.GenFORM.Lib/Scripts/Scripts.fsx
+++ b/src/Informedica.GenFORM.Lib/Scripts/Scripts.fsx
@@ -167,7 +167,7 @@ let printAllDoseRules () =
     let gs (rs: DoseRule[]) =
         rs |> Array.map _.Generic |> Array.distinct
 
-    DoseRule.Print.printGenerics gs rs
+    DoseRule.Print.printGenerics (Api.getNKFLinkProvider provider) gs rs
 
 Environment.CurrentDirectory <- __SOURCE_DIRECTORY__
 

--- a/src/Informedica.GenFORM.Lib/Source.fs
+++ b/src/Informedica.GenFORM.Lib/Source.fs
@@ -48,7 +48,9 @@ module Source =
     /// links only, and leaves FTK links intact.
     /// </remarks>
     let getLink (meds: NKFMedication list) source gen : string option =
-        let gen = gen |> GenericLabel.toString
+        // The base substance name: a brand or form qualifier ("glycopyrronium (Sialanar)")
+        // is neither an NKF index entry nor an FK monograph slug.
+        let gen = gen |> GenericLabel.genericName
         let src = source |> toString
         let slug = gen |> String.replace "/" "-"
 

--- a/src/Informedica.GenFORM.Lib/Source.fs
+++ b/src/Informedica.GenFORM.Lib/Source.fs
@@ -6,6 +6,27 @@ module Source =
     open Informedica.Utils.Lib.BCL
 
 
+    /// One Nederlands Kinder Formularium (NKF) entry: the generic name and the id
+    /// its URL is built from.
+    type NKFMedication =
+        {
+            // The generic name as the NKF spells it: trimmed, lower case, and with
+            // combination preparations joined by "+".
+            Generic: string
+            // The NKF's own id, the first path segment of a medication URL.
+            Id: string
+        }
+
+
+    /// Resolve the external formulary link for a <c>Source</c> / <c>GenericLabel</c>
+    /// pair, or <c>None</c> when there is none.
+    ///
+    /// A function type rather than a data dependency so that <c>DoseRule.Print</c>
+    /// stays pure and the NKF fetch can live in the loader that the resource registry
+    /// composes. Mirrors <c>Check.GStandProvider</c>.
+    type LinkProvider = Source -> GenericLabel -> string option
+
+
     let toString =
         function
         | Identified s -> s
@@ -17,35 +38,53 @@ module Source =
     let other = Other
 
 
-    let getLink
-        (meds:
-            {|
-                generic: string
-                id: string
-            |} list)
-        source
-        gen
-        =
+    /// <summary>
+    /// Find the external formulary link for a <c>Source</c> / <c>GenericLabel</c> pair.
+    /// </summary>
+    /// <remarks>
+    /// The source is matched first and <c>meds</c> is consulted only by the NKF branch,
+    /// which is the only one that needs an id. An empty <c>meds</c> — what the resource
+    /// registry yields when kinderformularium.nl is unreachable — therefore drops NKF
+    /// links only, and leaves FTK links intact.
+    /// </remarks>
+    let getLink (meds: NKFMedication list) source gen : string option =
         let gen = gen |> GenericLabel.toString
         let src = source |> toString
+        let slug = gen |> String.replace "/" "-"
 
-        meds
-        |> List.tryFind (fun m ->
-            m.generic
-            |> String.split "+"
-            |> List.map String.trim
-            |> String.concat "/"
-            |> String.equalsCapInsens gen
-        )
-        |> Option.bind (fun m ->
-            let gen = gen |> String.replace "/" "-"
+        match src with
+        | _ when src = "NKF" ->
+            meds
+            |> List.tryFind (fun m ->
+                m.Generic
+                |> String.split "+"
+                |> List.map String.trim
+                |> String.concat "/"
+                |> String.equalsCapInsens gen
+            )
+            |> Option.map (fun m ->
+                $"[Kinderformularium](https://www.kinderformularium.nl/geneesmiddel/%s{m.Id}/%s{slug})"
+            )
+        | _ when src = "FK" ->
+            // The FK files each monograph under the first letter of its (lower case)
+            // generic name: .../preparaatteksten/p/paracetamol. An empty label has no page.
+            let slug = slug |> String.toLower
 
-            match src with
-            | _ when src = "NKF" ->
-                $"[Kinderformularium](https://www.kinderformularium.nl/geneesmiddel/{m.id}/{gen})"
+            if slug |> String.isNullOrWhiteSpace then
+                None
+            else
+                $"[Farmacotherapeutisch Kompas](https://www.farmacotherapeutischkompas.nl/bladeren/preparaatteksten/%c{slug[0]}/%s{slug}#doseringen)"
                 |> Some
-            | _ when src = "FK" ->
-                $"[Farmacotherapeutisch Kompas](https://www.farmacotherapeutischkompas.nl/bladeren/preparaatteksten/n/{gen}#doseringen)"
-                |> Some
-            | _ -> None
-        )
+        | _ -> None
+
+
+    /// <summary>
+    /// A <c>LinkProvider</c> that never finds a link, so every caller falls back to its
+    /// own default.
+    /// </summary>
+    /// <remarks>
+    /// For scripts and tests that want no external links at all. It is deliberately *not*
+    /// what the resource registry falls back to when the NKF fetch fails: that degrades to
+    /// <c>getLink []</c>, which loses the NKF links but keeps the FTK ones.
+    /// </remarks>
+    let noLinks: LinkProvider = fun _ _ -> None

--- a/src/Informedica.GenFORM.Lib/SourceLoader.fs
+++ b/src/Informedica.GenFORM.Lib/SourceLoader.fs
@@ -1,0 +1,76 @@
+namespace Informedica.GenForm.Lib
+
+
+/// <summary>
+/// Orchestration / loading layer for external formulary sources. Holds the IO that
+/// the pure <c>Source</c> module must not: fetching the Nederlands Kinder Formularium
+/// (NKF) medication index that <c>Source.getLink</c> needs to build an NKF link.
+/// </summary>
+/// <remarks>
+/// Split out for the same reason as <c>DoseRuleLoader</c>: <c>Source</c> is a pure leaf
+/// consumed by <c>DoseRule</c>, so it cannot hold a network call. This module is the
+/// resources-side seam, composed by <c>Resources.Keys.nkfLinkProvider</c>, which decides
+/// what a failed fetch means. See issue #529.
+/// </remarks>
+module SourceLoader =
+
+    open System
+    open FSharp.Data
+    open FSharp.Data.JsonExtensions
+
+
+    /// The NKF medication index, as JSON.
+    let nkfUrl = "https://www.kinderformularium.nl/geneesmiddelen.json"
+
+
+    /// Capped well below HttpClient's 100 second default: the formulary link is
+    /// decoration, and a hung connection stalls a resource load just as a refused one does.
+    let nkfTimeout = TimeSpan.FromSeconds 10.
+
+
+    // Constructing an HttpClient performs no IO, so this is safe as a top-level value;
+    // one instance avoids the socket exhaustion of a client per call.
+    let private client = new Net.Http.HttpClient(Timeout = nkfTimeout)
+
+
+    /// <summary>
+    /// Fetch the NKF medication index from <paramref name="url"/>.
+    /// </summary>
+    /// <remarks>
+    /// An IO leaf returning a <c>Result</c>: what a failure means is the registry's
+    /// decision, not this function's. See <c>Resources.Keys.nkfLinkProvider</c>. The url is
+    /// a parameter so the failure path can be exercised without taking the site down.
+    /// </remarks>
+    let fetchNKFMedicationsFrom (url: string) : Result<Source.NKFMedication list, Message list> =
+        // `Generic` is a field name several record types in this namespace share, so the
+        // labels are resolved by this annotated constructor rather than inline.
+        let medication id generic : Source.NKFMedication =
+            {
+                Id = id
+                Generic = generic
+            }
+
+        try
+            let res =
+                client.GetStringAsync url
+                |> Async.AwaitTask
+                |> Async.RunSynchronously
+                |> JsonValue.Parse
+
+            [
+                for v in res do
+                    medication (v?id.AsString()) (v?generic_name.AsString().Trim().ToLower())
+            ]
+            |> List.distinct
+            |> Ok
+        with exn ->
+            // The message is what reaches ResourceInfo (the exception itself is dropped
+            // there), so carry the reason. HttpClient failures arrive wrapped — an
+            // AggregateException around the HttpRequestException — hence the base exception.
+            Utils.Result.createError
+                $"fetchNKFMedications: could not fetch %s{url}: %s{exn.GetBaseException().Message}"
+                exn
+
+
+    /// Fetch the NKF medication index from <c>nkfUrl</c>.
+    let fetchNKFMedications () = fetchNKFMedicationsFrom nkfUrl

--- a/src/Informedica.GenPRES.Server/ServerApi.Services.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Services.fs
@@ -197,7 +197,9 @@ DoseType : {filter.DoseType |> Option.map DoseType.toDescription |> Option.defau
                     writeDebugMessage $"finished checking {dsrs |> Array.length} rules"
 
                     { form with
-                        Markdown = dsrs |> DoseRule.Print.toMarkdown
+                        Markdown =
+                            dsrs
+                            |> DoseRule.Print.toMarkdown (Informedica.GenForm.Lib.Api.getNKFLinkProvider provider)
                         DoseCheck = doseCheck
                     }
 

--- a/src/Informedica.NLP.Lib/Scripts/DoseRuleExtract.fsx
+++ b/src/Informedica.NLP.Lib/Scripts/DoseRuleExtract.fsx
@@ -1243,7 +1243,9 @@ module Pipeline =
                 else
                     match buildDoseRules payload.rules with
                     | Error msgs -> return Error $"buildDoseRules failed: {msgs}"
-                    | Ok rules -> return rules |> DoseRule.Print.toMarkdown |> Ok
+                    // No resource provider here, and these rules were just extracted by an
+                    // LLM rather than looked up, so there is nothing to link out to.
+                    | Ok rules -> return rules |> DoseRule.Print.toMarkdown Source.noLinks |> Ok
         }
 
 

--- a/tests/Informedica.GenFORM.Tests/Tests.fs
+++ b/tests/Informedica.GenFORM.Tests/Tests.fs
@@ -3577,6 +3577,25 @@ module Tests =
                         |> Expect.equal $"FK link should be {exp}" (Some exp)
                     }
 
+                    test "brand- and form-qualified labels link on the base generic" {
+                        let fkExp =
+                            "[Farmacotherapeutisch Kompas](https://www.farmacotherapeutischkompas.nl/bladeren/preparaatteksten/p/paracetamol#doseringen)"
+
+                        let nkfExp =
+                            "[Kinderformularium](https://www.kinderformularium.nl/geneesmiddel/123/paracetamol)"
+
+                        let brand = GenericLabel.fromGenericBrand "paracetamol" "Panadol"
+                        let form = GenericLabel.fromGenericForm "paracetamol" "zetpil"
+
+                        Source.getLink meds fk brand |> Expect.equal "FK, brand qualified" (Some fkExp)
+                        Source.getLink meds fk form |> Expect.equal "FK, form qualified" (Some fkExp)
+
+                        Source.getLink meds nkf brand
+                        |> Expect.equal "NKF, brand qualified" (Some nkfExp)
+
+                        Source.getLink meds nkf form |> Expect.equal "NKF, form qualified" (Some nkfExp)
+                    }
+
                     test "FK link does not need the NKF index" {
                         Source.getLink [] fk (label "paracetamol")
                         |> Expect.equal

--- a/tests/Informedica.GenFORM.Tests/Tests.fs
+++ b/tests/Informedica.GenFORM.Tests/Tests.fs
@@ -3535,6 +3535,109 @@ module Tests =
                 ]
 
 
+    /// External formulary links (issue #529): `Source.getLink` is pure over an NKF index
+    /// that may be empty, and `SourceLoader` is the IO leaf that must fail as a `Result`.
+    module SourceLinkTests =
+
+        let private fk = Source.identified "FK"
+        let private nkf = Source.identified "NKF"
+        let private label = GenericLabel.fromShorthand
+
+        let private meds: Source.NKFMedication list =
+            [
+                {
+                    Generic = "paracetamol"
+                    Id = "123"
+                }
+                {
+                    Generic = "amoxicilline + clavulaanzuur"
+                    Id = "456"
+                }
+            ]
+
+        let tests =
+            testList
+                "Source links"
+                [
+                    test "FK link files the generic under its first letter" {
+                        // Verified live: .../preparaatteksten/n/paracetamol is a 404,
+                        // .../preparaatteksten/p/paracetamol is the monograph.
+                        let exp =
+                            "[Farmacotherapeutisch Kompas](https://www.farmacotherapeutischkompas.nl/bladeren/preparaatteksten/p/paracetamol#doseringen)"
+
+                        Source.getLink [] fk (label "paracetamol")
+                        |> Expect.equal $"FK link should be {exp}" (Some exp)
+                    }
+
+                    test "FK link is lower case and slugs '/' to '-'" {
+                        let exp =
+                            "[Farmacotherapeutisch Kompas](https://www.farmacotherapeutischkompas.nl/bladeren/preparaatteksten/a/amoxicilline-clavulaanzuur#doseringen)"
+
+                        Source.getLink meds fk (label "Amoxicilline/Clavulaanzuur")
+                        |> Expect.equal $"FK link should be {exp}" (Some exp)
+                    }
+
+                    test "FK link does not need the NKF index" {
+                        Source.getLink [] fk (label "paracetamol")
+                        |> Expect.equal
+                            "same link with and without index"
+                            (Source.getLink meds fk (label "paracetamol"))
+                    }
+
+                    test "FK link is None for an empty label" {
+                        Source.getLink [] fk (label "") |> Expect.isNone "no page for an empty generic"
+                    }
+
+                    test "NKF link is None when the index is empty" {
+                        Source.getLink [] nkf (label "paracetamol")
+                        |> Expect.isNone "empty index (site unreachable) drops NKF links"
+                    }
+
+                    test "NKF link is built from the index id and the slugged label" {
+                        let exp =
+                            "[Kinderformularium](https://www.kinderformularium.nl/geneesmiddel/456/amoxicilline-clavulaanzuur)"
+
+                        Source.getLink meds nkf (label "amoxicilline/clavulaanzuur")
+                        |> Expect.equal $"NKF link should be {exp}" (Some exp)
+                    }
+
+                    test "NKF index match is case-insensitive" {
+                        Source.getLink meds nkf (label "Paracetamol")
+                        |> Option.map (String.contains "/geneesmiddel/123/")
+                        |> Expect.equal "matched entry 123" (Some true)
+                    }
+
+                    test "NKF link is None when the generic is not in the index" {
+                        Source.getLink meds nkf (label "ibuprofen") |> Expect.isNone "not indexed"
+                    }
+
+                    test "other sources have no link" {
+                        Source.getLink meds (Source.other "Lokaal") (label "paracetamol")
+                        |> Expect.isNone "no external formulary"
+                    }
+
+                    test "noLinks never finds a link" {
+                        Source.noLinks fk (label "paracetamol") |> Expect.isNone "FK"
+                        Source.noLinks nkf (label "paracetamol") |> Expect.isNone "NKF"
+                    }
+
+                    test "fetchNKFMedicationsFrom returns Error, not an exception, when unreachable" {
+                        // Port 9 (discard) on the loopback: refused immediately, no DNS.
+                        let url = "http://127.0.0.1:9/geneesmiddelen.json"
+
+                        match SourceLoader.fetchNKFMedicationsFrom url with
+                        | Ok _ -> failwith "expected Error"
+                        | Error [ ErrorMsg(text, Some _) ] ->
+                            text |> String.contains url |> Expect.isTrue "message names the url"
+
+                            text
+                            |> String.contains "could not fetch"
+                            |> Expect.isTrue "message says what failed"
+                        | Error msgs -> failwith $"expected one ErrorMsg with the exception, got %A{msgs}"
+                    }
+                ]
+
+
     /// The boxed resource registry engine (approach a) + GStand as a
     /// function-valued resource. Engine validated in Scripts/ResourcesRegistryImpl.fsx
     /// (incl. live load parity); these are the in-CI unit checks.
@@ -3629,6 +3732,66 @@ module Tests =
                         out |> Seq.isEmpty |> Expect.isTrue "fake provider returns empty"
                         called |> Expect.isTrue "function-valued resource was invoked"
                     }
+
+                    test "ofResultOrDefault: Ok passes the value through without warnings" {
+                        let k = kInt "opt-ok"
+                        let reg = Map [ k.Name, ofResultOrDefault "note" -1 (fun () -> Ok 42) ]
+                        let eng = LoadEngine reg
+
+                        eng.Resolve k |> Expect.equal "value" 42
+                        eng.Warnings |> Expect.equal "no warnings" []
+                    }
+
+                    test "ofResultOrDefault: Error yields the fallback and a prefixed Warning per error" {
+                        let k = kInt "opt-err"
+
+                        let reg =
+                            Map
+                                [
+                                    k.Name,
+                                    ofResultOrDefault
+                                        "not loaded"
+                                        -1
+                                        (fun () -> Error [ ErrorMsg("boom", None); Warning "meh" ])
+                                ]
+
+                        let eng = LoadEngine reg
+
+                        eng.Resolve k |> Expect.equal "fallback served" -1
+
+                        eng.Warnings
+                        |> Expect.equal
+                            "each error is a Warning prefixed with the note"
+                            [ Warning "not loaded: boom"; Warning "not loaded: meh" ]
+                    }
+
+                    test "nkfLinkProvider degrades to FK-only links when the fetch fails" {
+                        // Mirrors the defaultRegistry entry, with the fetch replaced.
+                        let reg =
+                            Map
+                                [
+                                    Keys.nkfLinkProvider.Name,
+                                    ofResultOrDefault
+                                        "NKF links not loaded"
+                                        (Source.getLink []: Source.LinkProvider)
+                                        (fun () -> Error [ ErrorMsg("kinderformularium.nl down", None) ])
+                                ]
+
+                        let eng = LoadEngine reg
+                        let getLink: Source.LinkProvider = eng.Resolve Keys.nkfLinkProvider
+                        let label = GenericLabel.fromShorthand "paracetamol"
+
+                        getLink (Source.identified "FK") label |> Expect.isSome "FK link survives"
+
+                        getLink (Source.identified "NKF") label |> Expect.isNone "NKF link is lost"
+
+                        eng.Warnings
+                        |> Expect.equal
+                            "outage surfaces as a Warning"
+                            [
+                                Warning "NKF links not loaded: kinderformularium.nl down"
+                            ]
+                    }
                 ]
 
 
@@ -3649,5 +3812,6 @@ module Tests =
                 DoseRuleToDataTests.tests
                 DoseRuleRoundtripTests.tests
                 CheckTests.tests
+                SourceLinkTests.tests
                 ResourceRegistryTests.tests
             ]

--- a/tests/Informedica.GenPRES.Server.Tests/ResourceErrorTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/ResourceErrorTests.fs
@@ -137,6 +137,24 @@ let cachedProviderErrorStateTests =
                 (provider :> IResourceProvider).GetRenalRules()
                 |> Expect.equal "RenalRules should be empty" [||]
             }
+
+            test "getNKFLinkProvider serves FK-only links instead of throwing when loader failed" {
+                // Nothing is registered on a failed load, so `Get` would raise
+                // KeyNotFoundException; a decorative link must not fail a request.
+                let provider =
+                    CachedResourceProvider((fun () -> Error [ errMsg "load failed" ]), None)
+
+                let getLink =
+                    Informedica.GenForm.Lib.Api.getNKFLinkProvider (provider :> IResourceProvider)
+
+                let label = GenericLabel.fromShorthand "paracetamol"
+
+                getLink (Source.identified "FK") label
+                |> Expect.isSome "FK link is built from the generic name alone"
+
+                getLink (Source.identified "NKF") label
+                |> Expect.isNone "NKF link needs the index, which did not load"
+            }
         ]
 
 

--- a/tests/Informedica.GenPRES.Server.Tests/ResourceErrorTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/ResourceErrorTests.fs
@@ -155,6 +155,22 @@ let cachedProviderErrorStateTests =
                 getLink (Source.identified "NKF") label
                 |> Expect.isNone "NKF link needs the index, which did not load"
             }
+
+            test "getNKFLinkProvider degrades when the key is unresolved on a loaded provider" {
+                // The state a reload race leaves behind: IsLoaded says yes, the resolved
+                // map has no nkfLinkProvider. An IsLoaded guard would not catch this.
+                let provider =
+                    CachedResourceProvider((fun () -> loadAllResourcesWithRegistry okRegistry), None)
+
+                (provider :> IResourceProvider).GetResourceInfo().IsLoaded
+                |> Expect.isTrue "precondition: provider is loaded"
+
+                let getLink =
+                    Informedica.GenForm.Lib.Api.getNKFLinkProvider (provider :> IResourceProvider)
+
+                getLink (Source.identified "FK") (GenericLabel.fromShorthand "paracetamol")
+                |> Expect.isSome "FK link served instead of KeyNotFoundException"
+            }
         ]
 
 


### PR DESCRIPTION
fix(genform): degrade gracefully when Kinderformularium is unreachable

## Overview

Fixes #529.

Since #524 the Nederlands Kinderformularium (NKF) index is fetched on first use. That is the right place for it, but a failed fetch then threw out of `DoseRule.Print.toMarkdown`, reached from `ServerApi.Services` and `PrescriptionRule`, so an outage at kinderformularium.nl could fail a request over a decorative link.

This PR moves the fetch out of `DoseRule` and makes it an optional resource:

- **`SourceLoader.fs`** (new): the IO leaf. `fetchNKFMedicationsFrom url` returns `Result<NKFMedication list, Message list>`, never throws, and is capped at 10 s (HttpClient defaults to 100).
- **`Resources.ofResultOrDefault`** (new): an optional-leaf loader. On `Error` the load succeeds with a fallback and each error becomes a `Warning` prefixed with a note. It also replaces the hand-written `totalsData` swallow.
- **`Keys.nkfLinkProvider`**: a function-valued resource (`Source.LinkProvider`, mirroring `Check.GStandProvider`). On failure it degrades to `Source.getLink []`, so FK links survive and NKF links fall back to the existing `"*Lokaal*"`. The failure shows in `ResourceInfo.Messages` and an admin `ReloadResources` retries it.
- **`DoseRule.Print.toMarkdown` / `printGenerics`, `PrescriptionRule.toMarkdown`** take the `LinkProvider` as a parameter; `DoseRule.Print` is pure again. `Source.noLinks` exists for scripts that want no external links.
- **`Api.getNKFLinkProvider`** serves the same degraded provider when the whole resource load failed (`IsLoaded = false`), where `Get` would otherwise throw `KeyNotFoundException`.
- **FK link fix**: `Source.getLink` built `…/preparaatteksten/n/<generic>`, a 404 for every generic. FK files monographs under the generic's first letter (`…/p/paracetamol`). This matters more now because the FK branch no longer depends on the NKF index, so the link renders for every FK-sourced rule.

## Further information

Two behaviour changes worth knowing about:

- The fetch now runs inside the resource load (`ForceAll()`), i.e. at startup and on every `ReloadResources`, rather than on first render. During an outage that is one ≤10 s attempt per load instead of one per render. Normal case measured at ~0.5 s.
- There is no automatic retry: `CachedResourceProvider` has no TTL, so if the site is down at startup the NKF links stay on `"*Lokaal*"` until an admin reload. The warning in the resource messages is the signal.

`AGENTS.md`'s "Never Perform IO in a Top-Level `let` Value" example referred to the removed `getKFMedications`; it is rewritten as a general value-vs-function example.

Out of scope, worth a follow-up issue: `NKF.Lib/WebSiteParser.fs` fetches the same index through `Memoization.memoize`, which is `Lazy`-backed and caches a thrown exception for the life of the process — the exact trap #529 describes.

## Divergence from plan

No implementation plan (bug fix from issue). An earlier revision of this branch kept the fetch inside `DoseRule.Print` with an in-module cache and a 5-minute retry window; that was dropped in favour of the registry because it left `DoseRule` impure and its cache unreachable by `ReloadResources`.

## Verification

- `dotnet run build`, `dotnet fantomas --check`: clean.
- `Informedica.GenFORM.Tests`: 414 passed, 0 failed. `Informedica.GenPRES.Server.Tests`: 42 passed, 0 failed.
- New tests (no network needed; the failure-path test connects to `127.0.0.1:9`, refused immediately):
  - GenFORM `Source links` (11): FK letter segment, lower-casing and `/`→`-` slug, FK independent of the index, empty label, NKF with empty index / found / case-insensitive / not indexed, other source, `noLinks`, `fetchNKFMedicationsFrom` unreachable → `Error`.
  - GenFORM registry (3): `ofResultOrDefault` Ok and Error paths, `nkfLinkProvider` degrades to FK-only links with a `Warning`.
  - Server (1): `getNKFLinkProvider` on a failed-load `CachedResourceProvider` returns links instead of throwing.
- Live checks from FSI: the NKF fetch with a bare `HttpClient` returns 930 medications in ~0.5 s; `…/preparaatteksten/n/paracetamol` is HTTP 404, `…/p/paracetamol` is the monograph.
- To see it locally: start the server, open a dose rule with an NKF source and check the link; then block `www.kinderformularium.nl` (e.g. `/etc/hosts`), `ReloadResources` from the admin page, and the same rule renders `*Lokaal*` with a `NKF links not loaded…` warning in the resource info.

## Author checklist

I confirm that these changes:

- [ ] Follow the process described in [CONTRIBUTING.md](../CONTRIBUTING.md#Pull_Request_Process).
- [x] Make the changes proposed in the linked issue (if applicable): #529
- [x] Follow the approach documented in the linked implementation plan (if applicable): n/a
- [ ] Are no more than 200 lines of changed code, ideally 25-100. — **No**: 437+/90−, of which ~180 are tests and ~60 are doc comments. The library change itself is under 200.
- [x] Are not more complex than necessary.
- [x] Cannot easily be split in a way that would make reviewing them significantly easier. The FK fix could be split out, but it only becomes visible because of this change.
- [x] Follow the guidelines specified in [DEVELOPMENT.md](../../DEVELOPMENT.md).
- [x] Have been thoroughly tested.
- [x] Don't introduce new security vulnerabilities.
- [ ] Follow the [AI/LLM Usage Policy](../../AGENTS.md#aillm-usage-policy) — LLMs were not given direct write access to `.fs` source files (except client-side UI code). — **See disclosure below.**

### AI/Vibe Coding Disclosure

- [x] Some or all code in this PR is **vibe coded** (substantially AI-generated).

Claude Code (Fable 5.1) co-authored this PR. The registry design and the `SourceLoader`/`Resources`/`DoseRule` changes were written by the maintainer with Claude in the loop. After a Claude code review of the branch, the maintainer authorised Claude to apply the review findings directly to `.fs` files: the FK letter-segment fix in `Source.fs`, the `IsLoaded` fallback in `Api.getNKFLinkProvider`, the error text in `SourceLoader.fs`, the doc comments, and all new tests. Every change was reviewed by the maintainer, and verified by the build, Fantomas, the two test suites and the live FSI checks listed above.

I confirm that I have:

- [x] Added appropriate automated tests.
- [x] Updated documentation appropriately.
- [ ] Added comments that highlight important changes and add justification, where necessary. (Create the PR as a draft first, add your comments, then mark as ready for review.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxX87vWZg58xDyc6os5kL4
