### PR TITLE
ci(github): bring the macOS test leg in line with ubuntu and windows

### DIFF
--- a/.claude/docs/session-decisions.md
+++ b/.claude/docs/session-decisions.md
@@ -108,3 +108,56 @@ Three client-UI features this session. All changes are in `src/Informedica.GenPR
   that's `.fs` server code → would need the `.fsx` prototype-and-migrate workflow, not done.
 - Unit assumption in the ceiling `min`: dose qty and orderable qty share a unit (mL volume);
   holds for the orderable dose quantity, would be wrong if ever different-unit.
+
+---
+
+# Session Decisions - 2026-09-05 (macOS CI leg investigation)
+
+Branch `perf/ci-no-build-test`, PR open against informedica/GenPRES master.
+
+## Established facts (measured, not inferred)
+
+- Runner hardware (now echoed by a `Runner hardware` step in build.yml): macos-latest arm64 = 3 cores / 7 GB;
+  ubuntu-latest = 4 / 15 GB; windows-latest = 4 / 16 GB.
+- Restore+build costs the same on all three OSes (~105 s). The macOS gap was entirely in the `ServerTests` target.
+- `dotnet test` without `--no-build` re-evaluated the whole solution: 16 of 29 s locally; ~28 s on every CI leg. Fixed (c3cec9e5).
+- `DOTNET_EnableWriteXorExecute` has no effect on arm64 macOS (13.3 vs 13.4 s). Do not re-suggest.
+- GenSOLVER.Tests (4748 tests): per-test *durations* summed to ~3 s on macOS, but the tests window was 49 s.
+  The time was harness overhead between tests (~10 ms/test on macOS, ~2.5 ms ubuntu, ~0.2 ms local) × 4624 golden
+  MinMax scenario tests. Throughput ~65 tests/s while other testhosts ran, ~170/s alone → contention amplifies it.
+- Agents.Tests 13 → 25 s on macOS: three FileWriterAgent FsCheck properties each do `Thread.Sleep 100` per case
+  (`waitForFileWrite`) × 100 cases + temp-file IO. Not addressed yet.
+- Expecto worker count = ProcessorCount (max in-flight tests 3 on macOS, 4 on ubuntu, 16 locally).
+
+## Changes on the branch
+
+1. c3cec9e5 `Build.fs`: `--no-build` on ServerTests; per-assembly progress line with wall-clock + VSTest Duration.
+2. a6208fe0 `build.yml`: `Runner hardware` step; upload `**/TestResults/**/*.trx` per OS (7 days, always()).
+3. 36411726 `tests/Informedica.GenSOLVER.Tests/Tests.fs`: 4624 per-line scenario tests → 4 per-operator tests
+   (`scenarioTest`), mismatches listed by index. User explicitly authorised the .fs edit. Mutation-checked.
+4. 9889a752 `Build.fs`: `-m:(max 2 (ProcessorCount - 1))` — MEASURED WORSE and reverted (see Rejected).
+
+## Rejected
+
+- W^X env var (no effect). Trimming macOS from the PR matrix (user chose to keep full matrix).
+- Lowering FsCheck `maxTest=1000` in GenSOLVER: the properties were the *fast* part on macOS.
+- MSBuild `-m` cap on `dotnet test` (run 33973552546): macOS ServerTests 32.5 → 56.6 s, ubuntu 22.9 → 27.2 s,
+  windows 36.0 → 32.3 s. Once the 4624-test overhead was gone, less overlap only serialised the sleep-bound
+  assemblies. Uncapped default stays.
+
+## Analysis tooling (scratchpad, not in repo)
+
+- `trx_profile.py <file.trx>`: run window / discovery gap / per-bucket sums / top tests from trx startTime+endTime.
+- `wait_and_profile.sh <label> <sha>`: waits for the build.yml run on a commit, prints per-assembly lines, downloads trx.
+
+## Results
+
+| ServerTests | ubuntu | windows | macOS |
+|---|---|---|---|
+| original (5-run avg) | 57 s | 61 s | 116 s |
+| + --no-build (33972679870) | 26 s | 39 s | 60 s |
+| + scenario collapse (33973502710) | 23 s | 36 s | 32.5 s |
+
+Remaining long pole on every OS: Agents.Tests (13 / 15 / 26 s) — three FileWriterAgent FsCheck properties at
+~20 s each on macOS, `Thread.Sleep 100` per case × 100 cases. Next candidate fix (needs user OK, .fs test file):
+replace the fixed sleep with the file's existing `waitUntil` poll.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,24 @@ jobs:
 
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - name: Runner hardware
+      # Diagnostic for the macOS leg: GenSOLVER.Tests takes 66s there against 15s on ubuntu and
+      # 18s on windows, and nothing in the job log says what each leg actually runs on. Read the
+      # core count and RAM off the log rather than assuming the published runner specs.
+      shell: bash
+      run: |
+        echo "arch:  $(uname -m)"
+        case "$(uname -s)" in
+          Darwin)
+            echo "cores: $(sysctl -n hw.ncpu)"
+            echo "ram:   $(( $(sysctl -n hw.memsize) / 1073741824 )) GB" ;;
+          Linux)
+            echo "cores: $(nproc)"
+            echo "ram:   $(free -g | awk '/^Mem:/ {print $2}') GB" ;;
+          *)
+            echo "cores: $(nproc)"
+            echo "ram:   $(powershell -NoProfile -Command '[math]::Round((Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory / 1GB)') GB" ;;
+        esac
     - name: Use .NET Core 10.0 SDK
       # global-json-file (not dotnet-version) so global.json's pinned version + rollForward is the
       # single source of truth for which SDK CI installs — see issue #447: dotnet-version: '10.0.x'
@@ -55,6 +73,17 @@ jobs:
       # on Build, which transitively depends on Clean/RestoreClient, so it would redo the full restore/build 
       # which the "Test execution" just did. The DLLs are already fresh from build at this point.
       run: dotnet fsi scripts/CheckSolutionVersions.fsx
+
+    - name: Upload test results
+      # The trx files carry per-test durations; only the ubuntu ones were ever read (by the publish
+      # step below). Upload all three legs so the macOS GenSOLVER.Tests slowdown can be traced to
+      # specific tests. always(): a red run is still data.
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: test-results-${{ matrix.os }}
+        path: '**/TestResults/**/*.trx'
+        retention-days: 7
 
     - name: Publish test results
       # continue-on-error: Dependabot PRs (and PRs from forks) get a read-only GITHUB_TOKEN that GitHub forces 

--- a/Build.fs
+++ b/Build.fs
@@ -159,9 +159,12 @@ Target.create
 
         let started = ref false
 
+        // Wall-clock since the target began, stamped on each assembly summary below.
+        let sw = System.Diagnostics.Stopwatch.StartNew()
+
         // Capture all output so we can surface the failing tests on a non-zero
-        // exit. The progress dots replace the raw `dotnet test` output, so
-        // without this the CI log shows no indication of *what* failed.
+        // exit. The per-assembly progress lines replace the raw `dotnet test`
+        // output, so without this the CI log shows no indication of *what* failed.
         let captured = System.Collections.Generic.List<string>()
 
         let parseLine (line: string) =
@@ -195,9 +198,13 @@ Target.create
 
                 if not started.Value then
                     started.Value <- true
-                    printf "Running tests "
+                    printfn "Running tests ..."
 
-                printf "."
+                // One line per assembly rather than a bare dot, so a slow *assembly* can be
+                // told apart from a slow *platform*. `dotnet test` runs the test projects
+                // concurrently, so the stamp is when this assembly finished, while VSTest's
+                // own `Duration:` inside the line is how long it took.
+                printfn "  [%6.1fs] %s" sw.Elapsed.TotalSeconds (line.Trim())
 
         // Build the process directly rather than via the `dotnet` helper: that
         // helper attaches an `addOnExited` that throws on a non-zero exit code
@@ -209,6 +216,13 @@ Target.create
             [
                 "test"
                 sln
+                // ServerTests depends on Build, which has just run `dotnet build` over the
+                // whole solution (test projects included). Without --no-build, `dotnet test`
+                // evaluates the project graph and up-to-date-checks every project a second
+                // time: measured locally that second pass is 16 of the target's 29 seconds,
+                // more than the test run itself. The `totalTests = 0` guard below turns a
+                // genuinely unbuilt tree into a loud failure rather than a green no-op.
+                "--no-build"
                 "--no-restore"
                 "--verbosity"
                 "quiet"
@@ -240,7 +254,7 @@ Target.create
             printfn "====================================================================="
 
             if result.ExitCode <> 0 then
-                // The progress dots replace the raw `dotnet test` output, so dump
+                // The per-assembly progress lines replace the raw `dotnet test` output, so dump
                 // the captured output to reveal *what* failed. At minimal verbosity
                 // this is just the per-project summaries plus the failure blocks
                 // (no passing-test noise), so it stays readable.

--- a/Build.fs
+++ b/Build.fs
@@ -224,14 +224,6 @@ Target.create
                 // genuinely unbuilt tree into a loud failure rather than a green no-op.
                 "--no-build"
                 "--no-restore"
-                // Cap how many test projects MSBuild runs at once. Each one is a testhost
-                // whose Expecto workers already scale with the core count, and vstest.console
-                // plus the MSBuild node need a core too: on the 3-core / 7 GB macOS CI runner
-                // an uncapped run oversubscribed the box badly (run 33972679870: GenSOLVER
-                // scenario throughput ~65 tests/s while other testhosts ran, ~170/s alone).
-                // Leave one core free; never go below two so small boxes still overlap the
-                // sleep-bound assemblies (Agents.Tests, Logging.Tests) with the CPU-bound ones.
-                $"-m:%i{max 2 (System.Environment.ProcessorCount - 1)}"
                 "--verbosity"
                 "quiet"
                 "--logger"

--- a/Build.fs
+++ b/Build.fs
@@ -224,6 +224,14 @@ Target.create
                 // genuinely unbuilt tree into a loud failure rather than a green no-op.
                 "--no-build"
                 "--no-restore"
+                // Cap how many test projects MSBuild runs at once. Each one is a testhost
+                // whose Expecto workers already scale with the core count, and vstest.console
+                // plus the MSBuild node need a core too: on the 3-core / 7 GB macOS CI runner
+                // an uncapped run oversubscribed the box badly (run 33972679870: GenSOLVER
+                // scenario throughput ~65 tests/s while other testhosts ran, ~170/s alone).
+                // Leave one core free; never go below two so small boxes still overlap the
+                // sleep-bound assemblies (Agents.Tests, Logging.Tests) with the CPU-bound ones.
+                $"-m:%i{max 2 (System.Environment.ProcessorCount - 1)}"
                 "--verbosity"
                 "quiet"
                 "--logger"

--- a/tests/Informedica.GenSOLVER.Tests/Tests.fs
+++ b/tests/Informedica.GenSOLVER.Tests/Tests.fs
@@ -1133,6 +1133,33 @@ module Tests =
                     |> List.zip (opStr |> opToSheet |> scenarios)
 
 
+                // One test per operator rather than one per fixture line. With 4 x 1156
+                // lines, per-test harness overhead (Expecto scheduling plus the adapter
+                // reporting every result to VSTest) dwarfed the assertions: on the 3-core
+                // macOS CI runner the 4624 tests summed to under a second of work inside
+                // a 46 second window. Mismatches are listed by line, so a failure still
+                // says exactly which scenarios diverged from the fixture.
+                let scenarioTest name op opStr =
+                    test name {
+                        let scenarios = testScenarios op opStr
+
+                        // testScenarios zips the fixture line first, the computed line second
+                        let mismatches =
+                            scenarios
+                            |> List.indexed
+                            |> List.filter (fun (_, (fixture, computed)) -> fixture <> computed)
+                            |> List.map (fun (i, (fixture, computed)) ->
+                                $"scenario %i{i}: fixture %s{fixture}, computed %s{computed}"
+                            )
+
+                        mismatches
+                        |> Expect.isEmpty (
+                            $"%i{mismatches.Length} of %i{scenarios.Length} %s{name} scenarios differ from the fixture:\n"
+                            + (mismatches |> String.concat "\n")
+                        )
+                    }
+
+
                 let toValueUnit = List.toArray >> ValueUnit.withUnit Units.Count.times
 
                 let singleToValueUnit = ValueUnit.singleWithUnit Units.Count.times
@@ -1683,54 +1710,10 @@ module Tests =
                                     testList
                                         "Scenarios"
                                         [
-                                            testList
-                                                "Mult"
-                                                [
-                                                    yield!
-                                                        testScenarios mult "x"
-                                                        |> List.mapi (fun i (act, exp) ->
-                                                            test $"scenario: {i}" {
-                                                                act |> Expect.equal "should be equal" exp
-                                                            }
-                                                        )
-                                                ]
-
-                                            testList
-                                                "Div"
-                                                [
-                                                    yield!
-                                                        testScenarios div "/"
-                                                        |> List.mapi (fun i (act, exp) ->
-                                                            test $"scenario: {i}" {
-                                                                act |> Expect.equal "should be equal" exp
-                                                            }
-                                                        )
-                                                ]
-
-                                            testList
-                                                "Add"
-                                                [
-                                                    yield!
-                                                        testScenarios add "+"
-                                                        |> List.mapi (fun i (act, exp) ->
-                                                            test $"scenario: {i}" {
-                                                                act |> Expect.equal "should be equal" exp
-                                                            }
-                                                        )
-                                                ]
-
-                                            testList
-                                                "Sub"
-                                                [
-                                                    yield!
-                                                        testScenarios sub "-"
-                                                        |> List.mapi (fun i (act, exp) ->
-                                                            test $"scenario: {i}" {
-                                                                act |> Expect.equal "should be equal" exp
-                                                            }
-                                                        )
-                                                ]
-
+                                            scenarioTest "Mult" mult "x"
+                                            scenarioTest "Div" div "/"
+                                            scenarioTest "Add" add "+"
+                                            scenarioTest "Sub" sub "-"
                                         ]
 
                                 ]


### PR DESCRIPTION
## Overview

The macOS matrix leg was consistently the slowest, and the `Build` workflow's `Test execution` step was
the reason on every OS. This PR finds out why and fixes it. Restore + build were never the problem — they
cost the same ~105 s on all three runners — it was all inside the `ServerTests` FAKE target.

| `ServerTests` target | ubuntu-24.04 | windows-2025 | macos-26-arm64 |
|---|---|---|---|
| before (5-run average) | 57 s | 61 s | 116 s |
| + `--no-build` (c3cec9e5) | 26 s | 39 s | 60 s |
| + scenario tests collapsed (36411726) | **23 s** | **36 s** | **32.5 s** |

Two fixes carry all of that; everything else in the PR is instrumentation that made the second fix findable.

## Further information

### 1. `dotnet test` ran without `--no-build` (`Build.fs`)

`ServerTests` depends on `Build`, which had just built the whole solution, then ran
`dotnet test GenPRES.sln --no-restore` — so MSBuild evaluated the project graph and up-to-date-checked every
project a second time. Locally that pass is 16 s of the target's 29 s; on CI it was ~28 s on every OS.
`TestHeadless` already passed `--no-build`. The pre-existing `totalTests = 0` guard still fails the target
loudly on an unbuilt tree.

### 2. 4624 one-line golden tests in `GenSOLVER.Tests` (`tests/Informedica.GenSOLVER.Tests/Tests.fs`)

Per-test durations from the trx files told the story. On macOS the **sum of all 4748 test bodies was ~3 s**
(the M1 runs the FsCheck properties *faster* than ubuntu), yet the assembly's tests window was 49 s. The time
was harness overhead between tests — Expecto scheduling plus the VSTest adapter reporting every result —
multiplied by 4 × 1156 `MinMaxCalculator` scenario tests that each compare two strings:

| scenario tests / second | local | ubuntu | windows | macOS, other testhosts running | macOS, alone |
|---|---|---|---|---|---|
| | >1000 | ~370 | ~300 | **~65** | ~170 |

The runner is 3 cores / 7 GB (`macos-latest` arm64; ubuntu/windows are 4 cores / 15–16 GB — now printed
by a `Runner hardware` step), and that overhead is latency-bound, so it collapsed under 16 concurrent
testhosts. Replaced with one test per operator that diffs the whole fixture and lists every mismatching
line by index. Verified by corrupting a fixture line in the test output:

```
Failed GenSolver.minmax calculator.calc min max.Scenarios.Div [57 ms]
1 of 1156 Div scenarios differ from the fixture:
scenario 711: fixture 712, < -2 .. 3 >, /, < 3 .. >, =, < -2/3 ..1 >, computed 712, CORRUPTED LINE.
```

Same coverage, 4748 → 128 tests in the assembly, `Duration` 48 s → 3 s on macOS (13 → 2 s ubuntu).

### Instrumentation kept

- `Build.fs`: the bare progress dot per assembly is now one line with the wall-clock stamp and VSTest's
  `Duration`, so a slow assembly can be told from a slow platform at a glance.
- `build.yml`: `Runner hardware` step (arch / cores / RAM), and the `.trx` files uploaded as an artifact
  per OS (`always()`, 7 days). Only the ubuntu ones were ever read before, by the Linux-only publish step.

### Tried and rejected, with numbers

- **`DOTNET_EnableWriteXorExecute=0`** (arm64 W^X): 13.3 s vs 13.4 s on an M-series Mac, no effect.
  That regression was .NET 7-era and is fixed. An early draft of this branch carried it; removed.
- **MSBuild `-m:(cores − 1)` cap on `dotnet test`** (9889a752, reverted in 516bad10): measured on all three
  OSes, it made macOS *slower* (32.5 → 56.6 s; sum of testhost windows 86 → 105 s) and ubuntu slightly
  slower (22.9 → 27.2 s). Once the scenario overhead was gone, the sleep-bound assemblies benefit from
  overlapping the CPU-bound ones, so the uncapped default is right.
- Lowering FsCheck `maxTest = 1000` in GenSOLVER: the properties were the fast part.

### Left for a follow-up

The long pole is now `Agents.Tests` on every OS (13 / 15 / 26 s): its three `FileWriterAgent` FsCheck
properties do `Thread.Sleep 100` per case (`waitForFileWrite`) × 100 cases. Polling with the file's
existing `waitUntil` would take ~10 s off each leg.

## Divergence from plan

No issue or plan — the first commit was under 25 lines, and the rest followed the measurements.
The one test-file change was explicitly authorised by the maintainer during the investigation.

## Verification

- `dotnet run ServerTests` locally: 1521 passed, 0 failed, 2 skipped (the 4620 fewer are the collapsed
  scenario cases; every fixture line is still asserted). `dotnet fantomas --check` clean.
- Mutation check of the collapsed test shown above.
- CI numbers above are from runs 33970176074 (baseline), 33972679870 (`--no-build`),
  33973502710 (collapse) and 33973552546 (cap, reverted). The per-assembly lines are in each job log
  under `Test execution`; the trx artifacts are attached to the last three runs.

## Author checklist

- [x] Follow the process described in [CONTRIBUTING.md](../CONTRIBUTING.md#Pull_Request_Process).
- [x] Make the changes proposed in the linked issue (if applicable): n/a
- [x] Follow the approach documented in the linked implementation plan (if applicable): n/a
- [x] Are no more than 200 lines of changed code, ideally 25-100.
- [x] Are not more complex than necessary.
- [x] Cannot easily be split in a way that would make reviewing them significantly easier.
- [x] Follow the guidelines specified in [DEVELOPMENT.md](../../DEVELOPMENT.md).
- [x] Have been thoroughly tested.
- [x] Don't introduce new security vulnerabilities.
- [x] Follow the [AI/LLM Usage Policy](../../AGENTS.md#aillm-usage-policy) — no `src/**/*.fs` touched;
  the `tests/Informedica.GenSOLVER.Tests/Tests.fs` and `Build.fs` edits were made by an LLM with the
  maintainer's explicit authorisation and are disclosed below.

### AI/Vibe Coding Disclosure

- [x] Some or all code in this PR is **vibe coded** (substantially AI-generated).

Written by Claude Code. Everything in the diff is AI-generated — the `--no-build` argument, the per-assembly
logging, the workflow steps, and the `scenarioTest` helper — with the investigation driven by measurement
at each step: per-phase CI timings, then per-assembly, then per-test trx timelines. Verified by
`dotnet run ServerTests`, a fixture-corruption mutation check, `dotnet fantomas --check`, and CI runs on
all three OSes for every commit, including the two changes that were measured, found wanting, and removed.

I confirm that I have:

- [x] Added appropriate automated tests. — n/a: the suite itself is the test; coverage is unchanged.
- [x] Updated documentation appropriately. — `.claude/docs/session-decisions.md` records the investigation.
- [x] Added comments that highlight important changes and add justification, where necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQ7K5fnJDeanp86MkDuJiT
