### PR TITLE
test(agents): signal completion from the agent instead of polling

### DIFF
--- a/tests/Informedica.Agents.Tests/Tests.fs
+++ b/tests/Informedica.Agents.Tests/Tests.fs
@@ -43,19 +43,9 @@ module Tests =
 
     module AgentTests  =
 
-        // Poll until a condition holds or a timeout elapses. Used instead of a
-        // fixed Async.Sleep/Thread.Sleep after Post so the tests stay deterministic
-        // on slow or heavily-loaded CI runners, where a fixed wait can expire
-        // before the agent has processed the posted message(s).
-        let waitUntil (timeoutMs: int) (predicate: unit -> bool) =
-            let sw = Diagnostics.Stopwatch.StartNew()
-
-            while not (predicate ()) && sw.ElapsedMilliseconds < int64 timeoutMs do
-                Thread.Sleep 5
-
-            predicate ()
-
-        // Async variant for use inside `testAsync` bodies. It MUST yield the
+        // Poll until a condition holds or a timeout elapses, for `testAsync` bodies.
+        // Used instead of a fixed Async.Sleep after Post so the tests stay
+        // deterministic on slow or heavily-loaded CI runners. It MUST yield the
         // thread (Async.Sleep) rather than block it (Thread.Sleep): Expecto runs
         // tests in parallel, and the MailboxProcessor agents under test run their
         // loops on thread-pool threads. A blocking wait here would occupy those
@@ -453,51 +443,59 @@ module Tests =
                 testProperty "agent should process all posted messages" <| fun (messages: int list) ->
                     (messages.Length <= 100) ==> lazy (
                         let mutable receivedMessages = []
+                        let expected = messages.Length
+
+                        // Set from the agent's thread once every posted message has been
+                        // handled, and waited on here. A poll with Thread.Sleep 5 has ~15 ms
+                        // granularity on Windows, which made these 100-case properties take
+                        // up to 9 s there; the 30 s wait is a hang guard, not a timing budget.
+                        let allProcessed = new ManualResetEventSlim(false)
 
                         let agent = Agent.createSimple (fun msg ->
-                            receivedMessages <- msg :: receivedMessages)
+                            receivedMessages <- msg :: receivedMessages
+                            if List.length receivedMessages = expected then allProcessed.Set())
 
                         try
-                            messages |> List.iter agent.Post
+                            try
+                                messages |> List.iter agent.Post
 
-                            // Wait until every posted message has been processed.
-                            waitUntil 30000 (fun () -> List.length receivedMessages = List.length messages)
-                            |> ignore
-
-                            let result = List.rev receivedMessages = messages
+                                // Nothing to wait for when nothing was posted.
+                                let completed = expected = 0 || allProcessed.Wait 30_000
+                                completed && List.rev receivedMessages = messages
+                            with _ ->
+                                false
+                        finally
                             agent |> Agent.dispose
-                            result
-                        with
-                        | ex ->
-                            agent |> Agent.dispose
-                            false
+                            allProcessed.Dispose()
                     )
 
                 testProperty "stateful agent maintains state consistency" <| fun (operations: int list) ->
                     (operations.Length > 0 && operations.Length <= 50) ==> lazy (
                         let mutable finalState = None
+                        let mutable processed = 0
+                        let expected = operations.Length
+                        let allProcessed = new ManualResetEventSlim(false)
 
+                        // Signal on the message COUNT, not on the sum: an intermediate state
+                        // can equal the expected sum (e.g. [5; 0]) before the last message
+                        // has been handled, which is what the old sum-polling raced on.
                         let agent = Agent.createStateful (0, fun state msg ->
                             let newState = state + msg
                             finalState <- Some newState
+                            processed <- processed + 1
+                            if processed = expected then allProcessed.Set()
                             newState)
 
                         try
-                            operations |> List.iter agent.Post
+                            try
+                                operations |> List.iter agent.Post
 
-                            let expectedSum = List.sum operations
-
-                            // Wait until the accumulated state reaches the expected sum.
-                            waitUntil 30000 (fun () -> finalState = Some expectedSum)
-                            |> ignore
-
-                            let result = finalState = Some expectedSum
+                                allProcessed.Wait 30_000 && finalState = Some (List.sum operations)
+                            with _ ->
+                                false
+                        finally
                             agent |> Agent.dispose
-                            result
-                        with
-                        | ex ->
-                            agent |> Agent.dispose
-                            false
+                            allProcessed.Dispose()
                     )
 
                 testProperty "request-reply should preserve message content" <| fun (msg: string) ->
