### PR TITLE
refactor: replace remaining failwith in source files

### DIFF
--- a/Build.fs
+++ b/Build.fs
@@ -268,7 +268,7 @@ Target.create
                     // A discovery failure does this (a static initializer that throws yields no
                     // results — see issue #523), but so does a crashed or cancelled test host,
                     // so name the likely cause without asserting it.
-                    failwithf
+                    invalidOp
                         $"dotnet test exited %i{result.ExitCode}, but no assembly reported a \
                           failing test (%i{totalPassed.Value} passed). Results are missing \
                           rather than failing. Most often an assembly threw during discovery, \
@@ -278,10 +278,10 @@ Target.create
                           or cancelled test host looks the same, so check the output above \
                           for a project that reported no summary line at all."
                 else
-                    failwithf "Tests failed with exit code %d" result.ExitCode
+                    invalidOp $"Tests failed with exit code %d{result.ExitCode}"
 
             if totalTests.Value = 0 then
-                failwith
+                invalidOp
                     "No tests were discovered or run. The solution was likely not built/restored before `dotnet test`."
     )
 
@@ -354,7 +354,7 @@ Target.create
 let requireEnvVar name =
     match System.Environment.GetEnvironmentVariable name with
     | v when System.String.IsNullOrWhiteSpace v ->
-        failwithf "%s is not set. Load it from .env first (see DEVELOPMENT.md)." name
+        invalidOp $"%s{name} is not set. Load it from .env first (see DEVELOPMENT.md)."
     | v -> v
 
 
@@ -374,7 +374,7 @@ let buildDockerImage () =
         |> Seq.tryHead
         |> Option.map (fun e -> e.Value.Trim())
         |> Option.filter (System.String.IsNullOrWhiteSpace >> not)
-        |> Option.defaultWith (fun () -> failwith "Directory.Build.props: <Version> element is missing or empty.")
+        |> Option.defaultWith (fun () -> invalidOp "Directory.Build.props: <Version> element is missing or empty.")
 
     // Cross-build for a different target platform, e.g. amd64 from Apple
     // Silicon, via: DOCKER_PLATFORM=linux/amd64 dotnet run DockerBuild
@@ -414,7 +414,7 @@ let dockerImageExistsLocally () =
     elif result.Result.Error.Contains "No such image" then
         false
     else
-        failwithf "docker image inspect failed:\n%s" result.Result.Error
+        invalidOp $"docker image inspect failed:\n%s{result.Result.Error}"
 
 
 Target.create "DockerBuild" (fun _ -> buildDockerImage ())

--- a/Helpers.fs
+++ b/Helpers.fs
@@ -94,7 +94,7 @@ let createProcess exe args dir =
     |> CreateProcess.addOnExited (fun data exitCode ->
         // Treat SIGINT (130) and SIGTERM (143) as graceful shutdown
         if exitCode <> 0 && exitCode <> 130 && exitCode <> 143 then
-            failwithf "Process exit code '%d' <> 0. Command Line: %s %s" exitCode exe (args |> String.concat " ")
+            invalidOp $"""Process exit code '%d{exitCode}' <> 0. Command Line: %s{exe} %s{args |> String.concat " "}"""
 
         data
     )
@@ -111,7 +111,7 @@ let createProcessFromPath processName args dir =
         | None ->
             "npm was not found in path. Please install it and make sure it's available from your path. "
             + "See https://safe-stack.github.io/docs/quickstart/#install-pre-requisites for more info"
-            |> failwith
+            |> invalidOp
 
     createProcess path args dir
 

--- a/benchmark/Program.fs
+++ b/benchmark/Program.fs
@@ -30,13 +30,13 @@ module TestSolver =
     let printEqs =
         function
         | Ok eqs -> eqs |> Solver.printEqs true procss
-        | Error _ -> failwith "errors"
+        | Error _ -> invalidOp "errors"
 
 
     let printEqsWithUnits =
         function
         | Ok eqs -> eqs |> Solver.printEqs false procss
-        | Error _ -> failwith "errors"
+        | Error _ -> invalidOp "errors"
 
 
     let setProp n p eqs =

