### PR TITLE
ci(github): let re-run jobs overwrite their test-results artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,10 @@ jobs:
         name: test-results-${{ matrix.os }}
         path: '**/TestResults/**/*.trx'
         retention-days: 7
+        # Artifact names are unique per workflow run, and a re-run of a job is the same run: without
+        # this, "Re-run jobs" on any leg fails at this step with a name conflict. The re-run's trx
+        # replaces the earlier attempt's, which is the one you want anyway.
+        overwrite: true
 
     - name: Publish test results
       # continue-on-error: Dependabot PRs (and PRs from forks) get a read-only GITHUB_TOKEN that GitHub forces 


### PR DESCRIPTION
## Overview

`actions/upload-artifact` v4+ fails when an artifact with the same name already exists in the workflow
run, and a job re-run is the same run. Since #543 every matrix leg uploads `test-results-<os>`, so
**"Re-run jobs" on any leg of `build.yml` fails at the `Upload test results` step** with a name
conflict. Nobody has re-run a job since #543 merged, which is why it hasn't shown yet.

One line: `overwrite: true` on that step, so a re-run's trx replaces the earlier attempt's — the one
you'd want anyway. Confirmed against the action's README (`overwrite`: "If false, the action will fail
if an artifact for the given name already exists").

## Further information

Found while measuring #544: a second sample for the Windows leg would have needed a job re-run.
Follow-up to #543, which introduced the upload.

## Divergence from plan

n/a — one line, documentation-level change.

## Verification

`build.yml` parses. The behaviour only shows on a re-run: after this merges, "Re-run jobs" on any leg
should complete with the artifact replaced (a new artifact id, same name).

## Author checklist

- [x] Follow the process described in [CONTRIBUTING.md](../CONTRIBUTING.md#Pull_Request_Process).
- [x] Make the changes proposed in the linked issue (if applicable): n/a
- [x] Follow the approach documented in the linked implementation plan (if applicable): n/a
- [x] Are no more than 200 lines of changed code, ideally 25-100.
- [x] Are not more complex than necessary.
- [x] Cannot easily be split in a way that would make reviewing them significantly easier.
- [x] Follow the guidelines specified in [DEVELOPMENT.md](../../DEVELOPMENT.md).
- [x] Have been thoroughly tested.
- [x] Don't introduce new security vulnerabilities.
- [x] Follow the [AI/LLM Usage Policy](../../AGENTS.md#aillm-usage-policy) — no `.fs` files touched.

### AI/Vibe Coding Disclosure

- [x] Some or all code in this PR is **vibe coded** (substantially AI-generated).

Written by Claude Code; a single YAML input plus comment, checked against the action's README.

I confirm that I have:

- [x] Added appropriate automated tests. — n/a, CI configuration.
- [x] Updated documentation appropriately. — the comment on the step.
- [x] Added comments that highlight important changes and add justification, where necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQ7K5fnJDeanp86MkDuJiT
