### PR TITLE
test: replace failwith with failtest in test bodies

### DIFF
--- a/tests/Informedica.Agents.Tests/Tests.fs
+++ b/tests/Informedica.Agents.Tests/Tests.fs
@@ -203,7 +203,7 @@ module Tests =
 
                     let agent = Agent.createSimple (fun msg ->
                         match msg with
-                        | ErrorMessage _ -> failwith "Test exception"
+                        | ErrorMessage _ -> invalidOp "Test exception"
                         | _ -> ())
 
                     agent.OnError.Add (fun ex -> errorReceived <- Some ex.Message)
@@ -225,7 +225,7 @@ module Tests =
                     let agent = Agent.createSimple (fun msg ->
                         try
                             match msg with
-                            | ErrorMessage _ -> failwith "Recoverable error"
+                            | ErrorMessage _ -> invalidOp "Recoverable error"
                             | SimpleMessage _ -> messageCount <- messageCount + 1
                             | _ -> ()
                         with

--- a/tests/Informedica.GenCORE.Tests/Tests.fs
+++ b/tests/Informedica.GenCORE.Tests/Tests.fs
@@ -431,7 +431,7 @@ module Tests =
                                     | Some(Inclusive minVu), Some(Inclusive maxVu) ->
                                         minVu |> ValueUnit.getValue |> Expect.equal "min should be 15" [| 15N |]
                                         maxVu |> ValueUnit.getValue |> Expect.equal "max should be 15" [| 15N |]
-                                    | _ -> failwith "Expected both min and max to be Inclusive"
+                                    | _ -> failtest "Expected both min and max to be Inclusive"
                                 )
                                 |> Expect.isOk "should parse successfully"
                             }
@@ -448,7 +448,7 @@ module Tests =
                                         minVu
                                         |> ValueUnit.getUnit
                                         |> Expect.equal "units should match" (maxVu |> ValueUnit.getUnit)
-                                    | _ -> failwith "Expected both min and max to be Inclusive"
+                                    | _ -> failtest "Expected both min and max to be Inclusive"
                                 )
                                 |> Expect.isOk "should parse successfully"
                             }
@@ -465,7 +465,7 @@ module Tests =
                                         minVu
                                         |> ValueUnit.getUnit
                                         |> Expect.equal "units should match" (maxVu |> ValueUnit.getUnit)
-                                    | _ -> failwith "Expected both min and max to be Inclusive"
+                                    | _ -> failtest "Expected both min and max to be Inclusive"
                                 )
                                 |> Expect.isOk "should parse successfully"
                             }
@@ -477,7 +477,7 @@ module Tests =
                                     match mm.Min, mm.Max with
                                     | Some(Inclusive minVu), None ->
                                         minVu |> ValueUnit.getValue |> Expect.equal "min should be 10" [| 10N |]
-                                    | _ -> failwith "Expected min to be Inclusive and max to be None"
+                                    | _ -> failtest "Expected min to be Inclusive and max to be None"
                                 )
                                 |> Expect.isOk "should parse successfully"
                             }
@@ -489,7 +489,7 @@ module Tests =
                                     match mm.Min, mm.Max with
                                     | None, Some(Inclusive maxVu) ->
                                         maxVu |> ValueUnit.getValue |> Expect.equal "max should be 50" [| 50N |]
-                                    | _ -> failwith "Expected min to be None and max to be Inclusive"
+                                    | _ -> failtest "Expected min to be None and max to be Inclusive"
                                 )
                                 |> Expect.isOk "should parse successfully"
                             }
@@ -502,7 +502,7 @@ module Tests =
                                     | Some(Inclusive minVu), Some(Inclusive maxVu) ->
                                         minVu |> ValueUnit.getValue |> Expect.equal "min should be 5" [| 5N |]
                                         maxVu |> ValueUnit.getValue |> Expect.equal "max should be 10" [| 10N |]
-                                    | _ -> failwith "Expected both min and max to be Inclusive"
+                                    | _ -> failtest "Expected both min and max to be Inclusive"
                                 )
                                 |> Expect.isOk "should parse successfully"
                             }
@@ -522,7 +522,7 @@ module Tests =
                                         |> ValueUnit.getValue
                                         |> Array.head
                                         |> Expect.equal "max should be 20.5" (41N / 2N)
-                                    | _ -> failwith "Expected both min and max to be Inclusive"
+                                    | _ -> failtest "Expected both min and max to be Inclusive"
                                 )
                                 |> Expect.isOk "should parse successfully"
                             }

