### PR TITLE
feat(docker): let ShipIt bump the compose image tag on release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,9 +37,10 @@ GENPRES_PASSWORD=<your-password>
 
 # --- Docker Compose only (compose.yaml at the repo root) ---
 
-# Published image tag to run; see https://hub.docker.com/r/informedica/genpres/tags
-# No :latest is published yet, so a tag is required.
-GENPRES_IMAGE_TAG=0.1.2-alpha.11
+# Optional: pin a published image tag; see https://hub.docker.com/r/informedica/genpres/tags
+# Leave unset to run the current release, whose tag compose.yaml carries as its default
+# (kept current by ShipIt in every release PR).
+# GENPRES_IMAGE_TAG=0.1.2-alpha.11
 
 # Host port mapped to the container's 8085
 GENPRES_PORT=8080

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ updaters:
   - xml:
       file: Directory.Build.props
       selector: /Project/PropertyGroup/Version
+  - regex:
+      file: compose.yaml
+      pattern: (?<=informedica/genpres:\$\{GENPRES_IMAGE_TAG:-)[^}]*
 ---
 
 # Changelog

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -148,6 +148,14 @@ image tag in the root `compose.yaml` (`informedica/genpres:${GENPRES_IMAGE_TAG:-
 `git pull && docker compose pull && docker compose up -d` after a release runs the version that was
 just shipped. Do not hand-edit `<Version>` or that compose default.
 
+The `regex` updater writes the version verbatim, whereas `tag-release.yml` folds any `+` in the
+version to `-` because `+` is not a legal Docker tag character. The two agree only as long as
+`<Version>` carries no SemVer build metadata. ShipIt never generates build metadata (versions come
+from conventional commits plus the `alpha.N` pre-release counter), so this holds unless someone
+hand-edits `<Version>` with a `+`, which is already disallowed above. If build metadata is ever
+introduced deliberately, replace the `regex` updater with a `command` updater that applies the same
+fold before writing `compose.yaml`.
+
 To preview locally what ShipIt would generate:
 
 ```bash
@@ -368,7 +376,7 @@ Get-Content .env | ForEach-Object {
 dotnet run DockerRun
 ```
 
-**Run a published image** — the `compose.yaml` at the repo root (tracked; see the `!compose.yaml` allow-line in `.gitignore`) runs an image pulled from Docker Hub with port, secrets and mode read from `.env`, so nothing has to be retyped after a new release. Compose interpolates `${...}` from the `.env` in the project directory by itself; no `source` needed. The image tag defaults to the current release: ShipIt bumps it in `compose.yaml` as part of every release PR (see [Changelog & Release Automation](#changelog--release-automation-easybuildshipit)), so `git pull` brings the new tag along. Set `GENPRES_IMAGE_TAG` in `.env` only to pin a different version.
+**Run a published image** — the `compose.yaml` at the repo root (tracked; see the `!compose.yaml` allow-line in `.gitignore`) runs an image pulled from Docker Hub with port, secrets and mode read from `.env`, so nothing has to be retyped after a new release. Compose interpolates `${...}` from the `.env` in the project directory by itself; no `source` needed. The image tag defaults to the current release: ShipIt bumps it in `compose.yaml` as part of every release PR (see [Changelog & Release Automation](#changelog--release-automation-easybuildshipit)), so `git pull` brings the new tag along. Set `GENPRES_IMAGE_TAG` in `.env` only to pin a different version. If you added `GENPRES_IMAGE_TAG` to `.env` while it was still required (between [#550](https://github.com/informedica/GenPRES/pull/550) and [#552](https://github.com/informedica/GenPRES/pull/552)), remove it: a leftover value silently overrides the ShipIt-maintained default and keeps `docker compose pull` on the old image.
 
 ```bash
 cp .env.example .env            # once; for production, set the secrets

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -143,7 +143,10 @@ YAML front matter at the top of the root `CHANGELOG.md`.
 ShipIt runs in CI on every push to `master` (see [Release Automation](#release-automation-github-actions)
 below) and owns the version number: the `updaters:` block in the `CHANGELOG.md` front matter points at 
 `/Project/PropertyGroup/Version` in the root `Directory.Build.props`, so the release PR bumps that
-element as well as adding the changelog section. Do not hand-edit `<Version>`.
+element as well as adding the changelog section. A second, `regex` updater rewrites the default
+image tag in the root `compose.yaml` (`informedica/genpres:${GENPRES_IMAGE_TAG:-<version>}`) so a
+`git pull && docker compose pull && docker compose up -d` after a release runs the version that was
+just shipped. Do not hand-edit `<Version>` or that compose default.
 
 To preview locally what ShipIt would generate:
 
@@ -365,14 +368,16 @@ Get-Content .env | ForEach-Object {
 dotnet run DockerRun
 ```
 
-**Run a published image** — the `compose.yaml` at the repo root (tracked; see the `!compose.yaml` allow-line in `.gitignore`) runs an image pulled from Docker Hub with the tag, port, secrets and mode all read from `.env`, so nothing has to be retyped after a new release. Compose interpolates `${...}` from the `.env` in the project directory by itself; no `source` needed.
+**Run a published image** — the `compose.yaml` at the repo root (tracked; see the `!compose.yaml` allow-line in `.gitignore`) runs an image pulled from Docker Hub with port, secrets and mode read from `.env`, so nothing has to be retyped after a new release. Compose interpolates `${...}` from the `.env` in the project directory by itself; no `source` needed. The image tag defaults to the current release: ShipIt bumps it in `compose.yaml` as part of every release PR (see [Changelog & Release Automation](#changelog--release-automation-easybuildshipit)), so `git pull` brings the new tag along. Set `GENPRES_IMAGE_TAG` in `.env` only to pin a different version.
 
 ```bash
-cp .env.example .env            # once; set GENPRES_IMAGE_TAG (and the secrets for production)
-docker compose pull             # after each release, once GENPRES_IMAGE_TAG is bumped
+cp .env.example .env            # once; for production, set the secrets
+git pull && docker compose pull # after each release
 docker compose up -d            # (re)creates container "genpres" on http://localhost:8080
 docker compose logs -f genpres
 ```
+
+The image is published by `tag-release.yml` a few minutes *after* the release PR merges, so a `docker compose pull` in that window fails with "manifest unknown"; retry shortly after.
 
 Demo or production is whatever `GENPRES_PROD` says in `.env`. The image itself defaults to demo (`GENPRES_PROD=0`, public demo sheet ID, no password — issue [#541](https://github.com/informedica/GenPRES/issues/541)), so a bare `docker run -p 8080:8085 informedica/genpres:<tag>` or the Docker Desktop "Run" button also works with no flags. `GENPRES_PROD=1` additionally needs the proprietary `GENPRES_URL_ID`, a 16+ character `GENPRES_PASSWORD`, and the `data/cache` bind mount that `compose.yaml` already declares: production reads `*.cache`, and the image ships only the `*.demo` files. `compose.yaml` forwards only the `GENPRES_*` keys, not the whole `.env`, so unrelated local secrets stay out of the container. Unlike `dotnet run DockerRun`, this needs no .NET SDK on the host, runs the exact published image rather than a local build, and includes the cache mount.
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,7 @@
 # Run a published GenPRES image with everything read from .env (issue #541).
 #
-#   cp .env.example .env      # once: set GENPRES_IMAGE_TAG and, for production, the secrets
-#   docker compose pull       # after each release
+#   cp .env.example .env      # once: for production, set the secrets
+#   git pull && docker compose pull   # after each release
 #   docker compose up -d      # (re)creates container "genpres" on http://localhost:${GENPRES_PORT:-8080}
 #
 # Compose interpolates ${...} from the .env in this directory automatically, so .env stays the
@@ -9,8 +9,10 @@
 # forwarded on purpose: `env_file: .env` would also push unrelated local secrets into the container.
 services:
   genpres:
-    # No :latest is published (only pre-releases), so the tag is mandatory.
-    image: informedica/genpres:${GENPRES_IMAGE_TAG:?set GENPRES_IMAGE_TAG in .env}
+    # No :latest is published (only pre-releases), so a tag is needed. The default is the
+    # current release and is bumped by ShipIt's `regex` updater (CHANGELOG.md front matter)
+    # in every release PR; do not hand-edit it. Set GENPRES_IMAGE_TAG in .env to pin another.
+    image: informedica/genpres:${GENPRES_IMAGE_TAG:-0.1.2-alpha.11}
     container_name: genpres
     ports:
       - "${GENPRES_PORT:-8080}:8085"


### PR DESCRIPTION
Follow-up to #550 (refs #541), rebased onto master now that #550 is merged; single commit.

**Merge order matters**: merge this **before** the open release PR #551. ShipIt regenerates #551 on the next push to master and will then apply the new `regex` updater, so #551 also bumps the compose default to `0.1.2-alpha.12`. Merged the other way round, the compose default stays one release behind until the following release.

## Problem

`compose.yaml` from #550 requires `GENPRES_IMAGE_TAG` in `.env`, so every release still needs a manual edit of a local file before `docker compose pull` picks up the new image, and the example value in `.env.example` goes stale on each release.

## Change

- **compose.yaml**: the image line carries the current release as its default, `informedica/genpres:${GENPRES_IMAGE_TAG:-0.1.2-alpha.11}`. `GENPRES_IMAGE_TAG` in `.env` becomes an optional pin.
- **CHANGELOG.md front matter**: a second updater next to the existing `xml` one for `Directory.Build.props`:

  ```yaml
  - regex:
      file: compose.yaml
      pattern: (?<=informedica/genpres:\$\{GENPRES_IMAGE_TAG:-)[^}]*
  ```

  ShipIt replaces the full match with the new version, so the lookbehind limits the match to the tag itself. Each release PR now bumps `<Version>` and the compose default together.
- **.env.example**: `GENPRES_IMAGE_TAG` commented out and documented as an optional pin.
- **DEVELOPMENT.md**: ShipIt section mentions the second updater ("do not hand-edit" now covers the compose default too); the compose quick start becomes `git pull && docker compose pull && docker compose up -d`, with a note that the image is published a few minutes after the release PR merges, so a pull in that window fails until retried.

## Verification

- The pattern run through .NET `Regex` (the engine ShipIt uses) against `compose.yaml`: exactly one match, value `0.1.2-alpha.11`; `Regex.Replace` with a fake version yields `image: informedica/genpres:${GENPRES_IMAGE_TAG:-9.9.9-alpha.1}` and touches nothing else.
- `docker compose config` with `GENPRES_IMAGE_TAG` unset resolves to `informedica/genpres:0.1.2-alpha.11`.
- `dotnet shipit --dry-run --allow-branch <branch> --skip-merge-commit` parses the extended front matter and proposes `0.1.2-alpha.12`. Dry run does not apply updaters, so the actual rewrite is first exercised by the next real release PR; worth a glance at that PR's `compose.yaml` diff.
- Markdownlint: no new findings (remaining hits in `DEVELOPMENT.md` and `CHANGELOG.md` are pre-existing).

## Notes

- Docker tags fold `+` to `-` in `tag-release.yml`. No current version carries build metadata; if one ever does, the compose default and the published tag would differ.
- Commit is `feat` rather than `build` so the change reaches the changelog (ShipIt drops `build`/`chore`).

## AI-assisted contribution

Vibe coded per CONTRIBUTING.md: drafted by Claude Code (Claude Fable 5.1), reviewed by the author, verified as above. No `.fs` files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012F5UZAxUhrSRGPgZcwsTYH