--- a/src/Informedica.GenFORM.Lib/Product.fs
+++ b/src/Informedica.GenFORM.Lib/Product.fs
@@ -246,7 +246,7 @@ module Product =
                         let n, u =
                             match s |> String.split " " with
                             | [ n; u ] -> n |> String.trim, u |> String.trim
-                            | _ -> failwith $"cannot parse substance {s}"
+                            | _ -> raise (System.FormatException $"cannot parse substance {s}")
 
                         createSubstance n q u formUnit unitMapping
                     )
@@ -297,7 +297,7 @@ module Product =
                         let n, u =
                             match s |> String.split " " with
                             | [ n; u ] -> n |> String.trim, u |> String.trim
-                            | _ -> failwith $"cannot parse substance {s}"
+                            | _ -> raise (System.FormatException $"cannot parse substance {s}")
 
                         createSubstance n q u Units.Volume.milliLiter unitMapping
                     )
@@ -457,7 +457,7 @@ module Product =
                             let n, u =
                                 match s |> String.split " " with
                                 | [ n; u ] -> n |> String.trim, u |> String.trim
-                                | _ -> failwith $"cannot parse substance {s}"
+                                | _ -> raise (System.FormatException $"cannot parse substance {s}")
 
                             createSubstance n q u formUnit unitMapping
                         )

--- a/src/Informedica.GenFORM.Lib/SolutionRule.fs
+++ b/src/Informedica.GenFORM.Lib/SolutionRule.fs
@@ -156,7 +156,7 @@ module SolutionRule =
                                 match l.Substance, l.Component with
                                 | s, _ when s |> String.isNullOrWhiteSpace |> not -> s |> SubstanceLimitTarget
                                 | _, c when c |> String.isNullOrWhiteSpace |> not -> c |> ComponentLimitTarget
-                                | _ -> failwith "Solution limit should be either a substance or a component limit"
+                                | _ -> invalidOp "Solution limit should be either a substance or a component limit"
                             Quantity = (l.MinQty, l.MaxQty) |> fromTupleInclIncl u
                             QuantityAdj = (l.MinQtyAdj, l.MaxQtyAdj) |> fromTupleInclIncl au
                             Quantities =

--- a/src/Informedica.GenORDER.Lib/Medication.fs
+++ b/src/Informedica.GenORDER.Lib/Medication.fs
@@ -302,7 +302,7 @@ module Medication =
                         | first :: rest when not (first |> Seq.exists Char.IsDigit) ->
                             SubstanceLimitTarget first, rest |> String.concat ", "
                         | _ -> NoLimitTarget, s
-                    | _ -> $"{firstLabelPos} not valid" |> failwith
+                    | _ -> raise (System.FormatException $"{firstLabelPos} not valid")
 
                 // Split constraints by field labels using regex
                 // Pattern matches: [label] value until next [label] or end
@@ -1326,8 +1326,16 @@ module Medication =
         /// Create the base Order DTO based on order type
         let createBaseOrderDto (med: Medication) =
             match med.OrderType with
-            | AnyOrder -> failwith "Not implemented for a medication order, the order type cannot be 'Any'"
-            | ProcessOrder -> failwith "Not implemented for a mediction order, the order type cannot be 'Process'"
+            | AnyOrder ->
+                raise (
+                    System.NotSupportedException
+                        "Not implemented for a medication order, the order type cannot be 'Any'"
+                )
+            | ProcessOrder ->
+                raise (
+                    System.NotSupportedException
+                        "Not implemented for a medication order, the order type cannot be 'Process'"
+                )
             | OnceOrder -> Order.Dto.once med.Id med.Name med.Route []
             | OnceTimedOrder -> Order.Dto.onceTimed med.Id med.Name med.Route []
             | ContinuousOrder -> Order.Dto.continuous med.Id med.Name med.Route []

