### PR TITLE
perf(genorder): memoise getEquations once instead of per call

### DIFF
--- a/src/Informedica.GenORDER.Lib/EquationMapping.fs
+++ b/src/Informedica.GenORDER.Lib/EquationMapping.fs
@@ -175,6 +175,12 @@ module EquationMapping =
         |> List.map fst
 
 
+    // Memoised once at module init (issue #530). Kept private and wrapped below so the
+    // public binding stays an argument-taking function: a function value compiles to a
+    // property returning FSharpFunc, a different .NET shape.
+    let private memoizedGetEquations = Memoization.memoize getEquations_
+
+
     /// <summary>
     /// Get a string list of Equations and
     /// use an index to filter out the relevant equations
@@ -184,7 +190,7 @@ module EquationMapping =
     /// The indx can be 3 for discontinuous equations, 4 for continuous
     /// and 5 for timed equations.
     /// </remarks>
-    let getEquations = Memoization.memoize getEquations_
+    let getEquations indx = memoizedGetEquations indx
 
 
     /// <summary>

--- a/src/Informedica.GenORDER.Lib/EquationMapping.fs
+++ b/src/Informedica.GenORDER.Lib/EquationMapping.fs
@@ -184,8 +184,7 @@ module EquationMapping =
     /// The indx can be 3 for discontinuous equations, 4 for continuous
     /// and 5 for timed equations.
     /// </remarks>
-    let getEquations indx =
-        indx |> Memoization.memoize getEquations_
+    let getEquations = Memoization.memoize getEquations_
 
 
     /// <summary>

--- a/tests/Informedica.GenORDER.Tests/Tests.fs
+++ b/tests/Informedica.GenORDER.Tests/Tests.fs
@@ -1347,6 +1347,16 @@ module EquationsTests =
                         EquationMapping.getEquations indx
                         |> Expect.equal $"embedded {name} equations equal the sheet" (expectedFor pos)
                     }
+
+                test "getEquations is memoised: repeat calls return the same instance" {
+                    // Issue #530: memoize used to be applied per call, so every call
+                    // built and missed a fresh cache and returned a new list.
+                    let first = EquationMapping.getEquations 3
+                    let second = EquationMapping.getEquations 3
+
+                    obj.ReferenceEquals(first, second)
+                    |> Expect.isTrue "second call is served from the cache"
+                }
             ]
 
 


### PR DESCRIPTION
## Overview

Fixes #530.

`EquationMapping.getEquations` applied `Memoization.memoize` inside the function, so every call built a fresh cache, missed it, and filtered the equation table again. The memoization never did anything. The cache is now built once at module level:

```fsharp
let getEquations = Memoization.memoize getEquations_
```

Signature unchanged (`int -> string list`); callers in `Order.fs` and `OrderLogging.fs` untouched. Small effect in practice (in-memory list, a handful of keys), hence `perf` rather than `fix`.

## Further information

Building the cache at module level is safe under the "Never Perform IO in a Top-Level `let` Value" rule: `memoize` only allocates a `ConcurrentDictionary` and a closure, and `getEquations_` is pure, so the `Lazy` inside can never cache an exception.

## Divergence from plan

n/a — under 25 lines, no plan.

## Verification

- `dotnet run build`, `dotnet fantomas --check`: clean.
- `Informedica.GenORDER.Tests` "EquationMapping embedded equations vs sheet": 7 passed, 0 failed.
- New test: two calls to `getEquations 3` return the same list instance (`obj.ReferenceEquals`). Fails on the old code, which returned a new list per call.
- Confirmed against the built DLL in FSI: `ReferenceEquals(getEquations 3, getEquations 3) = true`.

## Author checklist

I confirm that these changes:

- [x] Follow the process described in [CONTRIBUTING.md](../CONTRIBUTING.md#Pull_Request_Process).
- [x] Make the changes proposed in the linked issue (if applicable): #530
- [x] Follow the approach documented in the linked implementation plan (if applicable): n/a
- [x] Are no more than 200 lines of changed code, ideally 25-100.
- [x] Are not more complex than necessary.
- [x] Cannot easily be split in a way that would make reviewing them significantly easier.
- [x] Follow the guidelines specified in [DEVELOPMENT.md](../../DEVELOPMENT.md).
- [x] Have been thoroughly tested.
- [x] Don't introduce new security vulnerabilities.
- [ ] Follow the [AI/LLM Usage Policy](../../AGENTS.md#aillm-usage-policy) — LLMs were not given direct write access to `.fs` source files (except client-side UI code). — **See disclosure below.**

### AI/Vibe Coding Disclosure

- [x] Some or all code in this PR is **vibe coded** (substantially AI-generated).

The one-line source change was written by the maintainer. Claude Code (Fable 5.1) reviewed it, added the regression test in `tests/Informedica.GenORDER.Tests/Tests.fs`, and verified the memoisation against the built DLL in FSI. All reviewed by the maintainer.

I confirm that I have:

- [x] Added appropriate automated tests.
- [x] Updated documentation appropriately.
- [x] Added comments that highlight important changes and add justification, where necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxX87vWZg58xDyc6os5kL4
