### PR TITLE
refactor: replace failwith with specific exceptions

### DIFF
--- a/src/Informedica.Agents.Lib/Agent.fs
+++ b/src/Informedica.Agents.Lib/Agent.fs
@@ -346,7 +346,7 @@ module Agent =
             |> tryPostAndReply fallbackMs msg
             |> function
                 | Some v -> v
-                | None -> failwith $"Timed out waiting for reply after {fallbackMs} ms"
+                | None -> raise (TimeoutException $"Timed out waiting for reply after {fallbackMs} ms")
         else
             agent.PostAndReply(fun replyChannel -> msg, replyChannel)
 

--- a/src/Informedica.GenFORM.Lib/Api.fs
+++ b/src/Informedica.GenFORM.Lib/Api.fs
@@ -30,7 +30,7 @@ module Api =
         | :? CachedResourceProvider as cachedProvider ->
             cachedProvider.ReloadCache()
             (cachedProvider :> IResourceProvider) |> logGenFormMessages logger
-        | _ -> failwith "Provider is not a CachedResourceProvider instance"
+        | _ -> invalidArg (nameof provider) "Provider is not a CachedResourceProvider instance"
 
 
     /// Generic accessor: resolve any registered resource by its typed key.

--- a/src/Informedica.GenORDER.Lib/Order.fs
+++ b/src/Informedica.GenORDER.Lib/Order.fs
@@ -3335,30 +3335,36 @@ module Order =
                 match xs with
                 | h :: rest ->
                     let h =
-                        try
-                            ovars |> List.find (fun v -> v.Variable.Name |> Name.toString = h)
-                        with _ ->
+                        match ovars |> List.tryFind (fun v -> v.Variable.Name |> Name.toString = h) with
+                        | Some v -> v
+                        | None ->
                             let h =
                                 if h |> String.isNullOrWhiteSpace then
                                     "'empty string'"
                                 else
                                     h
 
-                            failwith $"cannot find {h} from\n{eqMapping}\nin {ovars |> OrderVariable.getNames}"
+                            raise (
+                                System.Collections.Generic.KeyNotFoundException
+                                    $"cannot find {h} from\n{eqMapping}\nin {ovars |> OrderVariable.getNames}"
+                            )
 
                     let rest =
                         rest
                         |> List.map (fun s ->
-                            try
-                                ovars |> List.find (fun v -> v.Variable.Name |> Name.toString = s)
-                            with _ ->
+                            match ovars |> List.tryFind (fun v -> v.Variable.Name |> Name.toString = s) with
+                            | Some v -> v
+                            | None ->
                                 let s =
                                     if s |> String.isNullOrWhiteSpace then
                                         "'empty string'"
                                     else
                                         s
 
-                                failwith $"cannot find {s} from\n{eqMapping}\nin {ovars |> OrderVariable.getNames}"
+                                raise (
+                                    System.Collections.Generic.KeyNotFoundException
+                                        $"cannot find {s} from\n{eqMapping}\nin {ovars |> OrderVariable.getNames}"
+                                )
                         )
                         |> fun rest ->
                             if repl <> "+" then

--- a/src/Informedica.GenORDER.Lib/OrderVariable.fs
+++ b/src/Informedica.GenORDER.Lib/OrderVariable.fs
@@ -73,7 +73,7 @@ module ValueUnit =
                     |> Array.distinct
                     |> String.concat "; "
 
-                failwith $"Cannot collect the ValueUnit array to a single ValueUnit, values: [{details}]"
+                invalidArg (nameof vus) $"Cannot collect the ValueUnit array to a single ValueUnit, values: [{details}]"
 
             let result = vus |> Array.collect (toBase >> getValue) |> withUnit u |> toUnit
 

--- a/src/Informedica.GenPRES.Client/Views/ContinuousMeds.fs
+++ b/src/Informedica.GenPRES.Client/Views/ContinuousMeds.fs
@@ -156,7 +156,7 @@ module ContinuousMeds =
 
         let rowCreate (cells: string[]) =
             if cells |> Array.length <> 7 then
