### PR TITLE
fix(server): stop serialising requests through domain agents

### DIFF
--- a/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
@@ -8,7 +8,7 @@ module CompositionRoot =
 
 
     let compose (provider: Informedica.GenForm.Lib.Resources.IResourceProvider) : IServerApi =
-        let env = AgentAdapters.makeAppEnv provider
+        let env = Adapters.makeAppEnv provider
 
         {
             processCommand =


### PR DESCRIPTION
## Overview

First of two PRs for #420. Switches the server composition root from the agent-backed `AgentAdapters.makeAppEnv` to the existing, agent-free `Adapters.makeAppEnv`. One line changed.

Every API command used to be routed through one of five per-domain `MailboxProcessor` agents, so all operations within a domain, reads included, ran on a single thread. The original justification (the agent removes the need for the `lock` in `CachedResourceProvider`) no longer holds: the provider is lock-guarded on its own, so the agents only added a bottleneck.

## Further information

- Framed as a `fix`, not a `refactor`: per-domain single-threading is a concurrency defect. (`fix` also renders in the ShipIt changelog; `refactor` does not.)
- The blocking issue raised on #441 — `provider.GetTotals()` captured once at composition time in `Adapters` — was already fixed by #451 and #457; every call is inside the per-command lambda.
- The per-port `[XAgent] <- Cmd / -> Cmd completed` debug lines are dropped deliberately. `CompositionRoot` already logs the command name on entry and exit at info level and the full exception on failure, and the command name identifies the port. They were also no-ops unless `GENPRES_DEBUG=1`. Error surfacing is unchanged: exceptions still come back as `Error [| ex.Message |]` via the `try/with` in `CompositionRoot`.
- `ServerApi.AgentAdapters.fs` is left in place so this PR stays a one-line, trivially revertible swap. The follow-up PR deletes it and its two agent-only tests.

## Divergence from plan

None. Follows the sequencing agreed in the #441 thread (swap first, delete second).

## Verification

- `dotnet run build`: clean.
- `CI=true dotnet run servertests`: 6141 passed, 0 failed, 2 skipped.
- Manual smoke test with `GENPRES_DEBUG=1 GENPRES_LOG=i GENPRES_PROD=0 dotnet run`, driving the client in Chrome: patient entry, emergency list, prescribe, nutrition (TPN). The server log shows all six ports completing through the direct adapters — `FormularyCmd`, `ParenteraliaCmd`, `GetDrugNames`, `UpdateOrderContext`, `UpdatedOrderPlan`, `InitNutritionPlan`/`AddNutritionContext` — with zero `Error processing` lines. Command entry/exit lines for different domains now interleave, which is the intended effect.
- To see it yourself: `dotnet run`, open http://localhost:5173, enter a patient; watch the `server:` lines.

## Author checklist

> [!NOTE]
> An issue and agreed implementation plan are necessary unless either fewer than 25 lines have been changed or only documentation has been changed.

I confirm that these changes:

- [x] Follow the process described in [CONTRIBUTING.md](../CONTRIBUTING.md#Pull_Request_Process).
- [x] Make the changes proposed in the linked issue (if applicable): #420
- [x] Follow the approach documented in the linked implementation plan (if applicable): n/a — approach agreed in the #441 discussion; < 25 lines changed
- [x] Are no more than 200 lines of changed code, ideally 25-100.
- [x] Are not more complex than necessary.
- [x] Cannot easily be split in a way that would make reviewing them significantly easier.
- [x] Follow the guidelines specified in [DEVELOPMENT.md](../../DEVELOPMENT.md).
- [x] Have been thoroughly tested.
- [x] Don't introduce new security vulnerabilities.
- [ ] Follow the [AI/LLM Usage Policy](../../AGENTS.md#aillm-usage-policy) — LLMs were not given direct write access to `.fs` source files (except client-side UI code). **Exception, explicitly authorised by the maintainer for this issue:** the one-line edit to `ServerApi.CompositionRoot.fs` was made by Claude Code under the maintainer's direction. No new logic was written.

### AI/Vibe Coding Disclosure

- [x] Some or all code in this PR is **vibe coded** (substantially AI-generated). If checked, describe below which parts were AI-generated, which tool was used, and how the code was verified.

The one-line swap was applied by Claude Code (Claude Fable 5.1) following the plan agreed on #441; the target function `Adapters.makeAppEnv` pre-existed and was human-written. Verified by the full test suite and the manual smoke test above.

I confirm that I have:

- [x] Added appropriate automated tests. (Existing `processCmdGuardTests` already cover `Adapters.makeAppEnv`; no new behaviour to test.)
- [x] Updated documentation appropriately. (Design-history row lands with the deletion PR.)
- [x] Added comments that highlight important changes and add justification, where necessary.

## Reviewer checklist

I confirm that:

- [x] I am confident that the changes work.
- [x] The changed code meets our guidelines and standards.
- [x] The new code is not more complex than necessary.
- [x] I have clearly labelled suggestions as blocking, required but not blocking, or optional (see [CONTRIBUTING.md](../CONTRIBUTING.md#Pull_Request_Process)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019aTY7xQdUgUj6otBRH2qf6