--- a/src/Informedica.GenORDER.Lib/Order.fs
+++ b/src/Informedica.GenORDER.Lib/Order.fs
@@ -2504,9 +2504,7 @@ module Order =
                 | false, false, false, true, false -> dto.Frequency |> Frequency.fromDto |> Discontinuous
                 | false, false, false, false, true ->
                     (dto.Frequency |> Frequency.fromDto, dto.Time |> Time.fromDto) |> Timed
-                | _ ->
-                    exn "dto is neither or both process, continuous, discontinuous or timed"
-                    |> raise
+                | _ -> invalidOp "dto is neither or both process, continuous, discontinuous or timed"
 
 
             let toDto schedule =
@@ -3373,7 +3371,7 @@ module Order =
                                 rest |> List.filter (OrderVariable.eqsUnitGroup h)
 
                     (h, rest) |> c
-                | _ -> failwith $"cannot map {eqs}"
+                | _ -> invalidOp $"cannot map {eqs}"
             )
 
         let sumEqs, prodEqs = eqMapping

--- a/src/Informedica.GenORDER.Lib/Utils.fs
+++ b/src/Informedica.GenORDER.Lib/Utils.fs
@@ -26,7 +26,7 @@ module Utils =
             Env.loadDotEnv () |> ignore
 
             Env.getItem Constants.GENPRES_URL_ID
-            |> Option.defaultWith (fun () -> failwith $"{Constants.GENPRES_URL_ID} not set")
+            |> Option.defaultWith (fun () -> invalidOp $"{Constants.GENPRES_URL_ID} not set")
             |> fun urlId -> GoogleSheets.getCsvDataFromSheetSync urlId sheet // urlId sheet
             |> Result.defaultValue [||]
 

--- a/src/Informedica.GenPRES.Server/Server.fs
+++ b/src/Informedica.GenPRES.Server/Server.fs
@@ -137,13 +137,13 @@ let private validateProductionPassword () =
             |> Option.filter (System.String.IsNullOrWhiteSpace >> not)
         with
         | None ->
-            failwith
+            invalidOp
                 "GENPRES_PROD=1 but GENPRES_PASSWORD is not set (or is empty). \
                  Refusing to start in production without an admin password. \
                  Generate one with `openssl rand -base64 32` and inject it via a secret store. \
                  See DEVELOPMENT.md → Password policy."
         | Some pwd when pwd.Length < minProductionPasswordLength ->
-            failwith
+            invalidOp
                 $"GENPRES_PROD=1 but GENPRES_PASSWORD is shorter than %i{minProductionPasswordLength} characters. \
                  Refusing to start in production with a weak admin password. \
                  Generate a stronger one with `openssl rand -base64 32`. \
@@ -172,7 +172,7 @@ let provider =
     // confusing "cannot find column" error from GenForm.
     tryGetEnv "GENPRES_URL_ID"
     |> Option.filter (System.String.IsNullOrWhiteSpace >> not)
-    |> Option.defaultWith (fun () -> failwith "No GENPRES_URL_ID (or value is empty)")
+    |> Option.defaultWith (fun () -> invalidOp "No GENPRES_URL_ID (or value is empty)")
     |> Informedica.GenForm.Lib.Api.getCachedProviderWithDataUrlId logger
 
 

--- a/src/Informedica.GenPRES.Shared/Localization.fs
+++ b/src/Informedica.GenPRES.Shared/Localization.fs
@@ -205,7 +205,7 @@ module Localization =
         | _ when s = "deutsch" -> German
         | _ when s = "italiano" -> Italian
         //        | _ when s = "中文" -> Chinees
-        | _ -> failwith $"{s} is not a known language"
+        | _ -> raise (System.FormatException $"{s} is not a known language")
 
 
     let languages = [| English; Dutch; French; German; Spanish; Italian |]

--- a/src/Informedica.GenPRES.Shared/Models.fs
+++ b/src/Informedica.GenPRES.Shared/Models.fs
@@ -2297,7 +2297,7 @@ module Models =
                     | 1 -> Caution
                     | 2 -> Warning
                     | 3 -> Alert
-                    | i -> failwith $"not a valid textblock: {i}"
+                    | i -> raise (System.FormatException $"not a valid textblock: {i}")
 
 
         /// Flatten TextBlock[][] to a single-row TextBlock[][] for compact display.

