### PR TITLE
Docs/378 dependency rule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,12 @@ jobs:
     - name: Format check
       run: dotnet fantomas --check .
 
+    - name: Check dependency rule
+      # Architecture fitness test for ADR-0022: project references point inward, the core reaches no
+      # IO, only the DMZ names GENPRES_* settings or declares entry points. Reads the .fsproj and
+      # source files only, so it needs no build and runs before the tests for fast feedback.
+      run: dotnet fsi scripts/CheckDependencyRule.fsx
+
     - name: Test execution
       env:
         CI: true

--- a/docs/adr/0001-system-architecture.md
+++ b/docs/adr/0001-system-architecture.md
@@ -23,7 +23,7 @@ an enforced rule, and by 2026 it did not hold: see
 [#378](https://github.com/informedica/GenPRES/issues/378). The rule that makes it hold — which
 projects form the core, that references point inward, how effects enter the core, and that the
 outer ring is the DMZ — is decided in [ADR-0022](0022-dependency-rule-and-effects.md) and
-enforced by `scripts/CheckDependencyRule.fsx`.
+checked by `scripts/CheckDependencyRule.fsx`, run by hand until its CI step lands.
 
 ## Consequences
 

--- a/docs/adr/0001-system-architecture.md
+++ b/docs/adr/0001-system-architecture.md
@@ -23,7 +23,7 @@ an enforced rule, and by 2026 it did not hold: see
 [#378](https://github.com/informedica/GenPRES/issues/378). The rule that makes it hold — which
 projects form the core, that references point inward, how effects enter the core, and that the
 outer ring is the DMZ — is decided in [ADR-0022](0022-dependency-rule-and-effects.md) and
-checked by `scripts/CheckDependencyRule.fsx`, run by hand until its CI step lands.
+enforced by `scripts/CheckDependencyRule.fsx`.
 
 ## Consequences
 

--- a/docs/adr/0001-system-architecture.md
+++ b/docs/adr/0001-system-architecture.md
@@ -1,7 +1,7 @@
 # ADR-0001: System Architecture
 
 **Date**: 2024-01-01
-**Status**: Accepted
+**Status**: Accepted, amended (2026-09-06)
 
 ## Context
 
@@ -16,9 +16,20 @@ Two further foundational choices follow from it and are recorded here because th
 - **Google Spreadsheets as the configuration store.** Medication rules and constraints are authored in spreadsheets, downloaded as CSV and parsed at runtime. This lets clinical staff maintain the rule base without a developer, at the cost of coupling the system to an external service. Note that `GENPRES_URL_ID` selects the *server's* sheet only; the client reads a few of its own sheets from IDs hard-coded in `Client/Utils.fs`, so it is not a single switch over all sheet-sourced data.
 - **Docker as the production delivery mechanism.**
 
+### Domain purity — amended 2026-09-06
+
+The consequence below that "server-side F# domain libraries remain pure" was an intention, not
+an enforced rule, and by 2026 it did not hold: see
+[#378](https://github.com/informedica/GenPRES/issues/378). The rule that makes it hold — which
+projects form the core, that references point inward, how effects enter the core, and that the
+outer ring is the DMZ — is decided in [ADR-0022](0022-dependency-rule-and-effects.md) and
+enforced by `scripts/CheckDependencyRule.fsx`.
+
 ## Consequences
 
-- Server-side F# domain libraries remain pure and testable independent of the UI.
+- Server-side F# domain libraries are meant to be pure and testable independent of the UI. What
+  "pure" means and how it is enforced is decided in
+  [ADR-0022](0022-dependency-rule-and-effects.md).
 - Client code (Fable/Elmish) compiles to JavaScript and runs in the browser.
 - Client and server share one type-safe contract through Fable.Remoting, so an API change that breaks a caller fails at compile time rather than at runtime.
 - Editing a production spreadsheet changes the behavior of a running system with no deployment, which is the point — and the risk. It is not instantaneous, though: the server holds resources in a `CachedResourceProvider` with no expiry, so an edit takes effect only after an admin `ReloadResources` (or a restart), and the client's own hard-coded sheets are separate again.

--- a/docs/adr/0009-mcp-server-architecture.md
+++ b/docs/adr/0009-mcp-server-architecture.md
@@ -59,7 +59,7 @@ Only `GenFORM.Lib` and `GenORDER.Lib` are exposed. The others are deliberately n
 | `Informedica.GenSOLVER.Lib` | Pure mathematical solver; results only meaningful in the context of a full order — covered by GenORDER tools |
 | `Informedica.GenUNITS.Lib` | Pure unit-of-measure utilities; not a domain service |
 | `Informedica.GenCORE.Lib` | Core type definitions only |
-| `Informedica.Utils.Lib` | Pure utility functions |
+| `Informedica.Utils.Lib` | Utility functions; not a domain service (its IO half is being split out, see [ADR-0022](0022-dependency-rule-and-effects.md)) |
 | `Informedica.GenPRES.Server` | Already exposes the full API via `IServerApi`; MCP is an additional pathway, not a replacement |
 
 ## Dependencies

--- a/docs/adr/0022-dependency-rule-and-effects.md
+++ b/docs/adr/0022-dependency-rule-and-effects.md
@@ -1,0 +1,138 @@
+# ADR-0022: Dependency Rule and Effects
+
+**Date**: 2026-09-06
+
+**Status**: Proposed
+
+**Related Issues**: [#378 — Change project architecture](https://github.com/informedica/GenPRES/issues/378),
+[#416 — Standard logging library](https://github.com/informedica/GenPRES/issues/416),
+[#523](https://github.com/informedica/GenPRES/issues/523) and
+[#526](https://github.com/informedica/GenPRES/issues/526) — IO in a type initializer broke test discovery
+
+## Context
+
+[ADR-0001](0001-system-architecture.md) states as a consequence that "server-side F# domain
+libraries remain pure and testable independent of the UI". Nothing enforces it, and it is not
+true today: the formulary library fetches Google Sheets and a third-party website, the logging
+library bundles a file-writing agent that every domain library references, and the order and
+patient libraries read the clock. In [#378](https://github.com/informedica/GenPRES/issues/378)
+the project dependency graph was drawn and two edges were questioned: `GenFORM.Lib → ZForm.Lib`
+and `Logging.Lib` sitting in the core. The question "are ZIndex and ZForm part of the domain
+model?" was left open. [#523](https://github.com/informedica/GenPRES/issues/523) and
+[#526](https://github.com/informedica/GenPRES/issues/526) showed the cost of an unstated rule: a
+network fetch and a file read in module initializers poisoned type initialization for the whole
+test assembly.
+
+The code already contains the mechanisms a pure core needs, used correctly in places: the
+`Logger` record of functions passed as a parameter, the function-valued `GStandProvider`
+resource, the `ofResult` / `derive` resource registry, and the server's `AppEnv` record of ports.
+What is missing is the decision that makes them the rule rather than the exception.
+
+## Decision
+
+### 1. Dependencies point inward
+
+Every project in `GenPRES.sln` belongs to one ring. A project may reference only its own ring or
+a ring further in. The ring of a project is decided by behaviour, not by name: a library that
+reads an external source, the filesystem, the process environment, the clock or entropy, or that
+configures itself from an environment variable, is an adapter and belongs to the outer ring.
+
+The core is the domain: units, patient, solver, operational knowledge rules, orders, interactions.
+Core projects contain no call that reaches outside the process. Core projects do not read
+configuration; they receive values.
+
+### 2. ZIndex, ZForm, NKF and FTK are adapters
+
+They parse external sources (the G-Standaard files, the Kinderformularium website, the
+Farmacotherapeutisch Kompas) into source-shaped records and configure themselves from the
+environment. The domain owns the contract types it consumes (products, G-Standaard dose rules);
+the adapters reference the domain and produce those types, never the reverse. This answers the
+open question in #378.
+
+### 3. Effects enter the core as explicit parameters
+
+A domain function that needs an effect receives it: a `Logger` record, a `now` value, a `newId`
+function, a function-valued resource such as `GStandProvider`, or a record of functions such as
+the server's `AppEnv`. Resources are declared in the registry and resolved once by the
+composition root. There is exactly one composition root per executable (the Fable.Remoting server
+and the MCP host), and only composition roots construct loggers, providers and caches. No
+computation-expression interpreter, dependency-injection container or logging framework is
+referenced from the core.
+
+The known exception is `GStandProvider`: a domain function calls an injected function whose live
+implementation reads the G-Standaard on first use. It is accepted because the port is total and
+stubbable, and pre-loading every G-Standaard rule for every generic would cost startup time and
+memory that has not been justified.
+
+### 4. The outer ring is the DMZ
+
+The server-side outer ring — the server, the MCP host, the adapters, and the IO half of the
+utilities — is the demilitarized zone of GenPRES. It is the only ring that references the network,
+the filesystem, the environment, the clock and entropy. It owns every `GENPRES_*` setting and
+passes values inward. It hosts authentication, rate limiting, security headers and audit logging,
+in one place per concern. It declares the only entry points. It parses at every ingress — the
+browser, the MCP client, and the Google Sheets that hold the rule base — so that malformed or
+unavailable input becomes an `Error` at the edge, never an empty collection inside the core.
+
+The Fable client runs on a machine the device does not control and is outside the DMZ. It may run
+pure calculations for display. It does not compute a dose that is presented as advice, and it does
+not fetch rule data on its own; both cross the DMZ through the server.
+
+### 5. Enforcement
+
+`scripts/CheckDependencyRule.fsx` holds the ring map and checks, for every project in the
+solution, that references point inward, that core sources contain no call that reaches outside,
+that only the DMZ names a `GENPRES_*` setting, and that only the DMZ declares an entry point. The
+violations that exist at the time of this decision are listed in the script as allowances, each
+with a reason. An allowance that no longer matches fails the run, so the list can only shrink.
+The migration is planned in `docs/implementation-plans/378-dependency-rule.md`.
+
+## Consequences
+
+- One adapter project appears to receive the Google-Sheets loaders, the caching resource
+  provider, and the mapping from G-Standaard records to domain contract types. The logging
+  library keeps the `Logger` port and loses the agent runtime, which moves next to the agents.
+- Public signatures in the core gain parameters (`now`, `newId`) where they used ambient values.
+  Structural equality tests on constructed orders become possible.
+- The emergency-list and continuous-medication pages, which today fetch their sheets and compute
+  doses in the browser, will route through the server. That changes a dosing path and needs its
+  own issue and validation; it is the last step of the migration, not the first.
+- The MCP host composes the same ports as the server instead of its own singletons, and stops
+  setting environment variables.
+- A change that violates the rule fails the fitness test in CI; the reviewer points at this ADR
+  instead of arguing from taste.
+
+## Alternatives considered
+
+- **Domain workflows as a `program` computation expression over an instruction set, interpreted
+  at the edge** (the "Safe Clean Architecture" approach proposed in #194 and #226, closed without
+  discussion). Rejected: it adds an interpreter between the solver and its callers on the path the
+  project has spent effort making fast, it makes the effect boundary harder for a clinical
+  reviewer to read than an explicit parameter list, and the code base already has three working
+  mechanisms for the same purpose.
+- **Treat ZIndex and ZForm as domain.** Rejected: their records are shaped like the G-Standaard
+  tables, they decide demo versus production by reading `GENPRES_PROD` themselves, and the
+  formulary library maps their output to its own `ProductComponent` on first contact — the
+  signature of an adapter.
+- **Merge `Logging.Lib` and `Utils.Lib` into one foundation project** (the original proposal in
+  #378). Rejected: it would make the file-writing agent a permanent dependency of every core
+  library, the opposite of the rule.
+- **A standard logging framework referenced from the core** (#416). Rejected: the core's port is a
+  two-field record; which framework implements it is a decision for the composition root and can
+  change without touching the domain.
+- **Leave the rule unwritten and rely on review.** Rejected: ADR-0001's consequence line has been
+  unenforced since it was written, and #523 and #526 were the result.
+
+## References
+
+- [ADR-0000: Documentation Rules](0000-documentation-rules.md) — why this is an ADR and the
+  inventory is not
+- [ADR-0001: System Architecture](0001-system-architecture.md) — amended to point here
+- [ADR-0009: MCP Server Architecture](0009-mcp-server-architecture.md) — the second entry point
+- [ADR-0019: Shared Clinical Calculations](0019-shared-clinical-calculations.md) — pure formulas
+  may be shared with the client; that decision stands
+- `scripts/CheckDependencyRule.fsx` — the ring map and the fitness test
+- `docs/implementation-plans/378-dependency-rule.md` — the migration
+- Mark Seemann, [Impureim sandwich](https://blog.ploeh.dk/2020/03/02/impureim-sandwich/)
+- Romain Deneau, [Safe Clean Architecture](https://github.com/rdeneau/gitbook-safe-clean-archi)
+- Jeffrey Palermo, [The Onion Architecture](https://jeffreypalermo.com/2008/07/the-onion-architecture-part-1/)

--- a/docs/adr/0022-dependency-rule-and-effects.md
+++ b/docs/adr/0022-dependency-rule-and-effects.md
@@ -85,7 +85,9 @@ solution, that references point inward, that core sources contain no call that r
 that only the DMZ names a `GENPRES_*` setting, and that only the DMZ declares an entry point. The
 violations that exist at the time of this decision are listed in the script as allowances, each
 with a reason. An allowance that no longer matches fails the run, so the list can only shrink.
-The migration is planned in `docs/implementation-plans/378-dependency-rule.md`.
+The script is run by hand today (`dotnet fsi scripts/CheckDependencyRule.fsx`); adding it as a
+CI step is the first phase of the migration, planned in
+`docs/implementation-plans/378-dependency-rule.md`.
 
 ## Consequences
 
@@ -99,8 +101,8 @@ The migration is planned in `docs/implementation-plans/378-dependency-rule.md`.
   own issue and validation; it is the last step of the migration, not the first.
 - The MCP host composes the same ports as the server instead of its own singletons, and stops
   setting environment variables.
-- A change that violates the rule fails the fitness test in CI; the reviewer points at this ADR
-  instead of arguing from taste.
+- A change that violates the rule fails the fitness test — in CI once its step lands, by hand
+  until then — and the reviewer points at this ADR instead of arguing from taste.
 
 ## Alternatives considered
 

--- a/docs/adr/0022-dependency-rule-and-effects.md
+++ b/docs/adr/0022-dependency-rule-and-effects.md
@@ -85,9 +85,7 @@ solution, that references point inward, that core sources contain no call that r
 that only the DMZ names a `GENPRES_*` setting, and that only the DMZ declares an entry point. The
 violations that exist at the time of this decision are listed in the script as allowances, each
 with a reason. An allowance that no longer matches fails the run, so the list can only shrink.
-The script is run by hand today (`dotnet fsi scripts/CheckDependencyRule.fsx`); adding it as a
-CI step is the first phase of the migration, planned in
-`docs/implementation-plans/378-dependency-rule.md`.
+The migration is planned in `docs/implementation-plans/378-dependency-rule.md`.
 
 ## Consequences
 
@@ -101,8 +99,8 @@ CI step is the first phase of the migration, planned in
   own issue and validation; it is the last step of the migration, not the first.
 - The MCP host composes the same ports as the server instead of its own singletons, and stops
   setting environment variables.
-- A change that violates the rule fails the fitness test — in CI once its step lands, by hand
-  until then — and the reviewer points at this ADR instead of arguing from taste.
+- A change that violates the rule fails the fitness test in CI; the reviewer points at this ADR
+  instead of arguing from taste.
 
 ## Alternatives considered
 

--- a/docs/implementation-plans/378-dependency-rule.md
+++ b/docs/implementation-plans/378-dependency-rule.md
@@ -1,0 +1,171 @@
+# Implementation plan for issue #378
+
+## Problem description
+
+[#378](https://github.com/informedica/GenPRES/issues/378): GenPRES is meant to be an onion — a
+pure domain core, all IO at the outer edge, the domain never depending on IO — but two project
+references point outward (`GenFORM.Lib → ZForm.Lib → ZIndex.Lib`, `Logging.Lib → Agents.Lib`),
+the formulary library owns its own Google-Sheets loaders and cache, the core reads the clock and
+entropy, and the browser fetches rule data and computes emergency doses on its own. The rule is
+decided in [ADR-0022](../adr/0022-dependency-rule-and-effects.md); the inventory of violations is
+the allow-list in `scripts/CheckDependencyRule.fsx`. This plan is the order in which the
+allow-list shrinks.
+
+Each step is classified for validation, because this is medical device software:
+
+- **A** — no observable behaviour change (moves, signatures, references). Verified by the existing
+  test suite plus a before/after diff of the `Export` dose-check output and one recorded order
+  scenario.
+- **B** — failure-path behaviour changes only (an error is no longer swallowed). Verified by
+  error-path tests.
+- **C** — a dosing or data path changes. Needs validation in the MDR documentation repository
+  before release; its own issue, done last.
+
+## Approaches considered
+
+1. **Explicit parameters and function-valued ports** (impureim sandwich): keep the `Logger`
+   record, `IResourceProvider`, `GStandProvider`, the registry and the server's `AppEnv`; move
+   what is misplaced; add `now` / `newId` parameters. Chosen.
+2. **A `program` computation expression over an instruction set, interpreted at the edge**
+   (the approach of #194 and #226). Rejected in ADR-0022: interpreter on the solver's hot path,
+   less readable effect boundary, a fourth mechanism next to three that work.
+3. **Consolidate projects first** (`Logging` + `Utils` into a foundation project, as #378
+   originally proposed). Rejected: merging the agent runtime into the utilities every core library
+   references would cement the dependency this plan removes.
+
+## Chosen approach
+
+Option 1, in phases that each leave the build green and the fitness test green with a shorter
+allow-list. Pull requests stay under 200 changed lines; phases with more work are split into
+several PRs. All non-UI code is prototyped in `.fsx` scripts first and migrated by the maintainer
+(script-only policy in `AGENTS.md`).
+
+Target ring assignment (also the ring map in the fitness test):
+
+| Ring | Projects |
+| ---- | -------- |
+| Core | Utils (pure half), Logging (port only), GenUNITS, GenCORE, GenSOLVER, GenFORM, GenORDER, GenINTERACT |
+| Infrastructure (DMZ) | Utils IO half, Agents, ZIndex, ZForm, NKF, FTK, a new adapter project (working name `Informedica.GenPRES.Data.Lib`) |
+| Presentation (DMZ entry) | Server, MCP.Lib, MCP.Server |
+| Contract | Shared |
+| Outside the DMZ | Client |
+| Tooling, outside the runtime onion | NLP |
+
+## Confidence
+
+High for phases 0 to 5: they move code and add parameters, and the fitness test plus the existing
+suites catch regressions. Medium for phase 6: moving browser-side dosing behind the server changes
+a clinical path and the validation effort is not yet scoped.
+
+## Steps
+
+### Phase 0 — land the rule (A, docs and deletions)
+
+1. Delete the dead `getDataFromGenPres` in `src/Informedica.GenORDER.Lib/Utils.fs` (mutates the
+   process environment; no caller), the dead `GenPresProduct` / `GenericProduct` aliases in
+   `src/Informedica.GenFORM.Lib/DoseRule.fs`, and the unreferenced top-level `agentLogger` in
+   `src/Informedica.GenFORM.Lib/FormLogging.fs` (a top-level value that starts a
+   `MailboxProcessor` — the pattern of #523).
+2. Confirm the type-initialization "warm-up" in `src/Informedica.GenFORM.Lib/DoseRuleLoader.fs`
+   is unnecessary now that ZIndex loads lazily (#526), and delete it.
+3. Land `scripts/CheckDependencyRule.fsx` and a `CheckArchitecture` FAKE target in `Build.fs`
+   next to `CheckVersions`, run in CI:
+
+   ```fsharp
+   Target.create "CheckArchitecture" (fun _ -> run dotnet [ "fsi"; "scripts/CheckDependencyRule.fsx" ] ".")
+   ```
+
+4. Land ADR-0022 and the ADR-0001 amendment; answer the open question on #378.
+
+### Phase 1 — logging inversion (A)
+
+1. Split `src/Informedica.Logging.Lib/Logging.fs`: the `Logger` record, `Event`, `Level`,
+   `Message`, `noOp`, `create`, `combine` and `logLazy` stay; `createConsole`, `createFile` and
+   `AgentLogging` move into `Informedica.Agents.Lib`. Flip the reference so `Agents.Lib →
+   Logging.Lib`. The sink stamps the timestamp, so `createMessage` stops reading `DateTime.Now`.
+2. Move `SolverLogging.createAgentLogger` / `createFileLogger` and `OrderLogging.create*Logger`
+   into `src/Informedica.GenPRES.Server/Logging.fs` and an MCP equivalent. Formatters stay in
+   the libraries.
+3. Replace every console write below the injected `Logger` with a `Logger` call, one project per
+   PR: GenSOLVER (`Solver.fs`, `Variable.fs`, `Equation.fs`), GenORDER (`Order.fs`,
+   `OrderVariable.fs`, `Medication.fs`, `OrderProcessor.fs`, `Api.fs`, `Exceptions.fs`,
+   `Nutrition.fs`), GenFORM (`Product.fs`, `RenalRule.fs`, `Resources.fs`), GenUNITS
+   (`UnitsParse.fs`, `ValueUnit.fs`), Utils (`Json.fs`, `BCL/*.fs`).
+
+### Phase 2 — evict IO from GenFORM and Utils into the adapter project (A, one B)
+
+1. Create the adapter project referencing GenFORM, GenINTERACT, ZForm and the IO half of Utils.
+   Move `src/Informedica.GenFORM.Lib/SourceLoader.fs` (top-level `HttpClient`, hard-coded
+   kinderformularium.nl) and the `nkfLinkProvider` registry entry.
+2. Move the sheet-reading halves of `Mapping.fs`, `Product.fs`, `DoseRuleLoader.fs`,
+   `SolutionRule.fs` and `RenalRule.fs`; the parsers stay in GenFORM and take `string[][]`.
+   Replace the `Result.defaultValue [||]` in `src/Informedica.GenFORM.Lib/Utils.fs`
+   (`getDataFromSheet`) with a real `Error` — **B**, and the point of the exercise: an unavailable
+   rule sheet must not read as "no rules".
+3. Move `defaultRegistry`, `loadAllResources`, `CachedResourceProvider`,
+   `Api.getCachedProviderWithDataUrlId` and `Api.reloadCache` (the downcast of the port
+   disappears with them). GenFORM keeps `Keys`, `IResourceProvider`, `ofResult`, `derive`,
+   `LoadEngine`. `Server.fs` and `MCP.Server/Program.fs` reference the adapter project.
+4. Move the `None` branch of `src/Informedica.GenINTERACT.Lib/Data.fs` (cwd-relative file read)
+   and the cwd-relative export write in `src/Informedica.GenFORM.Lib/Export.fs`.
+5. Split `Informedica.Utils.Lib`: `Web.fs`, `File.fs`, `Env.fs`, `App.fs`, `AppPath.fs`,
+   `Console.fs`, `StopWatch.fs` move to an IO project (or into the adapter project). `Path.fs`
+   stays (string helpers only).
+
+### Phase 3 — invert `GenFORM → ZForm → ZIndex` (A, the riskiest A)
+
+1. Define a GenFORM-owned G-Standaard dose-rule contract carrying only what
+   `src/Informedica.GenFORM.Lib/Check.fs` reads (route, indications and dosages, patient
+   category age in months, the single/start dosage norm and absolute ranges, frequencies).
+   Retype `GStandProvider`, `filterPatient` and `matchWithZIndex`; implement the ZForm-to-contract
+   mapping in the adapter project. Verify with the dose-check tests and a golden diff of the
+   `Export` check output. Split the contract-type PR from the retyping PR.
+2. Define a GenFORM-owned source-product contract for what `Product.fromGenPresProducts` and
+   `filterGenPresProductsByData` read from `GenPresProduct` / `GenericProduct` /
+   `ProductSubstance`; mapping in the adapter; delete the impure `Product.get`; retype the
+   `GenPresProducts` field of `Resources.Data` and `Keys.genPresProducts`.
+3. Remove the `ZForm.Lib` reference from `Informedica.GenFORM.Lib.fsproj`, add `GenCORE.Lib`.
+   ZForm's `Web.getDataFromSheet` and ZIndex's `FilePath.useDemo` take `urlId` / `useDemo` as
+   values from the adapter instead of reading the environment. The reference allow-list in the
+   fitness test becomes empty.
+
+### Phase 4 — non-determinism in the core (A)
+
+1. `src/Informedica.GenCORE.Lib/Patient.fs`: the six `DateTime.Now` sites become a `now`
+   parameter (age from birth date, DTO defaults, date validation).
+2. `src/Informedica.GenORDER.Lib/Order.fs` (`DateTime.Now` in `StartStop.Start`) and
+   `Medication.fs` (`Guid.NewGuid()` in the constructor): supplied by the caller.
+   `Environment.ProcessorCount` stays allow-listed; it sizes chunks and never a result.
+
+### Phase 5 — DMZ consolidation at the edge (A, security-relevant)
+
+1. One authentication path in `src/Informedica.GenPRES.Server/ServerApi.Command.fs`; retire the
+   raw-password comparison in `ServerApi.Services.fs` (`ReloadResources`).
+2. The `GENPRES_PROD` read in `ServerApi.Services.fs` (`setDemoVersion`) and the module-level
+   `provider` in `Server.fs` (`Async.RunSynchronously` at assembly load) move into
+   `ServerApi.CompositionRoot.fs`.
+3. `src/Informedica.MCP.Server/Program.fs` stops setting `GENPRES_PROD`, `GENPRES_DEBUG` and
+   `CurrentDirectory`; `Informedica.MCP.Lib` composes the same `AppEnv` and mappers as the
+   server instead of two `static let mutable` provider singletons. This may need the ports,
+   adapters, services and mappers extracted from the server into an application project; if so,
+   its own issue.
+
+### Phase 6 — the client and Shared (the only C items; last)
+
+1. (A/B) Serve the eight sheets the client fetches today (`src/Informedica.GenPRES.Client/Utils.fs`:
+   emergency list, continuous medications, products, localization, growth charts) as registry
+   resources through a new port; the client fetches them via Fable.Remoting. Remove
+   `docs.google.com` from the CSP in `Server.fs`. Formulas still run in the browser, so the
+   dosing output is unchanged; only the data path moves inside the DMZ.
+2. (test) A property test asserting that `Shared/Calculations.fs` and `GenCORE/Calculations.fs`
+   agree within tolerance for BSA, adjusted age, eGFR and GFR staging. ADR-0019 stands; the test
+   guards against divergence.
+3. (**C**) Move `EmergencyTreatment.calculate` and `ContinuousMedication.calculate` from
+   `src/Informedica.GenPRES.Shared/Models.fs` behind a server port, and replace the
+   hospital-specific special case in `ContinuousMedication.calculate` with configuration. Own
+   issue; MDR validation.
+4. (**C**) Move the `NutritionDoseRuleSet` literals in `ServerApi.Services.fs` to a sheet loaded
+   through the resource provider. Own issue.
+
+Suggested: one child issue per phase, so that each PR closes an issue and this plan can be removed
+when #378 closes.

--- a/docs/implementation-plans/378-dependency-rule.md
+++ b/docs/implementation-plans/378-dependency-rule.md
@@ -68,12 +68,10 @@ a clinical path and the validation effort is not yet scoped.
    `MailboxProcessor` — the pattern of #523).
 2. Confirm the type-initialization "warm-up" in `src/Informedica.GenFORM.Lib/DoseRuleLoader.fs`
    is unnecessary now that ZIndex loads lazily (#526), and delete it.
-3. Land `scripts/CheckDependencyRule.fsx` and a `CheckArchitecture` FAKE target in `Build.fs`
-   next to `CheckVersions`, run in CI:
-
-   ```fsharp
-   Target.create "CheckArchitecture" (fun _ -> run dotnet [ "fsi"; "scripts/CheckDependencyRule.fsx" ] ".")
-   ```
+3. Run `scripts/CheckDependencyRule.fsx` on every CI build: a step in
+   `.github/workflows/build.yml` before the tests, calling the script directly the way
+   `CheckSolutionVersions.fsx` is called, so no `Build.fs` change is needed. Optionally add a
+   `CheckArchitecture` FAKE target for local use, mirroring `CheckVersions`.
 
 4. Land ADR-0022 and the ADR-0001 amendment; answer the open question on #378.
 

--- a/docs/implementation-plans/378-dependency-rule.md
+++ b/docs/implementation-plans/378-dependency-rule.md
@@ -68,18 +68,12 @@ a clinical path and the validation effort is not yet scoped.
    `MailboxProcessor` — the pattern of #523).
 2. Confirm the type-initialization "warm-up" in `src/Informedica.GenFORM.Lib/DoseRuleLoader.fs`
    is unnecessary now that ZIndex loads lazily (#526), and delete it.
-3. Run `scripts/CheckDependencyRule.fsx` in CI: a step in `.github/workflows/build.yml` next to
-   the one that runs `CheckSolutionVersions.fsx`, calling the script directly so no `Build.fs`
-   change is needed:
+3. Land `scripts/CheckDependencyRule.fsx` and a `CheckArchitecture` FAKE target in `Build.fs`
+   next to `CheckVersions`, run in CI:
 
-   ```yaml
-   - name: Check dependency rule
-     run: dotnet fsi scripts/CheckDependencyRule.fsx
+   ```fsharp
+   Target.create "CheckArchitecture" (fun _ -> run dotnet [ "fsi"; "scripts/CheckDependencyRule.fsx" ] ".")
    ```
-
-   The script has only run on macOS so far; the first CI run proves the path handling on Windows
-   and Linux. Optionally add a `CheckArchitecture` FAKE target for local use, mirroring
-   `CheckVersions`.
 
 4. Land ADR-0022 and the ADR-0001 amendment; answer the open question on #378.
 

--- a/docs/implementation-plans/378-dependency-rule.md
+++ b/docs/implementation-plans/378-dependency-rule.md
@@ -68,12 +68,18 @@ a clinical path and the validation effort is not yet scoped.
    `MailboxProcessor` — the pattern of #523).
 2. Confirm the type-initialization "warm-up" in `src/Informedica.GenFORM.Lib/DoseRuleLoader.fs`
    is unnecessary now that ZIndex loads lazily (#526), and delete it.
-3. Land `scripts/CheckDependencyRule.fsx` and a `CheckArchitecture` FAKE target in `Build.fs`
-   next to `CheckVersions`, run in CI:
+3. Run `scripts/CheckDependencyRule.fsx` in CI: a step in `.github/workflows/build.yml` next to
+   the one that runs `CheckSolutionVersions.fsx`, calling the script directly so no `Build.fs`
+   change is needed:
 
-   ```fsharp
-   Target.create "CheckArchitecture" (fun _ -> run dotnet [ "fsi"; "scripts/CheckDependencyRule.fsx" ] ".")
+   ```yaml
+   - name: Check dependency rule
+     run: dotnet fsi scripts/CheckDependencyRule.fsx
    ```
+
+   The script has only run on macOS so far; the first CI run proves the path handling on Windows
+   and Linux. Optionally add a `CheckArchitecture` FAKE target for local use, mirroring
+   `CheckVersions`.
 
 4. Land ADR-0022 and the ADR-0001 amendment; answer the open question on #378.
 

--- a/scripts/CheckDependencyRule.fsx
+++ b/scripts/CheckDependencyRule.fsx
@@ -1,0 +1,558 @@
+// Check Dependency Rule
+//
+// Architecture fitness test for ADR-0022 (docs/adr/0022-dependency-rule-and-effects.md):
+// project references point inward, the core never reaches network, filesystem,
+// environment, clock or entropy, and only the DMZ (the server-side outer ring) knows
+// configuration and owns entry points.
+//
+// The ring map below is the authoritative ring assignment of every project in
+// GenPRES.sln. The allow-lists are the inventory of today's violations; each entry
+// names a reason and is a ratchet: an entry that no longer matches anything fails the
+// run, so the list can only shrink. Add an entry only with a reason and an issue.
+//
+// Run with: dotnet fsi scripts/CheckDependencyRule.fsx
+// Prototype per the script-only policy in AGENTS.md; no build is required.
+
+#r "nuget: Expecto"
+
+open System
+open System.IO
+open System.Text.RegularExpressions
+open Expecto
+open Expecto.Flip
+
+
+let repoRoot = Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, ".."))
+
+
+// ---------------------------------------------------------------------------
+// Rings
+// ---------------------------------------------------------------------------
+
+/// The onion, outermost last. `Client` runs on an untrusted machine and is
+/// outside the DMZ; `Tooling` is the extraction pipeline, outside the runtime onion.
+[<RequireQualifiedAccess>]
+type Ring =
+    | Core
+    | Contract
+    | Infrastructure
+    | Presentation
+    | Client
+    | Tooling
+
+
+/// Which rings a project in a given ring may reference. Core references only core;
+/// the DMZ (Infrastructure, Presentation) may reach inward; the Client sees only the
+/// contract.
+let mayReference (from: Ring) (target: Ring) =
+    match from, target with
+    | Ring.Core, Ring.Core -> true
+    | Ring.Contract, Ring.Contract -> true
+    | Ring.Infrastructure, (Ring.Core | Ring.Infrastructure) -> true
+    | Ring.Presentation, (Ring.Core | Ring.Contract | Ring.Infrastructure | Ring.Presentation) -> true
+    | Ring.Client, Ring.Contract -> true
+    | Ring.Tooling, (Ring.Core | Ring.Infrastructure | Ring.Tooling) -> true
+    | _ -> false
+
+
+/// Target ring of every project in `src/`. A project not listed here fails the run.
+let rings =
+    Map.ofList
+        [
+            "Informedica.Utils.Lib", Ring.Core
+            "Informedica.Logging.Lib", Ring.Core
+            "Informedica.GenUNITS.Lib", Ring.Core
+            "Informedica.GenCORE.Lib", Ring.Core
+            "Informedica.GenSOLVER.Lib", Ring.Core
+            "Informedica.GenFORM.Lib", Ring.Core
+            "Informedica.GenORDER.Lib", Ring.Core
+            "Informedica.GenINTERACT.Lib", Ring.Core
+            "Informedica.GenPRES.Shared", Ring.Contract
+            "Informedica.Agents.Lib", Ring.Infrastructure
+            "Informedica.ZIndex.Lib", Ring.Infrastructure
+            "Informedica.ZForm.Lib", Ring.Infrastructure
+            "Informedica.NKF.Lib", Ring.Infrastructure
+            "Informedica.FTK.Lib", Ring.Infrastructure
+            "Informedica.GenPRES.Server", Ring.Presentation
+            "Informedica.MCP.Lib", Ring.Presentation
+            "Informedica.MCP.Server", Ring.Presentation
+            "Informedica.GenPRES.Client", Ring.Client
+            "Informedica.NLP.Lib", Ring.Tooling
+        ]
+
+
+let isDmz ring =
+    match ring with
+    | Ring.Infrastructure
+    | Ring.Presentation -> true
+    | _ -> false
+
+
+// ---------------------------------------------------------------------------
+// Allow-lists: the inventory of today's violations. Every entry must still match.
+// ---------------------------------------------------------------------------
+
+/// A project reference that points outward today. Removed when the reference is
+/// inverted (issue #378).
+let allowedReferences =
+    [
+        "Informedica.Logging.Lib",
+        "Informedica.Agents.Lib",
+        "Logging.Lib bundles the Logger port with the agent runtime; split pending (#378, #416)"
+        "Informedica.GenFORM.Lib",
+        "Informedica.ZForm.Lib",
+        "GenFORM consumes G-Standaard types from the ZForm/ZIndex adapters; contract types pending (#378)"
+    ]
+
+
+/// A core source file that reaches outside. `Token = None` allows the whole file
+/// (an IO module awaiting eviction); `Token = Some t` allows one banned token in it.
+type Allowance =
+    {
+        File: string
+        Token: string option
+        Reason: string
+    }
+
+
+let allowFile file reason =
+    {
+        File = file
+        Token = None
+        Reason = reason
+    }
+
+
+let allowToken file token reason =
+    {
+        File = file
+        Token = Some token
+        Reason = reason
+    }
+
+
+/// Tokens a core project may not contain outside comments. Matched on a word
+/// boundary before the token, so `AppEnv.` does not match `Env.`.
+let bannedTokens =
+    [
+        "System.IO"
+        "System.Net"
+        "HttpClient"
+        "Environment.GetEnvironmentVariable"
+        "Environment.SetEnvironmentVariable"
+        "Environment.GetEnvironmentVariables"
+        "Environment.CurrentDirectory"
+        "Environment.ProcessorCount"
+        "Environment.MachineName"
+        "Environment.UserName"
+        "AppDomain.CurrentDomain"
+        "AppContext.BaseDirectory"
+        "DateTime.Now"
+        "DateTime.UtcNow"
+        "DateTimeOffset.Now"
+        "DateTimeOffset.UtcNow"
+        "Guid.NewGuid"
+        "Console."
+        "ConsoleWriter"
+        "writeErrorMessage"
+        "writeWarningMessage"
+        "writeInfoMessage"
+        "writeDebugMessage"
+        "printfn"
+        "eprintfn"
+        "File."
+        "Directory."
+        "Web."
+        "Env."
+        "AppPath"
+        "StopWatch."
+        "Stopwatch"
+        "Async.RunSynchronously"
+        "Memoization.memoize"
+        "MailboxProcessor"
+        "FileWriterAgent"
+        "AgentLogging"
+    ]
+
+
+/// Phase numbers refer to docs/implementation-plans/378-dependency-rule.md.
+/// "Permanent" entries are accepted exceptions recorded in ADR-0022.
+let allowances =
+    let utilsSplit = "IO module in Utils.Lib; leaves the core with the Utils split (Phase 2)"
+    let loggingSplit = "Logger port and agent runtime share one file; split pending (Phase 1)"
+    let viaLogger = "console write below the injected Logger; route through Logger (Phase 1)"
+    let evict = "Google-Sheets/NKF loader in GenFORM; moves to the adapter project (Phase 2)"
+    let factory = "logger factory in a core library; moves to the composition root (Phase 1)"
+    let clock = "ambient clock in the core; becomes a `now` parameter (Phase 4)"
+    let chunking = "Permanent: Environment.ProcessorCount only sizes parallel chunks, never a result"
+
+    [
+        // Utils.Lib: whole IO modules awaiting the pure/IO split
+        allowFile "src/Informedica.Utils.Lib/File.fs" utilsSplit
+        allowFile "src/Informedica.Utils.Lib/Env.fs" utilsSplit
+        allowFile "src/Informedica.Utils.Lib/App.fs" utilsSplit
+        allowFile "src/Informedica.Utils.Lib/AppPath.fs" utilsSplit
+        allowFile "src/Informedica.Utils.Lib/Console.fs" utilsSplit
+        allowFile "src/Informedica.Utils.Lib/StopWatch.fs" utilsSplit
+        allowFile "src/Informedica.Utils.Lib/Web.fs" utilsSplit
+        allowToken "src/Informedica.Utils.Lib/Path.fs" "System.IO" "Permanent: System.IO.Path string helpers only, no filesystem access"
+        allowToken "src/Informedica.Utils.Lib/Memoization.fs" "Stopwatch" "Permanent: timing in an example function, no IO"
+        allowToken "src/Informedica.Utils.Lib/Json.fs" "printfn" viaLogger
+        allowToken "src/Informedica.Utils.Lib/BCL/Int32.fs" "printfn" viaLogger
+        allowToken "src/Informedica.Utils.Lib/BCL/BigInteger.fs" "printfn" viaLogger
+        allowToken "src/Informedica.Utils.Lib/BCL/DateTime.fs" "DateTime.Now" clock
+        // Logging.Lib
+        allowFile "src/Informedica.Logging.Lib/Logging.fs" loggingSplit
+        // GenUNITS.Lib
+        allowToken "src/Informedica.GenUNITS.Lib/UnitsParse.fs" "printfn" viaLogger
+        allowToken "src/Informedica.GenUNITS.Lib/ValueUnit.fs" "printfn" viaLogger
+        // GenCORE.Lib
+        allowToken "src/Informedica.GenCORE.Lib/Patient.fs" "DateTime.Now" clock
+        // GenSOLVER.Lib
+        allowToken "src/Informedica.GenSOLVER.Lib/Utils.fs" "Environment.ProcessorCount" chunking
+        allowToken "src/Informedica.GenSOLVER.Lib/Variable.fs" "ConsoleWriter" viaLogger
+        allowToken "src/Informedica.GenSOLVER.Lib/Variable.fs" "writeErrorMessage" viaLogger
+        allowToken "src/Informedica.GenSOLVER.Lib/Variable.fs" "writeDebugMessage" viaLogger
+        allowToken "src/Informedica.GenSOLVER.Lib/Variable.fs" "printfn" viaLogger
+        allowToken "src/Informedica.GenSOLVER.Lib/Equation.fs" "ConsoleWriter" viaLogger
+        allowToken "src/Informedica.GenSOLVER.Lib/Equation.fs" "writeErrorMessage" viaLogger
+        allowToken "src/Informedica.GenSOLVER.Lib/Equation.fs" "printfn" viaLogger
+        allowToken "src/Informedica.GenSOLVER.Lib/Solver.fs" "ConsoleWriter" viaLogger
+        allowToken "src/Informedica.GenSOLVER.Lib/Solver.fs" "writeErrorMessage" viaLogger
+        allowToken "src/Informedica.GenSOLVER.Lib/SolverLogging.fs" "AgentLogging" factory
+        // GenFORM.Lib
+        allowToken "src/Informedica.GenFORM.Lib/Utils.fs" "Environment.ProcessorCount" chunking
+        allowToken "src/Informedica.GenFORM.Lib/Utils.fs" "Web." evict
+        allowToken "src/Informedica.GenFORM.Lib/Utils.fs" "StopWatch." evict
+        allowToken "src/Informedica.GenFORM.Lib/Mapping.fs" "Web." evict
+        allowToken "src/Informedica.GenFORM.Lib/Product.fs" "ConsoleWriter" viaLogger
+        allowToken "src/Informedica.GenFORM.Lib/Product.fs" "writeErrorMessage" viaLogger
+        allowToken "src/Informedica.GenFORM.Lib/Product.fs" "Web." evict
+        allowToken "src/Informedica.GenFORM.Lib/Product.fs" "Async.RunSynchronously" evict
+        allowToken "src/Informedica.GenFORM.Lib/Product.fs" "StopWatch." evict
+        allowToken "src/Informedica.GenFORM.Lib/DoseRuleLoader.fs" "Web." evict
+        allowToken "src/Informedica.GenFORM.Lib/DoseRuleLoader.fs" "Async.RunSynchronously" evict
+        allowFile "src/Informedica.GenFORM.Lib/SourceLoader.fs" evict
+        allowToken "src/Informedica.GenFORM.Lib/SolutionRule.fs" "Web." evict
+        allowToken "src/Informedica.GenFORM.Lib/RenalRule.fs" "ConsoleWriter" viaLogger
+        allowToken "src/Informedica.GenFORM.Lib/RenalRule.fs" "writeWarningMessage" viaLogger
+        allowToken "src/Informedica.GenFORM.Lib/RenalRule.fs" "Web." evict
+        allowToken "src/Informedica.GenFORM.Lib/FormLogging.fs" "AgentLogging" "unreferenced top-level agent logger; delete (Phase 0)"
+        allowToken "src/Informedica.GenFORM.Lib/Resources.fs" "ConsoleWriter" viaLogger
+        allowToken "src/Informedica.GenFORM.Lib/Resources.fs" "writeErrorMessage" viaLogger
+        allowToken "src/Informedica.GenFORM.Lib/Resources.fs" "DateTime.UtcNow" "CachedResourceProvider TTL clock; provider moves to the adapter project (Phase 2)"
+        allowToken "src/Informedica.GenFORM.Lib/Export.fs" "File." "cwd-relative export file write; moves to the adapter project (Phase 2)"
+        allowToken "src/Informedica.GenFORM.Lib/Export.fs" "Environment.CurrentDirectory" "cwd-relative export file write; moves to the adapter project (Phase 2)"
+        allowToken "src/Informedica.GenFORM.Lib/Api.fs" "Async.RunSynchronously" "parallel rule filtering blocks on Async; keep pure or move to the edge (Phase 2)"
+        // GenORDER.Lib
+        allowToken "src/Informedica.GenORDER.Lib/Utils.fs" "Env." "dead getDataFromGenPres reads env; delete (Phase 0)"
+        allowToken "src/Informedica.GenORDER.Lib/Utils.fs" "printfn" viaLogger
+        allowToken "src/Informedica.GenORDER.Lib/Exceptions.fs" "printfn" viaLogger
+        allowToken "src/Informedica.GenORDER.Lib/OrderVariable.fs" "ConsoleWriter" viaLogger
+        allowToken "src/Informedica.GenORDER.Lib/OrderVariable.fs" "writeErrorMessage" viaLogger
+        allowToken "src/Informedica.GenORDER.Lib/EquationMapping.fs" "ConsoleWriter" viaLogger
+        allowToken "src/Informedica.GenORDER.Lib/EquationMapping.fs" "writeErrorMessage" viaLogger
+        allowToken "src/Informedica.GenORDER.Lib/EquationMapping.fs" "Memoization.memoize" "Permanent: memoizes a hard-coded, pure equation list"
+        allowToken "src/Informedica.GenORDER.Lib/Order.fs" "ConsoleWriter" viaLogger
+        allowToken "src/Informedica.GenORDER.Lib/Order.fs" "writeErrorMessage" viaLogger
+        allowToken "src/Informedica.GenORDER.Lib/Order.fs" "writeDebugMessage" viaLogger
+        allowToken "src/Informedica.GenORDER.Lib/Order.fs" "DateTime.Now" clock
+        allowToken "src/Informedica.GenORDER.Lib/OrderProcessor.fs" "ConsoleWriter" viaLogger
+        allowToken "src/Informedica.GenORDER.Lib/OrderProcessor.fs" "writeWarningMessage" viaLogger
+        allowToken "src/Informedica.GenORDER.Lib/Medication.fs" "ConsoleWriter" viaLogger
+        allowToken "src/Informedica.GenORDER.Lib/Medication.fs" "writeWarningMessage" viaLogger
+        allowToken "src/Informedica.GenORDER.Lib/Medication.fs" "Guid.NewGuid" "ambient entropy in a constructor; becomes a `newId` parameter (Phase 4)"
+        allowToken "src/Informedica.GenORDER.Lib/Nutrition.fs" "printfn" viaLogger
+        allowToken "src/Informedica.GenORDER.Lib/OrderLogging.fs" "ConsoleWriter" viaLogger
+        allowToken "src/Informedica.GenORDER.Lib/OrderLogging.fs" "writeErrorMessage" viaLogger
+        allowToken "src/Informedica.GenORDER.Lib/OrderLogging.fs" "writeInfoMessage" viaLogger
+        allowToken "src/Informedica.GenORDER.Lib/OrderLogging.fs" "AgentLogging" factory
+        allowToken "src/Informedica.GenORDER.Lib/Api.fs" "ConsoleWriter" viaLogger
+        allowToken "src/Informedica.GenORDER.Lib/Api.fs" "writeErrorMessage" viaLogger
+        allowToken "src/Informedica.GenORDER.Lib/Api.fs" "writeWarningMessage" viaLogger
+        // GenINTERACT.Lib
+        allowToken "src/Informedica.GenINTERACT.Lib/Data.fs" "System.IO" "cwd-relative cache read; loader moves to the adapter project (Phase 2)"
+        allowToken "src/Informedica.GenINTERACT.Lib/Data.fs" "File." "cwd-relative cache read; loader moves to the adapter project (Phase 2)"
+    ]
+
+
+/// Core files that may name a `GENPRES_*` setting today.
+let allowedConfigMentions =
+    [
+        "src/Informedica.Utils.Lib/AppPath.fs", "GENPRES_ROOT root resolution; leaves the core with the Utils split (Phase 2)"
+        "src/Informedica.Utils.Lib/Console.fs", "GENPRES_DEBUG read inside the console writer; leaves the core with the Utils split (Phase 2)"
+        "src/Informedica.GenORDER.Lib/Utils.fs", "GENPRES_URL_ID constant used only by dead getDataFromGenPres; delete (Phase 0)"
+    ]
+
+
+// ---------------------------------------------------------------------------
+// Solution and project model
+// ---------------------------------------------------------------------------
+
+type Project =
+    {
+        Name: string
+        Path: string
+        Ring: Ring option
+        References: string list
+        SourceFiles: string list
+    }
+
+
+let normalise (p: string) = p.Replace('\\', '/')
+
+
+/// Projects under `src/` declared in GenPRES.sln, read from the solution file.
+let srcProjects () =
+    let sln = Path.Combine(repoRoot, "GenPRES.sln") |> File.ReadAllText
+
+    Regex.Matches(sln, "\"([^\"]+\\.fsproj)\"")
+    |> Seq.map (fun m -> m.Groups[1].Value |> normalise)
+    |> Seq.filter (fun p -> p.StartsWith "src/")
+    |> Seq.distinct
+    |> Seq.map (fun rel ->
+        let full = Path.Combine(repoRoot, rel)
+        let dir = Path.GetDirectoryName full
+        let name = Path.GetFileNameWithoutExtension full
+        let xml = File.ReadAllText full
+
+        let references =
+            Regex.Matches(xml, "ProjectReference Include=\"([^\"]+)\"")
+            |> Seq.map (fun m -> m.Groups[1].Value |> normalise |> Path.GetFileNameWithoutExtension)
+            |> List.ofSeq
+
+        let sources =
+            Regex.Matches(xml, "Compile Include=\"([^\"]+)\"")
+            |> Seq.map (fun m -> Path.Combine(dir, m.Groups[1].Value |> normalise) |> Path.GetFullPath)
+            |> List.ofSeq
+
+        {
+            Name = name
+            Path = rel
+            Ring = rings |> Map.tryFind name
+            References = references
+            SourceFiles = sources
+        }
+    )
+    |> List.ofSeq
+
+
+let relative (full: string) =
+    Path.GetRelativePath(repoRoot, full) |> normalise
+
+
+/// A line that is only a comment does not reach outside.
+let isComment (line: string) = line.TrimStart().StartsWith "//"
+
+
+/// `token` occurs in `line` and is not the tail of a longer identifier.
+let containsToken (token: string) (line: string) =
+    let rec search from =
+        match line.IndexOf(token, from, StringComparison.Ordinal) with
+        | -1 -> false
+        | i when i = 0 || not (Char.IsLetterOrDigit line[i - 1]) -> true
+        | i -> search (i + 1)
+
+    search 0
+
+
+let codeLines (file: string) =
+    File.ReadAllLines file
+    |> Array.mapi (fun i l -> i + 1, l)
+    |> Array.filter (fun (_, l) -> not (isComment l))
+
+
+let failWithAll what (violations: string list) =
+    if not violations.IsEmpty then
+        violations
+        |> String.concat Environment.NewLine
+        |> sprintf "%s:%s%s" what Environment.NewLine
+        |> failtest
+
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+let ringMapTests =
+    testList
+        "ring map"
+        [
+            test "every src project in GenPRES.sln has a ring" {
+                srcProjects ()
+                |> List.filter (fun p -> p.Ring.IsNone)
+                |> List.map _.Name
+                |> failWithAll "projects without a ring"
+            }
+
+            test "every ring map entry names a project in GenPRES.sln" {
+                let names = srcProjects () |> List.map _.Name |> Set.ofList
+
+                rings
+                |> Map.keys
+                |> Seq.filter (fun n -> not (names.Contains n))
+                |> List.ofSeq
+                |> failWithAll "ring map entries without a project"
+            }
+        ]
+
+
+let referenceTests =
+    testList
+        "T1 project references point inward"
+        [
+            test "no project references an outer ring, except the allow-list" {
+                let projects = srcProjects ()
+                let ringOf name = rings |> Map.tryFind name
+
+                let allowed =
+                    allowedReferences |> List.map (fun (f, t, _) -> f, t) |> Set.ofList
+
+                projects
+                |> List.collect (fun p ->
+                    p.References
+                    |> List.choose (fun dep ->
+                        match p.Ring, ringOf dep with
+                        | Some from, Some target when not (mayReference from target) ->
+                            if allowed.Contains(p.Name, dep) then
+                                None
+                            else
+                                Some $"%s{p.Name} (%A{from}) -> %s{dep} (%A{target})"
+                        | _ -> None
+                    )
+                )
+                |> failWithAll "outward references"
+            }
+
+            test "every allowed reference still exists (ratchet)" {
+                let projects = srcProjects ()
+
+                allowedReferences
+                |> List.filter (fun (f, t, _) ->
+                    projects
+                    |> List.exists (fun p -> p.Name = f && p.References |> List.contains t)
+                    |> not
+                )
+                |> List.map (fun (f, t, _) -> $"%s{f} -> %s{t}")
+                |> failWithAll "allow-list entries for references that no longer exist; remove them"
+            }
+        ]
+
+
+let coreTests =
+    let coreFiles () =
+        srcProjects ()
+        |> List.filter (fun p -> p.Ring = Some Ring.Core)
+        |> List.collect _.SourceFiles
+
+    let isAllowed (file: string) (token: string) =
+        allowances
+        |> List.exists (fun a -> a.File = file && (a.Token.IsNone || a.Token = Some token))
+
+    testList
+        "T2 the core does not reach outside"
+        [
+            test "no core source line uses a banned token, except the allow-list" {
+                coreFiles ()
+                |> List.collect (fun file ->
+                    let rel = relative file
+
+                    codeLines file
+                    |> Array.toList
+                    |> List.collect (fun (n, line) ->
+                        bannedTokens
+                        |> List.filter (fun t -> containsToken t line && not (isAllowed rel t))
+                        |> List.map (fun t -> $"%s{rel}:%i{n} %s{t}")
+                    )
+                )
+                |> failWithAll "core files reaching outside"
+            }
+
+            test "every allowance still matches something (ratchet)" {
+                let files = coreFiles () |> List.map (fun f -> relative f, f) |> Map.ofList
+
+                allowances
+                |> List.filter (fun a ->
+                    match files |> Map.tryFind a.File with
+                    | None -> true
+                    | Some full ->
+                        let lines = codeLines full |> Array.map snd
+
+                        let tokens =
+                            match a.Token with
+                            | Some t -> [ t ]
+                            | None -> bannedTokens
+
+                        lines
+                        |> Array.exists (fun l -> tokens |> List.exists (fun t -> containsToken t l))
+                        |> not
+                )
+                |> List.map (fun a -> $"%s{a.File} %A{a.Token}")
+                |> failWithAll "allowances that no longer match; remove them"
+            }
+        ]
+
+
+let dmzTests =
+    testList
+        "T3/T4 only the DMZ knows configuration and owns entry points"
+        [
+            test "GENPRES_ settings are named only in DMZ projects, except the allow-list" {
+                let allowed = allowedConfigMentions |> List.map fst |> Set.ofList
+
+                srcProjects ()
+                |> List.filter (fun p ->
+                    match p.Ring with
+                    | Some r -> not (isDmz r) && r <> Ring.Client
+                    | None -> false
+                )
+                |> List.collect _.SourceFiles
+                |> List.collect (fun file ->
+                    let rel = relative file
+
+                    if allowed.Contains rel then
+                        []
+                    else
+                        codeLines file
+                        |> Array.filter (fun (_, l) -> l.Contains "\"GENPRES_")
+                        |> Array.map (fun (n, _) -> $"%s{rel}:%i{n}")
+                        |> Array.toList
+                )
+                |> failWithAll "configuration named outside the DMZ"
+            }
+
+            test "every config allowance still matches something (ratchet)" {
+                allowedConfigMentions
+                |> List.filter (fun (rel, _) ->
+                    let full = Path.Combine(repoRoot, rel)
+
+                    not (File.Exists full)
+                    || codeLines full |> Array.exists (fun (_, l) -> l.Contains "\"GENPRES_") |> not
+                )
+                |> List.map fst
+                |> failWithAll "config allowances that no longer match; remove them"
+            }
+
+            test "only Presentation projects declare an entry point" {
+                srcProjects ()
+                |> List.filter (fun p -> p.Ring <> Some Ring.Presentation)
+                |> List.collect _.SourceFiles
+                |> List.filter (fun file -> File.ReadAllText file |> _.Contains("[<EntryPoint>]"))
+                |> List.map relative
+                |> failWithAll "entry points outside Presentation"
+            }
+        ]
+
+
+runTestsWithCLIArgs
+    []
+    [| "--summary" |]
+    (testList
+        "dependency rule"
+        [
+            ringMapTests
+            referenceTests
+            coreTests
+            dmzTests
+        ])
+|> exit


### PR DESCRIPTION
## Overview

Records the onion-architecture decision for #378 and adds the test that enforces it. See the [reply on #378](https://github.com/informedica/GenPRES/issues/378#issuecomment-5557816450) for the analysis behind it.

- `.github/workflows/build.yml` — runs the fitness test on every build, before the tests.
- `docs/adr/0022-dependency-rule-and-effects.md` — the decision: references point inward; ZIndex, ZForm, NKF and FTK are adapters, not domain (answers the open question on #378); effects enter the core as explicit parameters and function-valued ports, the `program`/tagless-final approach of #194/#226 is rejected with reasons; the server-side outer ring is the DMZ and the Fable client is outside it; one accepted exception (`GStandProvider`); four rejected alternatives.
- `docs/adr/0001-system-architecture.md` — dated amendment: the "domain libraries remain pure" consequence was unenforced and does not hold today; it now points at ADR-0022. One stale cell in ADR-0009 fixed.
- `scripts/CheckDependencyRule.fsx` — Expecto fitness test over `GenPRES.sln`: a ring map for every `src/` project; T1 references point inward; T2 core sources contain no banned token (`System.IO`, `HttpClient`, `Environment.*`, `DateTime.Now`, `Guid.NewGuid`, console writes, `Web.`, `Env.`, `AppPath`, `Async.RunSynchronously`, agents); T3 only the DMZ names a `GENPRES_*` setting; T4 only Presentation declares an entry point. Today's violations are allow-listed with a reason and a phase each. Every allow-list entry is a ratchet: one that no longer matches fails the run, so the list can only shrink.
- `docs/implementation-plans/378-dependency-rule.md` — the migration in six phases, PR-sized, each step classified A (no behaviour change) / B (failure path only) / C (dosing or data path, needs MDR validation). Phase 0 is deletions and landing the test; the browser-side dosing move is C and last.

Per ADR-0000 the ADR holds only the rule and the alternatives. The project table lives in the script's ring map and the violation inventory in its allow-lists, where they cannot go stale silently.

## Further information

The script runs in CI from this PR on: a `build.yml` step before the tests on all three runners, calling `dotnet fsi` directly the way the `CheckSolutionVersions.fsx` step does, so no `Build.fs` change is needed. This is also the first time the script runs on Windows and Linux; the green legs on this PR are the proof of its path handling.

ADR-0022 is marked **Proposed**; flip to Accepted on merge if the reviewers agree with the ring assignment. It is one `Map` in the script and easy to correct.

## Divergence from plan

n/a — this PR lands the plan.

## Verification

- `dotnet fsi scripts/CheckDependencyRule.fsx` — 9 tests, all green on the seeded allow-list (no build required).
- Negative checks done locally: removing one allowance that had no match failed the ratchet test with the entry named; adding a fake `ProjectReference` from `GenUNITS.Lib` to `Agents.Lib` failed T1 with `Informedica.GenUNITS.Lib (Core) -> Informedica.Agents.Lib (Infrastructure)`; reverted.
- One script gotcha worth knowing for review: `ProjectReference` paths use backslashes, so the name must be normalised before `Path.GetFileNameWithoutExtension` on macOS/Linux, otherwise T1 silently passes.
- `npx markdownlint-cli2` on the four Markdown files: 0 issues. All relative links resolve.
- Scripts are excluded from Fantomas by `.fantomasignore`.

## Author checklist

> [!NOTE]
> An issue and agreed implementation plan are necessary unless either fewer than 25 lines have been changed or only documentation has been changed.

I confirm that these changes:

- [x] Follow the process described in [CONTRIBUTING.md](../../CONTRIBUTING.md#pull-request-process).
- [x] Make the changes proposed in the linked issue (if applicable): #378
- [x] Follow the approach documented in the linked implementation plan (if applicable): `docs/implementation-plans/378-dependency-rule.md` (introduced here)
- [ ] Are no more than 200 lines of changed code, ideally 25-100. — the script is ~560 lines, of which ~130 are the allow-list inventory; the rest is docs.
- [x] Are not more complex than necessary.
- [x] Cannot easily be split in a way that would make reviewing them significantly easier. — two commits: script, then docs.
- [x] Follow the guidelines specified in [DEVELOPMENT.md](../../DEVELOPMENT.md).
- [x] Have been thoroughly tested.
- [x] Don't introduce new security vulnerabilities.
- [x] Follow the [AI/LLM Usage Policy](../../AGENTS.md#aillm-usage-policy) — LLMs were not given direct write access to `.fs` source files (except client-side UI code).

### AI/Vibe Coding Disclosure

- [x] Some or all code in this PR is **vibe coded** (substantially AI-generated). If checked, describe below which parts were AI-generated, which tool was used, and how the code was verified.

The analysis, the four Markdown files and `scripts/CheckDependencyRule.fsx` were generated with Claude Code (Claude Fable 5.1) from an exploration of `src/`, `docs/` and the issue history, with the ring assignment, the DMZ definition, the effect mechanism and the output format decided by the maintainer. The script was verified by running it (green), by the two negative checks above, and by reading the allow-list against the source. No `.fs` file is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9fayJFRi6STiZEkiTq9TF