-                failwith $"cannot create row with {cells}"
+                invalidArg (nameof cells) $"cannot create row with {cells}"
             else
                 {|
                     id = cells[0]

--- a/src/Informedica.GenPRES.Client/Views/EmergencyList.fs
+++ b/src/Informedica.GenPRES.Client/Views/EmergencyList.fs
@@ -200,7 +200,7 @@ module EmergencyList =
 
         let rowCreate (cells: string[]) =
             if cells |> Array.length <> 6 then
-                failwith $"cannot create row with {cells}"
+                invalidArg (nameof cells) $"cannot create row with {cells}"
             else
                 {|
                     id = cells[0]

--- a/src/Informedica.GenPRES.Shared/Models.fs
+++ b/src/Informedica.GenPRES.Shared/Models.fs
@@ -65,7 +65,7 @@ module Models =
 
             let fromBirthDate (now: DateTime) (bdt: DateTime) =
                 if bdt > now then
-                    failwith $"birthdate: {bdt} cannot be after current date: {now}"
+                    invalidArg (nameof bdt) $"birthdate: {bdt} cannot be after current date: {now}"
                 // calculated last birthdate and number of years ago
                 let last, yrs =
                     // set day one day back if not a leap year, and the birthdate is at Feb 29 in a leap year

--- a/src/Informedica.GenPRES.Shared/Utils.fs
+++ b/src/Informedica.GenPRES.Shared/Utils.fs
@@ -414,7 +414,11 @@ module Csv =
         columns
         |> Array.tryFindIndex ((=) s)
         |> function
-            | None -> $"""cannot find column {s} in {columns |> String.concat ", "}""" |> failwith
+            | None ->
+                raise (
+                    System.Collections.Generic.KeyNotFoundException
+                        $"""cannot find column {s} in {columns |> String.concat ", "}"""
+                )
             | Some i -> sl |> Array.item i |> tryCast dt
 
 

--- a/src/Informedica.GenSOLVER.Lib/Equation.fs
+++ b/src/Informedica.GenSOLVER.Lib/Equation.fs
@@ -498,7 +498,10 @@ module Equation =
                             |> List.tryFind (Variable.eqName v2)
                             |> function
                                 | Some v1 -> v2, v2.Values |> Variable.ValueRange.diffWith v1.Values
-                                | None -> $"cannot find {v2}! in {vars}!" |> failwith
+                                | None ->
+                                    raise (
+                                        System.Collections.Generic.KeyNotFoundException $"cannot find {v2}! in {vars}!"
+                                    )
                         )
                         |> List.filter (snd >> Set.isEmpty >> not)
                         |> Changed

--- a/src/Informedica.GenSOLVER.Lib/Solver.fs
+++ b/src/Informedica.GenSOLVER.Lib/Solver.fs
@@ -107,7 +107,7 @@ module Solver =
                 let msg = $"didn't catch {e}"
                 writeErrorMessage msg
 
-                msg |> failwith
+                reraise ()
 
         let rec loop n que acc =
             match acc with
@@ -212,7 +212,7 @@ module Solver =
                 | e ->
                     let msg = $"something unexpected happened, didn't catch {e}"
                     writeErrorMessage msg
-                    msg |> failwith
+                    reraise ()
 
                 |> function
                     | Ok eqs ->

--- a/src/Informedica.GenSOLVER.Lib/Variable.fs
+++ b/src/Informedica.GenSOLVER.Lib/Variable.fs
@@ -1668,7 +1668,7 @@ module Variable =
         /// </remarks>
         let minMultipleOf incr min =
             if (min, incr) |> MinIncr |> allSameUnitGroup |> not then
-                $"{min}, {incr} don't have the same unit group" |> failwith
+                invalidArg (nameof incr) $"{min}, {incr} don't have the same unit group"
 
             min |> Minimum.multipleOf incr
 
@@ -1701,7 +1701,7 @@ module Variable =
         /// </remarks>
         let maxMultipleOf incr max =
             if (incr, max) |> IncrMax |> allSameUnitGroup |> not then
-                $"{incr}, {max} don't have the same unit group" |> failwith
+                invalidArg (nameof max) $"{incr}, {max} don't have the same unit group"
 
             max |> Maximum.multipleOf incr
 
@@ -1734,7 +1734,7 @@ module Variable =
                 | _ -> min, max
 
             if (min, max) |> MinMax |> allSameUnitGroup |> not then
-                $"{min}, {max} don't have the same unit group" |> failwith
+                invalidArg (nameof max) $"{min}, {max} don't have the same unit group"
 
             if min |> minGTmax max then
                 // printfn $"min:\n{min}\nmax:\n{max}"
@@ -1776,7 +1776,7 @@ module Variable =
                 | _ -> min
 
             if (min, incr) |> MinIncr |> allSameUnitGroup |> not then
-                $"{min}, {incr} don't have the same unit group" |> failwith
+                invalidArg (nameof incr) $"{min}, {incr} don't have the same unit group"
 
             if min |> Minimum.hasZeroUnit |> not then
                 (min |> minMultipleOf incr, incr) |> MinIncr
@@ -1815,7 +1815,7 @@ module Variable =
                 | _ -> max
 
             if (incr, max) |> IncrMax |> allSameUnitGroup |> not then
-                $"{incr}, {max} don't have the same unit group" |> failwith
+                invalidArg (nameof max) $"{incr}, {max} don't have the same unit group"
 
             (incr, max |> maxMultipleOf incr) |> IncrMax
 
@@ -1847,7 +1847,7 @@ module Variable =
                     max |> Maximum.setUnit incrUnit
 
             if (min, incr, max) |> MinIncrMax |> allSameUnitGroup |> not then
-                $"{min}, {incr}, {max} don't have the same unit group" |> failwith
+                invalidArg (nameof max) $"{min}, {incr}, {max} don't have the same unit group"
 
             let min = min |> minMultipleOf incr
             let max = max |> maxMultipleOf incr

--- a/src/Informedica.GenUNITS.Lib/Units.fs
+++ b/src/Informedica.GenUNITS.Lib/Units.fs
@@ -65,7 +65,7 @@ module Units =
         /// create a general unit with unit value = 1
         let general n =
             if n |> String.isNullOrWhiteSpace then
-                failwith "the name of a General Unit cannot be an empty string"
+                invalidArg (nameof n) "the name of a General Unit cannot be an empty string"
 
             (n, 1N) |> toGeneral
 
@@ -512,7 +512,7 @@ module Units =
         /// </example>
         let createGeneral n v =
             if n |> String.isNullOrWhiteSpace then
-                "The name for a general unit cannot be an empty string" |> failwith
+                invalidArg (nameof n) "The name for a general unit cannot be an empty string"
 
             let un = (n, v) |> General
 

--- a/src/Informedica.GenUNITS.Lib/ValueUnit.fs
+++ b/src/Informedica.GenUNITS.Lib/ValueUnit.fs
@@ -780,7 +780,7 @@ module ValueUnit =
                 | ZeroUnit, u
                 | u, ZeroUnit -> u
                 // Otherwise fail
-                | _ -> failwith <| $"cannot add or subtract different units %A{u1} %A{u2}"
+                | _ -> invalidArg (nameof vu2) $"cannot add or subtract different units %A{u1} %A{u2}"
             |> fun u -> if b then simplifyUnit u else u
         // recreate valueunit with base value and combined unit
         v
@@ -818,7 +818,7 @@ module ValueUnit =
             && (vu1 |> hasNoUnit |> not && vu2 |> hasNoUnit |> not)
             && (vu1 |> eqsGroup vu2 |> not)
         then
-            failwith $"cannot compare {vu1} with {vu2}"
+            invalidArg (nameof vu2) $"cannot compare {vu1} with {vu2}"
         //else
         let vs1 = vu1 |> toBaseValue
         let vs2 = vu2 |> toBaseValue
@@ -839,7 +839,7 @@ module ValueUnit =
             && (vu1 |> hasNoUnit |> not && vu2 |> hasNoUnit |> not)
             && (vu1 |> eqsGroup vu2 |> not)
         then
-            failwith $"cannot compare {vu1} with {vu2}"
+            invalidArg (nameof vu2) $"cannot compare {vu1} with {vu2}"
 
         let vs1 = vu1 |> toBaseValue |> BigRational.distinct |> Array.sort
 

--- a/src/Informedica.Utils.Lib/BCL/BigRational.fs
+++ b/src/Informedica.Utils.Lib/BCL/BigRational.fs
@@ -341,7 +341,7 @@ module BigRational =
         | _ when op |> opIsDiv -> Div
         | _ when op |> opIsAdd -> Add
         | _ when op |> opIsSubtr -> Sub
-        | _ -> failwith "Operator is not supported"
+        | _ -> raiseExc CannotMatchOperator
 
 
     let calcCartesian op (vs1: BigRational[]) (vs2: BigRational[]) : BigRational[] =

--- a/src/Informedica.Utils.Lib/BCL/String.fs
+++ b/src/Informedica.Utils.Lib/BCL/String.fs
@@ -179,7 +179,7 @@ module String =
     /// c appears in string t
     let countChar c t =
         if String.IsNullOrEmpty(c) then
-            "Cannot count empty string in text: '" + t + "'" |> failwith
+            invalidArg (nameof c) ("Cannot count empty string in text: '" + t + "'")
 
         (c |> regex).Matches(t).Count
 

--- a/src/Informedica.Utils.Lib/Csv.fs
+++ b/src/Informedica.Utils.Lib/Csv.fs
@@ -64,11 +64,11 @@ module Csv =
     /// </summary>
     /// <remarks>
     /// Header names are matched case-insensitively, and an unknown column name
-    /// RAISES rather than yielding a default. Callers that parse a whole sheet wrap
-    /// this in try/with and surface the failure as an Error, which makes the header
-    /// row of a sheet a checkable contract: feed a parser exactly the column set it
-    /// is supposed to read and it succeeds, drop any one of them and it fails. The
-    /// GenFORM column-contract tests rely on that.
+    /// RAISES a <c>KeyNotFoundException</c> rather than yielding a default. Callers
+    /// that parse a whole sheet wrap this in try/with and surface the failure as an
+    /// Error, which makes the header row of a sheet a checkable contract: feed a
+    /// parser exactly the column set it is supposed to read and it succeeds, drop
+    /// any one of them and it fails. The GenFORM column-contract tests rely on that.
     ///
     /// A column that may legitimately be absent therefore needs an explicit
     /// tolerant wrapper at the call site (see DoseRuleData.getIfNull) - there is no
@@ -78,7 +78,11 @@ module Csv =
         columns
         |> Array.tryFindIndex (String.equalsCapInsens name)
         |> function
-            | None -> $"""cannot find column {name} in {columns |> String.concat ", "}""" |> failwith
+            | None ->
+                raise (
+                    System.Collections.Generic.KeyNotFoundException
+                        $"""cannot find column {name} in {columns |> String.concat ", "}"""
+                )
             | Some i -> row |> Array.item i |> tryCast<'T> dataType
 
 

--- a/src/Informedica.Utils.Lib/List.fs
+++ b/src/Informedica.Utils.Lib/List.fs
@@ -202,13 +202,14 @@ module List =
         |> List.countBy id
         |> List.map (fun (k, v) -> k, v - 1)
         |> List.sortBy (fun (k, _) ->
-            try
-                xs1 |> List.findIndex ((=) k)
-            with _ ->
+            match xs1 |> List.tryFindIndex ((=) k) with
+            | Some i -> i
+            | None ->
                 xs1
                 |> String.concat ", "
                 |> sprintf "countByList couldn't find %s in %s" k
-                |> failwith
+                |> System.Collections.Generic.KeyNotFoundException
+                |> raise
         )
 
     let inline findNearestMax n ns =

--- a/tests/Informedica.Agents.Tests/Tests.fs
+++ b/tests/Informedica.Agents.Tests/Tests.fs
@@ -612,7 +612,7 @@ module Tests =
                             let _ = agent |> Agent.postAndReply "should-timeout"
                             failtest "should have thrown timeout"
                         with
-                        | ex ->
+                        | :? TimeoutException as ex ->
                             ex.Message |> Expect.stringContains "should mention timeout duration" "200 ms"
                     )
                 }