--- a/src/Informedica.GenPRES.Shared/Utils.fs
+++ b/src/Informedica.GenPRES.Shared/Utils.fs
@@ -403,7 +403,7 @@ module Csv =
         | FloatData ->
             match Double.TryParse(x) with
             | true, n -> n |> box
-            | _ -> $"cannot parse {x} to double" |> failwith
+            | _ -> raise (System.FormatException $"cannot parse {x} to double")
         | FloatOptionData ->
             match Double.TryParse(x) with
             | true, n -> n |> Some |> box

--- a/src/Informedica.GenSOLVER.Lib/Solver.fs
+++ b/src/Informedica.GenSOLVER.Lib/Solver.fs
@@ -246,7 +246,7 @@ module Solver =
             let n2 = eqs |> List.length
 
             if n2 <> n1 then
-                failwith $"not the same number of eqs, was: {n1}, now {n2}"
+                invalidOp $"not the same number of eqs, was: {n1}, now {n2}"
             else
                 Ok eqs
 
@@ -270,6 +270,6 @@ module Solver =
             let n2 = eqs |> List.length
 
             if n2 <> n1 then
-                failwith $"not the same number of eqs, was: {n1}, now {n2}"
+                invalidOp $"not the same number of eqs, was: {n1}, now {n2}"
             else
                 Ok eqs

--- a/src/Informedica.GenUNITS.Lib/Api.fs
+++ b/src/Informedica.GenUNITS.Lib/Api.fs
@@ -41,7 +41,7 @@ module Api =
             | _ when s = "/" -> (fun a b -> a / b)
             | _ when s = "+" -> (fun a b -> a + b)
             | _ when s = "-" -> (fun a b -> a - b)
-            | _ -> failwith <| $"Cannot evaluate string %s{s}"
+            | _ -> raise (System.FormatException $"Cannot evaluate string %s{s}")
 
         let rec eval' acc terms =
             if acc |> Option.isNone then
@@ -59,7 +59,7 @@ module Api =
 
                     rest |> eval' vu
 
-                | _ -> failwith <| sprintf "Cannot evaluate string %s" (terms |> String.concat ",")
+                | _ -> raise (System.FormatException $"""Cannot evaluate string %s{terms |> String.concat ","}""")
 
         s
         |> String.replace mults (mults |> addDel)

--- a/src/Informedica.GenUNITS.Lib/Combine.fs
+++ b/src/Informedica.GenUNITS.Lib/Combine.fs
@@ -115,7 +115,7 @@ module Combine =
                     match n1, n2 with
                     | Some x1, Some x2 -> u1 |> Units.setUnitValue (x1 + x2)
                     | _ -> u1
-                | _ -> failwith <| $"Cannot combine units {u1} and {u2} with operator {op}"
+                | _ -> raise (System.NotSupportedException $"Cannot combine units {u1} and {u2} with operator {op}")
 
 
     /// <summary>

--- a/src/Informedica.GenUNITS.Lib/Core.fs
+++ b/src/Informedica.GenUNITS.Lib/Core.fs
@@ -23,7 +23,7 @@ module Core =
         | _ when s = "*" -> OpTimes
         | _ when s = "+" -> OpPlus
         | _ when s = "-" -> OpMinus
-        | _ -> failwith <| $"Cannot parse %s{s} to operand"
+        | _ -> raise (System.FormatException $"Cannot parse %s{s} to operand")
 
 
     /// A 'count' unit with n = 1

--- a/src/Informedica.GenUNITS.Lib/Units.fs
+++ b/src/Informedica.GenUNITS.Lib/Units.fs
@@ -1276,7 +1276,8 @@ module Units =
             match e with
             | Calorie n -> (n, Energy.calorie)
             | KiloCalorie n -> (n, Energy.kiloCalorie)