--- a/tests/Informedica.GenFORM.Tests/FixtureJson.fs
+++ b/tests/Informedica.GenFORM.Tests/FixtureJson.fs
@@ -41,7 +41,7 @@ module FixtureJson =
             let parts = s.Split('/')
 
             if parts.Length <> 2 then
-                failwith $"BigRational fixture token expected 'num/den', got: '%s{s}'"
+                raise (FormatException $"BigRational fixture token expected 'num/den', got: '%s{s}'")
 
             let bi (t: string) = System.Numerics.BigInteger.Parse t
             (BigRational.FromBigInt(bi parts[0]) / BigRational.FromBigInt(bi parts[1])) :> obj

--- a/tests/Informedica.GenFORM.Tests/Tests.fs
+++ b/tests/Informedica.GenFORM.Tests/Tests.fs
@@ -2356,7 +2356,7 @@ module Tests =
                 | None ->
                     // fail loudly rather than fall back to a size that does not
                     // actually conflict, which would make the test vacuous
-                    failwithf
+                    failtestf
                         "patientFor: BSA %s is unreachable within 400 kg; this rule cannot induce a realistic adjusted-vs-MaxQty conflict"
                         (adjVU |> ValueUnit.toStringDecimalDutchShortWithPrec 2)
 
@@ -3645,14 +3645,14 @@ module Tests =
                         let url = "http://127.0.0.1:9/geneesmiddelen.json"
 
                         match SourceLoader.fetchNKFMedicationsFrom url with
-                        | Ok _ -> failwith "expected Error"
+                        | Ok _ -> failtest "expected Error"
                         | Error [ ErrorMsg(text, Some _) ] ->
                             text |> String.contains url |> Expect.isTrue "message names the url"
 
                             text
                             |> String.contains "could not fetch"
                             |> Expect.isTrue "message says what failed"
-                        | Error msgs -> failwith $"expected one ErrorMsg with the exception, got %A{msgs}"
+                        | Error msgs -> failtest $"expected one ErrorMsg with the exception, got %A{msgs}"
                     }
                 ]
 

--- a/tests/Informedica.GenORDER.Tests/Tests.fs
+++ b/tests/Informedica.GenORDER.Tests/Tests.fs
@@ -85,7 +85,7 @@ module Result =
     let get result =
         match result with
         | Ok value -> value
-        | Error err -> failwith $"{err}"
+        | Error err -> failtest $"{err}"
 
 
 // --- New tests for fluent pipeline guard/order behavior ---
@@ -121,13 +121,13 @@ module Pipeline =
         Scenarios.kaliumchlorideOnceTimedText
         |> Medication.fromString
         |> function
-            | Error errs -> failwith $"Failed to parse kaliumchloride OnceTimed: {errs}"
+            | Error errs -> failtest $"Failed to parse kaliumchloride OnceTimed: {errs}"
             | Ok med ->
                 med
                 |> Medication.toOrderDto
                 |> Dto.fromDto
                 |> function
-                    | Error msg -> failwith $"Failed to create order: {msg}"
+                    | Error msg -> failtest $"Failed to create order: {msg}"
                     | Ok ord -> ord
 
     [<Tests>]
@@ -254,7 +254,7 @@ module Pipeline =
                         |> Medication.toOrderDto
                         |> Dto.fromDto
                         |> function
-                            | Error msg -> failwith $"{msg}"
+                            | Error msg -> failtest $"{msg}"
                             | Ok o -> o
 
                     let res = OrderProcessor.processPipeline noLogger (CalcMinMax ord)
@@ -593,8 +593,8 @@ module ToOrderDto =
 
         let dto =
             match d.OrderType with
-            | AnyOrder -> "the order type cannot be 'Any'" |> failwith
-            | ProcessOrder -> "the order type cannot be 'Process'" |> failwith
+            | AnyOrder -> "the order type cannot be 'Any'" |> failtest
+            | ProcessOrder -> "the order type cannot be 'Process'" |> failtest
             | OnceOrder -> Order.Dto.once d.Id d.Name d.Route []
             | OnceTimedOrder -> Order.Dto.onceTimed d.Id d.Name d.Route []
             | ContinuousOrder -> Order.Dto.continuous d.Id d.Name d.Route []
@@ -1385,7 +1385,7 @@ module OrderProcessorTests =
         |> Order.Dto.fromDto
         |> function
             | Ok o -> o