### PR DESCRIPTION
## Overview

First implementation PR for #419, following the plan in #555. This batch covers the sites where the exception type carries information a caller can act on (plan categories A, C, G, H, I):

- **G, diagnostic fix.** `Solver.fs` catch-alls now `reraise ()` after logging. Before, `failwith $"didn't catch {e}"` replaced the original exception, discarding its stack trace and inner exception. Deliberately *not* `SolverException`: the outer handler would then swallow it and turn a crash into `Error(...)`.
- **H.** `Agent.fs` reply timeout raises `TimeoutException`. Message text kept, the existing test asserts on it and now also matches the type.
- **A.** Argument preconditions use `invalidArg (nameof x)`: unit-group mismatches in `Variable.fs` and `ValueUnit.fs`, empty general-unit names, `String.countChar`, birthdate after now, `OrderVariable.collect`, `Api.reloadCache`, the two client `rowCreate` guards.
- **C.** Lookups by name raise `KeyNotFoundException`: `Csv.getColumn` and its `Shared` mirror (the remarks now name the type; the column-contract tests still pass), `Equation.solve`, the `Order` eqMapping lookup (now `List.tryFind` + match instead of `try/with` around `List.find`), `List.countByList`.
- **I.** `BigRational` operator match raises the existing, never-used `CannotMatchOperator` case.