-        | CombiUnit(u1, op, u2) -> failwith <| $"Cannot map combined unit %A{(u1, op, u2) |> CombiUnit}"
+        | CombiUnit(u1, op, u2) ->
+            raise (System.NotSupportedException $"Cannot map combined unit %A{(u1, op, u2) |> CombiUnit}")
 
 
     /// <summary>

--- a/src/Informedica.GenUNITS.Lib/UnitsParse.fs
+++ b/src/Informedica.GenUNITS.Lib/UnitsParse.fs
@@ -44,7 +44,7 @@ module UnitsParse =
                                 None
                             else
                                 if s |> groupIsGeneralOrNone |> not then
-                                    failwith $"invalid unit group {s}"
+                                    raise (System.FormatException $"invalid unit group {s}")
 
                                 s |> String.removeBrackets |> Units.General.general |> Some
                     )

--- a/src/Informedica.MCP.Lib/McpServer.fs
+++ b/src/Informedica.MCP.Lib/McpServer.fs
@@ -36,7 +36,7 @@ type GenFormMcpTools() =
 
     static member private Provider =
         _provider
-        |> Option.defaultWith (fun () -> failwith "Provider not initialized. Call GenFormMcpTools.SetProvider first.")
+        |> Option.defaultWith (fun () -> invalidOp "Provider not initialized. Call GenFormMcpTools.SetProvider first.")
 
 
     [<McpServerTool(Name = "get_resource_info")>]
@@ -131,7 +131,7 @@ type GenOrderMcpTools() =
 
     static member private Provider =
         _provider
-        |> Option.defaultWith (fun () -> failwith "Provider not initialized. Call GenOrderMcpTools.SetProvider first.")
+        |> Option.defaultWith (fun () -> invalidOp "Provider not initialized. Call GenOrderMcpTools.SetProvider first.")
 
 
     [<McpServerTool(Name = "get_order_context_filter_options")>]

--- a/src/Informedica.NKF.Lib/Utils.fs
+++ b/src/Informedica.NKF.Lib/Utils.fs
@@ -72,7 +72,7 @@ module Utils =
 
         let private getDataUrlId () =
             Env.getItem "GENPRES_URL_ID"
-            |> Option.defaultWith (fun () -> failwith "No valid data url id")
+            |> Option.defaultWith (fun () -> invalidOp "No valid data url id")
             |> fun s ->
                 ConsoleWriter.writeInfoMessage $"using: {s}" true false
                 s

--- a/src/Informedica.Utils.Lib/Csv.fs
+++ b/src/Informedica.Utils.Lib/Csv.fs
@@ -40,7 +40,7 @@ module Csv =
             if isOption then
                 None
             else
-                $"cannot parse {x} to {typeDescr}" |> failwith
+                raise (System.FormatException $"cannot parse {x} to {typeDescr}")
 
 
     /// Try to cast a string to a value of the given type.

--- a/src/Informedica.Utils.Lib/Result.fs
+++ b/src/Informedica.Utils.Lib/Result.fs
@@ -7,7 +7,7 @@ module Result =
     let get =
         function
         | Ok r -> r
-        | Error _ -> failwith "cannot get result from Error"
+        | Error _ -> invalidOp "cannot get result from Error"
 
     module Tests =
 

--- a/src/Informedica.ZForm.Lib/GStand.fs
+++ b/src/Informedica.ZForm.Lib/GStand.fs
@@ -79,7 +79,7 @@ module GStand =
     /// i.e. if all min weights are the same and all max weights are the same.
     /// </summary>
     /// <param name="drs"></param>
-    /// <exception cref="System.Exception">Cannot calculate weight min max with: {drs}</exception>
+    /// <exception cref="System.InvalidOperationException">Cannot calculate weight min max with: {drs}</exception>
     let calcWeightMinMax (drs: ZIndexTypes.DoseRule seq) =
 
         match drs |> Seq.toList with
@@ -89,7 +89,7 @@ module GStand =
             if tail |> List.forall (fun mm -> mm.Weight = h.Weight) then
                 h.Weight
             else