-            | Error e -> failwith $"could not create tpn order: %A{e}"
+            | Error e -> failtest $"could not create tpn order: %A{e}"
         |> run CalcMinMax
         |> fst
         |> run IncreaseIncrements

--- a/tests/Informedica.GenPRES.Server.Tests/ResourceErrorTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/ResourceErrorTests.fs
@@ -66,7 +66,7 @@ let errorPropagationTests =
             test "loader throws exception is caught and returned as Error" {
                 let result =
                     okRegistry
-                    |> Map.add Keys.unitMappings.Name (fun _ -> failwith "unexpected crash")
+                    |> Map.add Keys.unitMappings.Name (fun _ -> invalidOp "unexpected crash")
                     |> loadAllResourcesWithRegistry
 
                 result |> Result.isError |> Expect.isTrue "should be Error"
@@ -80,7 +80,7 @@ let errorPropagationTests =
                         | _ -> false
                     )
                     |> Expect.isTrue "should contain 'Failed to load resources' message"
-                | Ok _ -> failwith "expected Error"
+                | Ok _ -> failtest "expected Error"
             }
         ]
 
@@ -100,7 +100,7 @@ let successPathTests =
                     loaded.State.IsLoaded |> Expect.isTrue "IsLoaded should be true"
 
                     loaded.State.Messages |> Expect.equal "Messages should be empty" [||]
-                | Error _ -> failwith "expected Ok"
+                | Error _ -> failtest "expected Ok"
             }
         ]
 

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -12,7 +12,8 @@ open ServerApi
 /// No IResourceProvider, no network, no data loading.
 module StubAdapters =
 
-    let private notStubbed _ = failwith "not stubbed"
+    let private notStubbed _ =
+        raise (System.NotImplementedException "not stubbed")
 
 
     let formularyAlwaysOk (returnForm: Formulary) : FormularyPort =

--- a/tests/Informedica.GenSOLVER.Tests/Tests.fs
+++ b/tests/Informedica.GenSOLVER.Tests/Tests.fs
@@ -116,13 +116,13 @@ module TestSolver =
     let printEqs =
         function
         | Ok eqs -> eqs |> Solver.printEqs true procss
-        | Error _ -> failwith "errors"
+        | Error _ -> Expecto.Tests.failtest "errors"
 
 
     let printEqsWithUnits =
         function
         | Ok eqs -> eqs |> Solver.printEqs false procss
-        | Error _ -> failwith "errors"
+        | Error _ -> Expecto.Tests.failtest "errors"
 
 
     let setProp n p eqs =
@@ -534,7 +534,7 @@ module Tests =
                                             ]
                                         |> Variable.ValueRange.getIncr
                                         |> function
-                                            | None -> failwith "no incr"
+                                            | None -> failtest "no incr"
                                             | Some incr -> incr |> Expect.equal "should be 100" (create [| 100N |])
                                     }
 
@@ -553,7 +553,7 @@ module Tests =
                                              |> List.map (ValueUnit.singleWithUnit u >> Increment.create))
                                         |> Variable.ValueRange.getIncr
                                         |> function
-                                            | None -> failwith "no incr"
+                                            | None -> failtest "no incr"
                                             | Some incr ->
                                                 incr
                                                 |> Expect.equal
@@ -1126,7 +1126,7 @@ module Tests =
                         | "/" -> "div"
                         | "+" -> "add"
                         | "-" -> "sub"
-                        | _ -> failwith $"unknown op {opStr}"
+                        | _ -> failtest $"unknown op {opStr}"
 
                     validPermutations
                     |> List.mapi (scenarioToString op opStr)
@@ -2102,7 +2102,7 @@ module Tests =
                                          |> List.map (ValueUnit.singleWithUnit u >> Increment.create))
                                     |> fun v -> v.Values |> Variable.ValueRange.getIncr
                                     |> function
-                                        | None -> failwith "no incr"
+                                        | None -> failtest "no incr"
                                         | Some incr ->
                                             incr
                                             |> Expect.equal

--- a/tests/Informedica.GenUNITS.Tests/Tests.fs
+++ b/tests/Informedica.GenUNITS.Tests/Tests.fs
@@ -204,7 +204,7 @@ module Tests =
         | Ok exp -> res =? exp |> Expect.isTrue ""
         | _ ->
             false |> Expect.isTrue ""
