### PR TITLE
test(agents): drop the fixed sleep after FileWriterAgent.flush

### DIFF
--- a/tests/Informedica.Agents.Tests/Tests.fs
+++ b/tests/Informedica.Agents.Tests/Tests.fs
@@ -719,7 +719,11 @@ module Tests =
                         ""
                 with _ -> ""
 
-            let waitForFileWrite () = Thread.Sleep(100)
+            // No wait is needed between `FileWriterAgent.flush` and reading the file
+            // back: flush is PostAndReply, the agent handles messages in order, and it
+            // replies only after StreamWriter.Flush() on every open writer. A fixed
+            // Thread.Sleep here used to cost 100 ms x 100 cases in each FsCheck
+            // property below.
 
         open TestHelpers
 
@@ -743,8 +747,6 @@ module Tests =
                         |> FileWriterAgent.flush
                         |> ignore
 
-                        waitForFileWrite()
-
                         let content = readAllLines tempFile
                         content |> Expect.equal "Should write single line" [|"Hello, World!"|]
 
@@ -763,8 +765,6 @@ module Tests =
                         |> FileWriterAgent.append tempFile lines
                         |> FileWriterAgent.flush
                         |> ignore
-
-                        waitForFileWrite()
 
                         let content = readAllLines tempFile
                         content |> Expect.equal "Should write all lines" lines
@@ -786,8 +786,6 @@ module Tests =
                         |> FileWriterAgent.flush
                         |> ignore
 
-                        waitForFileWrite()
-
                         let content = readAllLines tempFile
                         content |> Expect.equal "Should accumulate lines" [|"First"; "Second"; "Third"|]
 
@@ -806,8 +804,6 @@ module Tests =
                         |> FileWriterAgent.append tempFile [|"Created file"|]
                         |> FileWriterAgent.flush
                         |> ignore
-
-                        waitForFileWrite()
 
                         (File.Exists tempFile) |> Expect.isTrue "Should create file"
                         let content = readAllLines tempFile
@@ -836,8 +832,6 @@ module Tests =
                         |> FileWriterAgent.flush
                         |> ignore
 
-                        waitForFileWrite()
-
                         let content = readAllText tempFile
                         content |> Expect.equal "Should be empty after clear" ""
 
@@ -856,8 +850,6 @@ module Tests =
                         |> FileWriterAgent.clear tempFile
                         |> FileWriterAgent.flush
                         |> ignore
-
-                        waitForFileWrite()
 
                         (File.Exists tempFile) |> Expect.isTrue "Should create file"
                         let content = readAllText tempFile
@@ -881,8 +873,6 @@ module Tests =
                         |> FileWriterAgent.append tempFile [|"New content"|]
                         |> FileWriterAgent.flush
                         |> ignore
-
-                        waitForFileWrite()
 
                         let content = readAllLines tempFile
                         content |> Expect.equal "Should only have new content" [|"New content"|]
@@ -909,8 +899,6 @@ module Tests =
                         |> FileWriterAgent.flush
                         |> ignore
 
-                        waitForFileWrite()
-
                         let content1 = readAllLines tempFile1
                         let content2 = readAllLines tempFile2
 
@@ -936,15 +924,11 @@ module Tests =
                         |> FileWriterAgent.flush
                         |> ignore
 
-                        waitForFileWrite()
-
                         // Clear only file 1
                         writer
                         |> FileWriterAgent.clear tempFile1
                         |> FileWriterAgent.flush
                         |> ignore
-
-                        waitForFileWrite()
 
                         let content1 = readAllText tempFile1
                         let content2 = readAllLines tempFile2
@@ -975,8 +959,6 @@ module Tests =
                         |> FileWriterAgent.flush
                         |> ignore
 
-                        waitForFileWrite()
-
                         let content = readAllLines tempFile
                         content |> Expect.equal "Should handle Unicode correctly" unicodeContent
 
@@ -997,8 +979,6 @@ module Tests =
                         |> FileWriterAgent.append tempFile [|"Appended content"|]
                         |> FileWriterAgent.flush
                         |> ignore