-                failwith $"cannot calculate weight min max with: {drs}"
+                invalidOp $"cannot calculate weight min max with: {drs}"
         |> mapMinMax
             ((Option.map ValueUnit.weightInKg) >> (Optic.set MinMax.Optics.inclMinLens))
             ((Option.map ValueUnit.weightInKg) >> (Optic.set MinMax.Optics.inclMaxLens))
@@ -100,7 +100,7 @@ module GStand =
     /// i.e. if all min bsa are the same and all max bsa are the same.
     /// </summary>
     /// <param name="drs"></param>
-    /// <exception cref="System.Exception">Cannot calculate bsa min max with: {drs}</exception>
+    /// <exception cref="System.InvalidOperationException">Cannot calculate bsa min max with: {drs}</exception>
     let calcBSAMinMax (drs: ZIndexTypes.DoseRule seq) =
 
         match drs |> Seq.toList with
@@ -110,7 +110,7 @@ module GStand =
             if tail |> List.forall (fun mm -> mm.BSA = h.BSA) then
                 h.BSA
             else
-                failwith $"cannot calculate bsa min max with: {drs}"
+                invalidOp $"cannot calculate bsa min max with: {drs}"
         |> mapMinMax
             ((Option.map ValueUnit.bsaInM2) >> (Optic.set MinMax.Optics.inclMinLens))
             ((Option.map ValueUnit.bsaInM2) >> (Optic.set MinMax.Optics.inclMaxLens))
@@ -141,7 +141,7 @@ module GStand =
     /// </summary>
     /// <param name="freq">The frequency to map</param>
     /// <returns>The mapped frequency</returns>
-    /// <exception cref="System.Exception">Cannot parse freq value unit</exception>
+    /// <exception cref="System.FormatException">Cannot parse freq value unit</exception>
     /// <example>
     /// <code>
     /// let freq : ZIndexTypes.RuleFrequency = { Frequency = 1.; Time = "dag" }
@@ -191,7 +191,7 @@ module GStand =
             |> function
                 | Error err ->
                     writeErrorMessage $"Cannot parse |{s}| freq value unit: {freq}\n{err}"
-                    err |> failwith
+                    raise (System.FormatException err)
                 | Ok vu -> vu
             |> map
 
@@ -387,7 +387,7 @@ module GStand =
                             |> List.map (ValueUnit.toStringDecimalDutchShortWithPrec 1)
                             |> String.concat ", "
 
-                        failwith <| $"cannot add frequency %s{s1} to list with units %s{s2}"
+                        invalidOp $"cannot add frequency %s{s1} to list with units %s{s2}"
 
 
                     if frs |> List.exists ((=) d.frequency) then

--- a/src/Informedica.ZForm.Lib/Utils.fs
+++ b/src/Informedica.ZForm.Lib/Utils.fs
@@ -87,7 +87,7 @@ module Web =
         | None ->
             let msg = "Cannot load the GENPRES_URL_ID"
             ConsoleWriter.writeErrorMessage msg true false
-            failwith msg
+            invalidOp msg
         | Some urlId ->
             sheet
             |> Web.GoogleSheets.getCsvDataFromSheetSync urlId

--- a/src/Informedica.ZIndex.Lib/BST000T.fs
+++ b/src/Informedica.ZIndex.Lib/BST000T.fs
@@ -110,7 +110,7 @@ module BST000T =
 
             if t.MDRECL <> BST001T.recordLength n then
                 $"Calculated record length: %i{t.MDRECL}, is not equal to table record length: %i{BST001T.recordLength n}"
-                |> failwith
+                |> invalidOp
 
             t.MDOBST
 


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #556.** Until #556 merges, the diff here shows both commits; review only the two commits titled “refactor: replace remaining failwith in source files” and “refactor: replace failwith in build and benchmark tooling”. Draft for that reason.

## Overview

Second implementation PR for #419, following the plan in #555. This batch covers the remaining source sites, where the type adds convention rather than information a caller acts on (plan categories B, D, E, F):