-            failwith "can't run the test"
+            failtest "can't run the test"
 
         res
 
@@ -306,7 +306,7 @@ module Tests =
                     |> fromString
                     |> function
                         | Ok vu -> vu
-                        | Error err -> $"can't run this test: {err}" |> failwith
+                        | Error err -> $"can't run this test: {err}" |> failtest
                     |> toStringDutchShort
                     |> Expect.equal "should equal" "1 x[Count]/4 weken[Time]"
                 }
@@ -333,7 +333,7 @@ module Tests =
                     |> fromString
                     |> function
                         | Ok vu -> vu
-                        | Error err -> $"can't run this test: {err}" |> failwith
+                        | Error err -> $"can't run this test: {err}" |> failtest
                     |> toStringEngShort
                     |> Expect.equal "should equal" "3/2 mg[Mass]"
                 }
@@ -343,7 +343,7 @@ module Tests =
                     |> fromString
                     |> function
                         | Ok vu -> vu
-                        | Error err -> $"can't run this test: {err}" |> failwith
+                        | Error err -> $"can't run this test: {err}" |> failtest
                     |> toStringEngShort
                     |> Expect.equal "should equal" "1;3;5 x[Count]"
                 }
@@ -353,7 +353,7 @@ module Tests =
                     |> fromString
                     |> function
                         | Ok vu -> vu
-                        | Error err -> $"can't run this test: {err}" |> failwith
+                        | Error err -> $"can't run this test: {err}" |> failtest
                     |> toStringEngShort
                     |> Expect.equal "should equal" "1;3;5 x[Count]"
                 }
@@ -363,7 +363,7 @@ module Tests =
                     |> fromString
                     |> function
                         | Ok vu -> vu
-                        | Error err -> $"can't run this test: {err}" |> failwith
+                        | Error err -> $"can't run this test: {err}" |> failtest
                     |> toStringEngShort
                     |> Expect.equal "should equal" "10;20;30 mg[Mass]"
                 }
@@ -373,7 +373,7 @@ module Tests =
                     |> fromString
                     |> function
                         | Ok vu -> vu
-                        | Error err -> $"can't run this test: {err}" |> failwith
+                        | Error err -> $"can't run this test: {err}" |> failtest
                     |> toStringEngShort
                     |> Expect.equal "should equal" "1/2;1;3/2 mg[Mass]"
                 }
@@ -383,7 +383,7 @@ module Tests =
                     |> fromString
                     |> function
                         | Ok vu -> vu
-                        | Error err -> $"can't run this test: {err}" |> failwith
+                        | Error err -> $"can't run this test: {err}" |> failtest
                     |> toStringEngShort
                     |> Expect.equal "should equal" "120 stuk[General]"
                 }
@@ -393,7 +393,7 @@ module Tests =
                     |> fromString
                     |> function
                         | Ok vu -> vu
-                        | Error err -> $"can't run this test: {err}" |> failwith
+                        | Error err -> $"can't run this test: {err}" |> failtest
                     |> toStringEngShort
                     |> Expect.equal "should equal" "120 stuk[General]"
                 }
@@ -403,7 +403,7 @@ module Tests =
                     |> fromString
                     |> function
                         | Ok vu -> vu
-                        | Error err -> $"can't run this test: {err}" |> failwith
+                        | Error err -> $"can't run this test: {err}" |> failtest
                     |> toStringEngShort
                     |> Expect.equal "should equal" "1 stuk[General]"
                 }
@@ -413,7 +413,7 @@ module Tests =
                     |> fromString
                     |> function
                         | Ok vu -> vu
-                        | Error err -> $"can't run this test: {err}" |> failwith
+                        | Error err -> $"can't run this test: {err}" |> failtest
                     |> toStringEngShort
                     |> Expect.equal "should equal" "120;240;500 mg[Mass]/stuk[General]"
                 }
@@ -423,7 +423,7 @@ module Tests =
                     |> fromString
                     |> function
                         | Ok vu -> vu
-                        | Error err -> $"can't run this test: {err}" |> failwith
+                        | Error err -> $"can't run this test: {err}" |> failtest
                     |> toStringEngShort
                     |> Expect.equal "should equal" "10;20;30 tablet[General]"
                 }
@@ -433,7 +433,7 @@ module Tests =
                     |> fromString
                     |> function
                         | Ok vu -> vu