@@ -995,13 +993,19 @@ module Tests =
                 testAsync "should handle invalid path gracefully" {
                     use writer = FileWriterAgent.create()
 
-                    // This should not crash the agent
-                    let invalidPath = "//invalid//path//file.txt"
+                    // This should not crash the agent. A path whose parent is a regular
+                    // file fails immediately on every OS; the previous "//invalid//path//..."
+                    // parsed as a UNC path on Windows and cost a ~3 s network name lookup.
+                    let parentFile = createTempFile()
+                    let invalidPath = Path.Combine(parentFile, "file.txt")
 
-                    writer
-                    |> FileWriterAgent.append invalidPath [|"test"|]
-                    |> FileWriterAgent.flush
-                    |> ignore
+                    try
+                        writer
+                        |> FileWriterAgent.append invalidPath [|"test"|]
+                        |> FileWriterAgent.flush
+                        |> ignore
+                    finally
+                        deleteFileIfExists parentFile
 
                     // Agent should still be responsive
                     let tempFile = createTempFile()


### PR DESCRIPTION
## Overview

Follow-up to #544. Removing the fixed sleep took `Agents.Tests` from 13 → 2 s on ubuntu and
26 → 4 s on macOS, but **Windows stayed at 15 s** (run 33976240251). The per-test trx puts the
remaining time in exactly the two items #544 deliberately left out:

| Windows, run 33976240251 | duration | cause |
|---|---|---|
| `Property-based Tests.agent should process all posted messages` | 8.6 s | polls with `Thread.Sleep 5`; ~15 ms timer granularity on Windows × 100 cases × several polls |
| `Property-based Tests.stateful agent maintains state consistency` | 8.4 s | same |
| `Error Handling.should handle invalid path gracefully` | 4.4 s | `//invalid//path//file.txt` parses as a UNC path on Windows → network name lookup |

These vary with runner load (the two properties were 1.5 s in one earlier run and 9.3 s in another),
which is why Windows `Agents.Tests` swung 14–27 s across runs.

This PR replaces the polls with a completion signal from the agent itself, and gives the invalid-path
test a path that fails instantly on every OS. One test file, `+48 / −44`.

## Further information

**Why this is less brittle, not more.** The poll was a guess with a 5 ms sleep and a 30 s cap; the
event is set by the agent's own handler when the last posted message has been processed, and the test
waits on that. The 30 s `Wait` is a hang guard — it only elapses if the agent never processes its
mailbox, which is a genuine failure — not a timing budget the test has to fit inside.

**A latent race fixed along the way.** The stateful property polled on `finalState = expectedSum`. An
intermediate state can equal the expected sum before the last message is handled (e.g. operations
`[5; 0]`, or any suffix summing to zero), so the poll could return early and the assertion pass on a
state the agent was still about to overwrite. It now signals on the *message count* and asserts the sum
afterwards.

Detail worth a reviewer's eye: `let mutable` locals captured by the agent closure are ref cells
(F# 4.0+); `ManualResetEventSlim.Set`/`Wait` are full fences, so the test thread reads the final
list/state after the handler wrote them. The empty-list case (`messages = []`, allowed by the
precondition) short-circuits the wait, since nothing will ever signal.

The sync `waitUntil` helper has no callers left and is removed; the async variant stays (14 uses).

## Divergence from plan

n/a — under 25 lines of logic changed; no issue or implementation plan.

## Verification

Local (`tests/Informedica.Agents.Tests`, trx):

| | before (#544 merged) | after |
|---|---|---|
| the two `Agent` properties | 0.59 s / 0.57 s | < 0.07 s each |
| `Agents.Tests` assembly | 2 s | **1 s** |

Ten consecutive runs after the change, 52/52 green each. `dotnet run ServerTests` green for the whole
suite (1521 passed, 2 skipped). `dotnet fantomas --check` clean.

CI, run 33976752836, `Agents.Tests` VSTest `Duration` (baseline = run 33976240251, #544 merged):

| | ubuntu | windows | macOS |
|---|---|---|---|
| before | 2 s | **15 s** | 4 s |
| after | 2 s | **2 s** | 2 s |

Windows per-test trx after: the two `Agent` properties 0.25 s / < 0.2 s (were 8.6 s / 8.4 s), the
invalid-path test off the top-6 entirely (was 4.4 s). The whole `Agents.Tests` window on Windows is
2.6 s; its longest test is now the fallback-timeout test at 1.2 s, which is the intended sleep.
All three legs report `Agents.Tests` at 2 s.

**Second Windows sample, to be honest about variance.** The merge-from-master commit (453312fd, run
33976951986, identical test code) reported Windows `Agents.Tests` at 12 s. The trx shows it is not the
tests: the testhost's *discovery* phase — reflection, no test code — took 8.1 s against 1.1 s in the
run above, and every test in the assembly was 10–30× slower for the same window, including
`create agent should succeed` at 0.87 s. That testhost ran with `GenCORE.Tests` (18 s overlap, CPU-bound
FsCheck) and `Logging.Tests` (15 s) on the 4-core runner; in the fast run it overlapped only `Utils`
and `Logging` for ~4 s. So the residual Windows variance is CPU contention between concurrently
running testhosts, which agent-based tests feel most because every message is a cross-thread handoff.
Neither the poll nor the event changes that; the event just stops adding ~15 ms of timer granularity
per poll on top of it. `Logging.Tests` shows the same signature on Windows in every run (its four
agent-logging tests at 5–12 s each vs 4 s for the whole assembly on ubuntu/macOS) and is the next thing
to look at if Windows wall time matters.

## Author checklist

- [x] Follow the process described in [CONTRIBUTING.md](../CONTRIBUTING.md#Pull_Request_Process).
- [x] Make the changes proposed in the linked issue (if applicable): n/a
- [x] Follow the approach documented in the linked implementation plan (if applicable): n/a
- [x] Are no more than 200 lines of changed code, ideally 25-100.
- [x] Are not more complex than necessary.
- [x] Cannot easily be split in a way that would make reviewing them significantly easier.
- [x] Follow the guidelines specified in [DEVELOPMENT.md](../../DEVELOPMENT.md).
- [x] Have been thoroughly tested.
- [x] Don't introduce new security vulnerabilities.
- [x] Follow the [AI/LLM Usage Policy](../../AGENTS.md#aillm-usage-policy) — no `src/**/*.fs` touched;
  the `tests/Informedica.Agents.Tests/Tests.fs` edit was made by an LLM with the maintainer's explicit
  authorisation and is disclosed below.

### AI/Vibe Coding Disclosure

- [x] Some or all code in this PR is **vibe coded** (substantially AI-generated).

Written by Claude Code, from the per-test trx analysis of the Windows leg. Verified by before/after
trx timings, ten consecutive green runs, the full `ServerTests` target and `dotnet fantomas --check`.

I confirm that I have:

- [x] Added appropriate automated tests. — n/a: the 52 existing tests keep their assertions; one gains a stricter completion condition.
- [x] Updated documentation appropriately. — n/a.
- [x] Added comments that highlight important changes and add justification, where necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQ7K5fnJDeanp86MkDuJiT