- **B.** Parse failures raise `FormatException`: unit strings, operator tokens, CSV cells, substance strings, medication labels, language names, text-block levels, G-Standaard frequency units.
- **D.** Missing configuration or uninitialized state uses `invalidOp`: the `GENPRES_URL_ID` / `GENPRES_PASSWORD` startup guards (still fail-fast, messages unchanged, see the security review), MCP provider not set.
- **E.** Invariant violations use `invalidOp`: equation count after solving, `Result.get` on `Error`, eqMapping shape, schedule DTO flags (was a hand-built `exn ... |> raise`), solution-limit target, G-Standaard min/max aggregation, BST record length. This is the plan's low-benefit bucket.
- **F.** Unsupported operations raise `NotSupportedException`: mapping a `CombiUnit`, combining unit groups, order types `Any` and `Process`.

The three `<exception cref="System.Exception">` tags in `GStand.fs` now name the thrown type. After this PR no `failwith` remains under `src/`.

- **Tooling (second commit, after review on #555).** The ten sites outside `src/` and `tests/` use `invalidOp`: six in `Build.fs`, two in `Helpers.fs`, two in `benchmark/Program.fs`. FAKE fails the target on any exception, so build behaviour is unchanged. `failwithf` format strings became interpolated strings with the same text.

## Divergence from plan

The plan filed the G-Standaard frequency-unit mismatch under A (`invalidArg`). It sits inside a `Seq.fold` lambda comparing an element against the accumulator, so there is no argument to name; it uses `invalidOp` (E) instead.

## Verification

- `dotnet run build`: succeeds. `dotnet build Build.fsproj`: succeeds.
- `benchmark/benchmark.fsproj` does not build on `master` either (#513: stale `net6.0` restriction in its own `paket.lock`), so its two one-token edits are unverified by a compiler. They mirror the GenSOLVER test helpers, which do compile.
- `dotnet run servertests`: all 16 test projects pass (1,519 tests).
- `dotnet fable` on the client: compiles; generated JS for `Localization.fromString` throws `FormatException`.
- `grep -rnE '\bfailwith(f)?\b|\bexn "' --include='*.fs' src`: empty.
- `dotnet fantomas --check` clean on the changed files.

## Author checklist

I confirm that these changes:

- [x] Follow the process described in [CONTRIBUTING.md](../../CONTRIBUTING.md#pull-request-process).
- [x] Make the changes proposed in the linked issue (if applicable): #419
- [x] Follow the approach documented in the linked implementation plan (if applicable): #555
- [x] Are no more than 200 lines of changed code, ideally 25-100.
- [x] Are not more complex than necessary.
- [x] Cannot easily be split in a way that would make reviewing them significantly easier.
- [x] Follow the guidelines specified in [DEVELOPMENT.md](../../DEVELOPMENT.md).
- [x] Have been thoroughly tested.
- [x] Don't introduce new security vulnerabilities.
- [ ] Follow the [AI/LLM Usage Policy](../../AGENTS.md#aillm-usage-policy) — LLMs were not given direct write access to `.fs` source files (except client-side UI code). **Not checked on purpose:** the LLM edited `.fs` files directly, as an explicit exception granted by the maintainer for this issue (see the issue thread).

### AI/Vibe Coding Disclosure

- [x] Some or all code in this PR is **vibe coded** (substantially AI-generated). If checked, describe below which parts were AI-generated, which tool was used, and how the code was verified.

All edits were made by Claude Code (Claude Fable 5.1) as exact-string replacements per the plan's site table. Verified by the full Expecto suite, a Fable compile, and author review of the diff.

I confirm that I have:

- [ ] Added appropriate automated tests. (None added: no behaviour changes; the existing untyped `Expect.throws` tests cover the sites that had tests.)
- [x] Updated documentation appropriately.
- [x] Added comments that highlight important changes and add justification, where necessary.

## Reviewer checklist

I confirm that:

- [x] I am confident that the changes work.
- [x] The changed code meets our guidelines and standards.
- [x] The new code is not more complex than necessary.
- [ ] I have clearly labeled suggestions as blocking, required but not blocking, or optional (see [CONTRIBUTING.md](../../CONTRIBUTING.md#pull-request-process)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012F5UZAxUhrSRGPgZcwsTYH