-                        | Error err -> $"can't run this test: {err}" |> failwith
+                        | Error err -> $"can't run this test: {err}" |> failtest
                     |> get
                     |> snd
                     |> Group.unitToGroup
@@ -445,7 +445,7 @@ module Tests =
                     |> fromString
                     |> function
                         | Ok vu -> vu
-                        | Error err -> $"can't run this test: {err}" |> failwith
+                        | Error err -> $"can't run this test: {err}" |> failtest
                     |> toStringEngShort
                     |> Expect.equal "should equal" "10 mg[Mass]/ml[Volume]"
                 }
@@ -455,7 +455,7 @@ module Tests =
                     |> fromString
                     |> function
                         | Ok vu -> vu
-                        | Error err -> $"can't run this test: {err}" |> failwith
+                        | Error err -> $"can't run this test: {err}" |> failtest
                     |> toStringEngShort
                     |> Expect.equal "should equal" "5 ml[Volume]/ampul[General]"
                 }
@@ -468,7 +468,7 @@ module Tests =
                     |> fromString
                     |> function
                         | Ok vu -> vu
-                        | Error err -> $"can't run this test: {err}" |> failwith
+                        | Error err -> $"can't run this test: {err}" |> failtest
                     |> Expect.equal "should equal original" original
                 }
 
@@ -477,7 +477,7 @@ module Tests =
                     |> fromString
                     |> function
                         | Ok vu -> vu
-                        | Error err -> $"can't run this test: {err}" |> failwith
+                        | Error err -> $"can't run this test: {err}" |> failtest
                     |> toStringEngShort
                     |> Expect.equal "should equal" "1;3;5 x[Count]"
                 }
@@ -487,7 +487,7 @@ module Tests =
                     |> fromString
                     |> function
                         | Ok vu -> vu
-                        | Error err -> $"can't run this test: {err}" |> failwith
+                        | Error err -> $"can't run this test: {err}" |> failtest
                     |> toStringEngShort
                     |> Expect.equal "should equal" "1/2;1;3/2 sachet[General]"
                 }
@@ -814,7 +814,7 @@ module Tests =
                     |> fromString
                     |> function
                         | Ok vu -> vu
-                        | Error err -> $"can't run this test: {err}" |> failwith
+                        | Error err -> $"can't run this test: {err}" |> failtest
                     |> getUnit
                     |> Group.unitToGroup
                     |> Expect.equal "kg should resolve to Weight" Group.WeightGroup

--- a/tests/Informedica.Logging.Tests/Tests.fs
+++ b/tests/Informedica.Logging.Tests/Tests.fs
@@ -823,14 +823,7 @@ module Tests =
                         (logger :> IDisposable).Dispose()
 
                         // Should not be able to use after disposal
-                        Expect.throws
-                            (fun () ->
-                                try
-                                    logger.Start None Level.Informative
-                                with exn ->
-                                    "should throw and exception" |> failwith
-                            )
-                            "should throw an exception"
+                        Expect.throws (fun () -> logger.Start None Level.Informative) "should throw an exception"
                     }
 
                 ]
@@ -879,7 +872,7 @@ module Tests =
                 [
 
                     testAsync "should handle formatter exceptions gracefully" {
-                        let badFormatter = fun (_: IMessage) -> failwith "Formatter error!"
+                        let badFormatter = fun (_: IMessage) -> invalidOp "Formatter error!"
 
                         let config =
                             { AgentLogging.AgentLoggerDefaults.config with Formatter = badFormatter }

--- a/tests/Informedica.Utils.Tests/Tests.fs
+++ b/tests/Informedica.Utils.Tests/Tests.fs
@@ -1029,7 +1029,7 @@ module Tests =
                             | [| cols; row1; _; _ |] ->
                                 let v = row1 |> Csv.getColumn<string> Csv.StringData cols |> (fun get -> get "c")
                                 Expect.equal "column c should be hello" v stringData
-                            | _ -> failwith "unexpected parseCSV result"
+                            | _ -> failtest "unexpected parseCSV result"
                     }
                 ]
 

--- a/tests/Informedica.ZIndex.Tests/ZIndexFixture.fs
+++ b/tests/Informedica.ZIndex.Tests/ZIndexFixture.fs
@@ -440,7 +440,7 @@ module ZIndexFixture =
     /// to the corresponding field length and concatenating.
     let private buildRecord (lens: int[]) (vals: string[]) =
         if lens.Length <> vals.Length then