Messages are preserved verbatim. Every new type still derives from `System.Exception`.

## Further information

Two more PRs are stacked on this one as drafts: #557 (remaining source sites: `FormatException`, `invalidOp`, `NotSupportedException`) and #558 (test bodies: `failtest`). Their diffs shrink to one commit each as this stack merges.

## Divergence from plan

None.

## Verification

- `dotnet run build`: succeeds.
- `dotnet run servertests`: all 16 test projects pass (1,519 tests).
- `dotnet fable` on the client: compiles; the generated JS for `Shared.Csv.getColumn` throws `KeyNotFoundException`, `rowCreate` and `fromBirthDate` throw with the parameter name appended.
- `dotnet fantomas --check` clean on the changed files.
- The `Expect.throws` tests that depended on these sites (`Utils.Tests` getColumn, `GenUNITS.Tests` unit comparison and operator, `GenORDER.Tests` mass/volume mix) still pass because they are untyped.

## Author checklist

I confirm that these changes:

- [x] Follow the process described in [CONTRIBUTING.md](../../CONTRIBUTING.md#pull-request-process).
- [x] Make the changes proposed in the linked issue (if applicable): #419
- [x] Follow the approach documented in the linked implementation plan (if applicable): #555 (`docs/implementation-plans/419-do-not-use-failwith.md`)
- [x] Are no more than 200 lines of changed code, ideally 25-100.
- [x] Are not more complex than necessary.
- [x] Cannot easily be split in a way that would make reviewing them significantly easier.
- [x] Follow the guidelines specified in [DEVELOPMENT.md](../../DEVELOPMENT.md).
- [x] Have been thoroughly tested.
- [x] Don't introduce new security vulnerabilities.
- [ ] Follow the [AI/LLM Usage Policy](../../AGENTS.md#aillm-usage-policy) — LLMs were not given direct write access to `.fs` source files (except client-side UI code). **Not checked on purpose:** the LLM edited `.fs` files directly, as an explicit exception granted by the maintainer for this issue (see the issue thread). There is nothing to prototype in a script for a type swap.

### AI/Vibe Coding Disclosure

- [x] Some or all code in this PR is **vibe coded** (substantially AI-generated). If checked, describe below which parts were AI-generated, which tool was used, and how the code was verified.

All edits were made by Claude Code (Claude Fable 5.1) as exact-string replacements per the plan's site table, after a sweep of every `try/with` and `Expect.throws` in the repo to confirm no handler depends on the exact `System.Exception` type. Verified by the full Expecto suite, a Fable compile with inspection of the generated JS, and author review of the diff.

I confirm that I have:

- [x] Added appropriate automated tests. (Existing timeout test tightened to `TimeoutException`; no other behaviour changed.)
- [x] Updated documentation appropriately.
- [x] Added comments that highlight important changes and add justification, where necessary.

## Reviewer checklist

I confirm that:

- [x] I am confident that the changes work.
- [x] The changed code meets our guidelines and standards.
- [x] The new code is not more complex than necessary.
- [x] I have clearly labeled suggestions as blocking, required but not blocking, or optional (see [CONTRIBUTING.md](../../CONTRIBUTING.md#pull-request-process)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012F5UZAxUhrSRGPgZcwsTYH