-
-                        waitForFileWrite()
 
                         let content = readAllLines tempFile
                         content |> Expect.equal "Should preserve and append correctly" [|"Initial content"; "Appended content"|]
@@ -1032,8 +1012,6 @@ module Tests =
                         |> FileWriterAgent.flush
                         |> ignore
 
-                        waitForFileWrite()
-
                         let content = readAllLines tempFile
                         content |> Expect.equal "Agent should continue working after error" [|"Valid operation"|]
 
@@ -1051,8 +1029,6 @@ module Tests =
                         |> FileWriterAgent.append tempFile [||]
                         |> FileWriterAgent.flush
                         |> ignore
-
-                        waitForFileWrite()
 
                         let content = readAllText tempFile
                         content |> Expect.equal "Empty array should result in no content" ""
@@ -1079,8 +1055,6 @@ module Tests =
                         |> FileWriterAgent.flush
                         |> ignore
 
-                        waitForFileWrite()
-
                         let content = readAllLines tempFile
                         content.Length |> Expect.equal "Should handle large content" 1000
                         content[0] |> Expect.equal "First line should be correct" "Line 0"
@@ -1103,7 +1077,6 @@ module Tests =
                             |> ignore
 
                         writer |> FileWriterAgent.flush |> ignore
-                        waitForFileWrite()
 
                         let content = readAllLines tempFile
                         content.Length |> Expect.equal "Should handle all rapid operations" 100
@@ -1136,8 +1109,6 @@ module Tests =
                             |> FileWriterAgent.append tempFile linesArray
                             |> FileWriterAgent.flush
                             |> ignore
-
-                            waitForFileWrite()
 
                             let content = readAllLines tempFile
                             content = linesArray
@@ -1172,8 +1143,6 @@ module Tests =
                             |> FileWriterAgent.clear tempFile
                             |> FileWriterAgent.flush
                             |> ignore
-
-                            waitForFileWrite()
 
                             let content = readAllText tempFile
                             content = ""
@@ -1222,8 +1191,6 @@ module Tests =
                                 |> FileWriterAgent.append tempFile2 (List.toArray validLines2)
                                 |> ignore
                             writer |> FileWriterAgent.flush |> ignore
-
-                            waitForFileWrite()
 
                             let content1 = readAllLines tempFile1
                             let content2 = readAllLines tempFile2


### PR DESCRIPTION
## Overview

After #543, `Informedica.Agents.Tests` is the slowest assembly on every CI leg (13 s ubuntu, 15 s
windows, 26 s macOS). The per-test trx from run 33973502710 puts almost all of it in three FsCheck
properties (`FileWriterAgent Tests.Property-based Tests.*`): 10.3 s each on ubuntu, 11.5 s windows,
20 s macOS. Each runs 100 cases and each case called `waitForFileWrite ()` = `Thread.Sleep 100` — a
10 s floor per property before any IO.

The sleep waited for something that had already happened. All 19 calls sit directly after
`FileWriterAgent.flush`, which is `PostAndReply Flush`: the agent handles its mailbox in order and the
`Flush` handler calls `StreamWriter.Flush()` on every open writer *before* `reply.Reply(())`
(`FileWriterAgent.fs`), so when `flush` returns the bytes are at the OS and readable. The same file
already proves it — the two `Async Operations` tests read straight after `flushAsync` / `stopAsync`
with no sleep and pass on all three OSes.

This PR deletes the helper and its 19 calls, and leaves a comment where the helper was so a sleep
isn't re-added. Nothing else changes. −38 / +5 lines, one test file.

## Further information

On brittleness — the reason this is safe rather than a trade-off: no timeout is introduced and nothing
becomes timing-dependent. A fixed sleep *is* the brittle construct (a guess that happens to be long
enough); the reply from `PostAndReply` is the protocol's own completion signal. The tests are now
strictly more deterministic than before.

Deliberately **not** touched, so the change stays a pure removal:

- the polling `waitUntil` (`Thread.Sleep 5`) in the two `Agent` FsCheck properties (0.6–3 s);
- the `//invalid//path//file.txt` in `Error Handling` that costs 2.9 s on Windows because it parses as a
  UNC path (network name lookup);
- the fallback-timeout tests' `Thread.Sleep 1200 / 800` — those sleeps are the subject of the tests.

## Divergence from plan

n/a — under 25 lines of changed code; no issue or implementation plan.

## Verification

Local, `tests/Informedica.Agents.Tests` with a trx logger, before / after:

| | before | after |
|---|---|---|
| `all written lines should be readable` | 10.19 s | < 0.2 s |
| `clear always results in empty file` | 10.23 s | < 0.2 s |
| `append is associative` | 10.23 s | < 0.2 s |
| assembly `Duration` | 11 s | **2 s** |

What's left is the fallback-timeout tests (1.2 s, sequenced, by design) and the two Agent properties.

Flakiness: ten consecutive runs of the project after the change, all `52/52` passed, all 2 s.
`dotnet run ServerTests` green for the whole suite; `dotnet fantomas --check` clean.

CI, run 33976240251 (`Agents.Tests` VSTest `Duration` / whole `ServerTests` target), against the last
master run before this change (33973502710):

| | ubuntu | windows | macOS |
|---|---|---|---|
| `Agents.Tests` before | 13 s | 15 s | 26 s |
| `Agents.Tests` after | **2 s** | 15 s | **4 s** |
| `ServerTests` before | 23 s | 36 s | 32.5 s |
| `ServerTests` after | 23.5 s | 39 s | **25 s** |

macOS and ubuntu behave as the local numbers predicted. **Windows did not move**, and the trx shows why:
the three FileWriterAgent properties did drop (11.5 s → 0.3–5 s), but the two `Agent` FsCheck
properties that poll with `Thread.Sleep 5` went 1.5 s → 8.5 s each on this run, and the UNC-path
lookup in `Error Handling` 2.9 s → 4.4 s — the two items deliberately left out of this PR. Both are
Windows timer-granularity / name-resolution costs and vary run to run (the same two properties were
9.3 s / 8.8 s in run 33972679870 and 1.5 s in 33973502710), so Windows `Agents.Tests` was already
swinging 14–27 s before this change. Taking them on is a separate, small PR if wanted; this one stays a
pure removal.

## Author checklist

- [x] Follow the process described in [CONTRIBUTING.md](../CONTRIBUTING.md#Pull_Request_Process).
- [x] Make the changes proposed in the linked issue (if applicable): n/a
- [x] Follow the approach documented in the linked implementation plan (if applicable): n/a
- [x] Are no more than 200 lines of changed code, ideally 25-100.
- [x] Are not more complex than necessary.
- [x] Cannot easily be split in a way that would make reviewing them significantly easier.
- [x] Follow the guidelines specified in [DEVELOPMENT.md](../../DEVELOPMENT.md).
- [x] Have been thoroughly tested.
- [x] Don't introduce new security vulnerabilities.
- [x] Follow the [AI/LLM Usage Policy](../../AGENTS.md#aillm-usage-policy) — no `src/**/*.fs` touched;
  the `tests/Informedica.Agents.Tests/Tests.fs` edit was made by an LLM with the maintainer's explicit
  authorisation and is disclosed below.

### AI/Vibe Coding Disclosure

- [x] Some or all code in this PR is **vibe coded** (substantially AI-generated).

Written by Claude Code. The diff is a deletion of a helper and its 19 call sites plus one comment; the
analysis behind it (per-test trx timings, reading `FileWriterAgent`'s `Flush` handler and the existing
sleep-free async tests) is what justifies it. Verified by before/after trx timings, ten consecutive green
runs, the full `ServerTests` target, and `dotnet fantomas --check`.

I confirm that I have:

- [x] Added appropriate automated tests. — n/a: the existing 52 tests are unchanged in what they assert.
- [x] Updated documentation appropriately. — n/a.
- [x] Added comments that highlight important changes and add justification, where necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQ7K5fnJDeanp86MkDuJiT