-            failwith $"buildRecord: field count mismatch — expected {lens.Length}, got {vals.Length}"
+            invalidArg (nameof vals) $"buildRecord: field count mismatch — expected {lens.Length}, got {vals.Length}"
 
         Array.map2
             (fun (len: int) (v: string) ->


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #557 (which is stacked on #556).** Until those merge, the diff here shows the whole stack; review only the commit titled “test: replace failwith with failtest in test bodies”. Draft for that reason.

## Overview

Third and last implementation PR for #419, following the plan in #555 (categories T and T2). Closes #419.

- **T.** Test-body `failwith` becomes Expecto's `failtest` / `failtestf`, so a failed precondition is reported as a *failed* test rather than an *errored* one. 44 sites across `GenUNITS`, `GenORDER`, `GenCORE`, `GenSOLVER`, `GenFORM`, `Utils` and `Server` tests. As the plan notes, tests wrapped in `try ... with _ -> false` swallow `AssertException` just as they swallowed `Exception`, so those gain nothing and are converted for consistency only.
- **Fixture helpers** raise the type that fits: `FormatException` for a malformed BigRational token in `FixtureJson.fs`, `invalidArg` for the field-count mismatch in `ZIndexFixture.buildRecord`, `NotImplementedException` for the never-called stub adapter.
- **T2.** Tests that deliberately inject a crash through a boundary (`ResourceErrorTests` loader, `Logging.Tests` bad formatter, two `Agents.Tests` handlers) use `invalidOp` so they still exercise the generic catch path. The resource-loader one must stay generic; a `ResourceLoadError` would take the other branch of the handler under test.
- The `Logging.Tests` disposal test wrapped `failwith` *inside* an `Expect.throws` lambda, so the assertion passed because of the `failwith`, not the call under test. It now asserts on `logger.Start` directly.
- Two print helpers in the `GenSOLVER` `TestSolver` module qualify `Expecto.Tests.failtest` because a local `module Expecto` shadows the namespace there.

## Divergence from plan

None.

## Verification

- `dotnet run build`: succeeds.
- `dotnet run servertests`: all 16 test projects pass (1,519 tests).
- `grep -rnE '\bfailwith(f)?\b|\bexn "' --include='*.fs' src tests`: empty.
- `dotnet fantomas --check` clean on the changed files (`Agents.Tests/Tests.fs` is in `.fantomasignore`; its two one-token edits keep the existing layout).

## Author checklist

I confirm that these changes:

- [x] Follow the process described in [CONTRIBUTING.md](../../CONTRIBUTING.md#pull-request-process).
- [x] Make the changes proposed in the linked issue (if applicable): #419
- [x] Follow the approach documented in the linked implementation plan (if applicable): #555
- [x] Are no more than 200 lines of changed code, ideally 25-100.
- [x] Are not more complex than necessary.
- [x] Cannot easily be split in a way that would make reviewing them significantly easier.
- [x] Follow the guidelines specified in [DEVELOPMENT.md](../../DEVELOPMENT.md).
- [x] Have been thoroughly tested.
- [x] Don't introduce new security vulnerabilities.
- [ ] Follow the [AI/LLM Usage Policy](../../AGENTS.md#aillm-usage-policy) — LLMs were not given direct write access to `.fs` source files (except client-side UI code). **Not checked on purpose:** the LLM edited test `.fs` files directly, as an explicit exception granted by the maintainer for this issue (see the issue thread).

### AI/Vibe Coding Disclosure

- [x] Some or all code in this PR is **vibe coded** (substantially AI-generated). If checked, describe below which parts were AI-generated, which tool was used, and how the code was verified.

All edits were made by Claude Code (Claude Fable 5.1): whole-file `failwith` → `failtest` swaps in files where every site is a test body (site counts asserted before replacing), exact-string replacements elsewhere. Verified by the full Expecto suite and author review of the diff.

I confirm that I have:

- [x] Added appropriate automated tests. (This PR is the tests.)
- [x] Updated documentation appropriately. (n/a)
- [x] Added comments that highlight important changes and add justification, where necessary.

## Reviewer checklist

I confirm that:

- [x] I am confident that the changes work.
- [x] The changed code meets our guidelines and standards.
- [x] The new code is not more complex than necessary.
- [ ] I have clearly labeled suggestions as blocking, required but not blocking, or optional (see [CONTRIBUTING.md](../../CONTRIBUTING.md#pull-request-process)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012F5UZAxUhrSRGPgZcwsTYH
