### PR TITLE
docs: name the Contract ring and section status in ADR-0001

### DIFF
--- a/docs/adr/0000-documentation-rules.md
+++ b/docs/adr/0000-documentation-rules.md
@@ -72,6 +72,11 @@ An ADR is **not** written for:
   decision is an amendment: a dated `### … — amended YYYY-MM-DD` section in place, as
   [ADR-0005](0005-build-system-versioning-and-release.md) does. A superseded ADR stays as the record
   of a road not taken ([ADR-0004](0004-fhir-r4-integration.md)); it is not deleted.
+  *Amended 2026-09-06*: an amendment section may carry its own status when it differs from the
+  ADR's — a `Proposed` amendment to an `Accepted` ADR, with the condition under which it becomes
+  `Accepted` — and the ADR-level status line then names it, as in
+  `Accepted, amended (date); § <section>: Proposed`. [ADR-0001](0001-system-architecture.md)'s
+  dependency-rule section is the case in point.
 - There is no hand-maintained index or change log. The folder listing and `git log docs/adr` are the index.
 
 ### 4. What lives where in `docs/`

--- a/docs/adr/0001-system-architecture.md
+++ b/docs/adr/0001-system-architecture.md
@@ -2,7 +2,7 @@
 
 **Date**: 2024-01-01
 
-**Status**: Accepted, amended (2026-09-06)
+**Status**: Accepted, amended (2026-09-06); § Dependency rule and effects: Proposed
 
 **Related Issues** (amendment): [#378 — Change project architecture](https://github.com/informedica/GenPRES/issues/378),
 [#416 — Standard logging library](https://github.com/informedica/GenPRES/issues/416),
@@ -62,6 +62,15 @@ The core is the domain: units, patient, solver, operational knowledge rules, ord
 Core projects contain no call that reaches outside the process. Core projects do not read
 configuration; they receive values.
 
+The ring map in `scripts/CheckDependencyRule.fsx` names six rings, innermost first: Core;
+Contract, which is `GenPRES.Shared` alone — the types and pure functions that client and server
+exchange; Infrastructure, the adapters and the agent runtime; Presentation, the server and the
+MCP host; Client; and Tooling, the extraction pipeline, which sits outside the runtime rings. For
+the Contract ring the rule is stricter than "inward": Contract references only Contract, and only
+Presentation and Client may reference it. Core and Infrastructure never see the contract types,
+so the domain cannot come to depend on the wire shape, and the client sees nothing but the
+contract.
+
 #### 2. ZIndex, ZForm, NKF and FTK are adapters
 
 They parse external sources (the G-Standaard files, the Kinderformularium website, the
@@ -106,7 +115,11 @@ solution, that references point inward, that core sources contain no call that r
 that only the DMZ names a `GENPRES_*` setting, and that only the DMZ declares an entry point. The
 violations that exist at the time of this decision are listed in the script as allowances, each
 with a reason. An allowance that no longer matches fails the run, so the list can only shrink.
-The migration is planned in `docs/implementation-plans/378-dependency-rule.md`.
+The check reads code lines only, so a comment may name a setting or a banned token without an
+allowance. The setting check matches the string literal `"GENPRES_`, the form in which a setting
+is read; the prefix is one value in the script today and becomes one per executable if GenPRES
+is ever split into separately deployed modules. The migration is planned in
+`docs/implementation-plans/378-dependency-rule.md`.
 
 ## Consequences
 

--- a/docs/adr/0001-system-architecture.md
+++ b/docs/adr/0001-system-architecture.md
@@ -115,8 +115,9 @@ solution, that references point inward, that core sources contain no call that r
 that only the DMZ names a `GENPRES_*` setting, and that only the DMZ declares an entry point. The
 violations that exist at the time of this decision are listed in the script as allowances, each
 with a reason. An allowance that no longer matches fails the run, so the list can only shrink.
-The check reads code lines only, so a comment may name a setting or a banned token without an
-allowance. The setting check matches the string literal `"GENPRES_`, the form in which a setting
+The check skips lines that are whole-line `//` comments, so such a comment may name a setting or
+a banned token without an allowance; an inline `//` or a `(* … *)` comment is scanned like code.
+The setting check matches the string literal `"GENPRES_`, the form in which a setting
 is read; the prefix is the `settingPrefixes` list in the script. The migration is planned in
 `docs/implementation-plans/378-dependency-rule.md`.
 

--- a/docs/adr/0001-system-architecture.md
+++ b/docs/adr/0001-system-architecture.md
@@ -117,8 +117,7 @@ violations that exist at the time of this decision are listed in the script as a
 with a reason. An allowance that no longer matches fails the run, so the list can only shrink.
 The check reads code lines only, so a comment may name a setting or a banned token without an
 allowance. The setting check matches the string literal `"GENPRES_`, the form in which a setting
-is read; the prefix is one value in the script today and becomes one per executable if GenPRES
-is ever split into separately deployed modules. The migration is planned in
+is read; the prefix is the `settingPrefixes` list in the script. The migration is planned in
 `docs/implementation-plans/378-dependency-rule.md`.
 
 ## Consequences

--- a/docs/roadmap/modular-design-discussion.md
+++ b/docs/roadmap/modular-design-discussion.md
@@ -1,0 +1,67 @@
+# Discussion: GenPRES as separately deployed modules
+
+> Discussion, not a decision. Nothing here is decided until it becomes an ADR (ADR-0000 §2). It
+> collects the points that a cross-check of the amended [ADR-0001](../adr/0001-system-architecture.md)
+> (2026-09-06) raised against a modular design draft ("GenPRES as modules: GenPRES, GenPREP and
+> the rest"). The draft itself is not in this repository.
+
+## Why this is not in ADR-0001
+
+ADR-0001 decides "a client-server web application". Several separately deployed module servers
+changes that sentence, and brings decisions of its own: one database per module and a shared
+credential store (storage), module-to-module reads over contracts and a platform for publication
+(integration), and a shared hosting component. That is a decision in its own right, ADR-0006 when
+it is taken, with a one-line amendment to ADR-0001 saying that "the system" is since then each
+GenPRES module and that the dependency rule and its ring map apply per module executable.
+Folding it into ADR-0001 would make that ADR carry three decisions.
+
+## Where the draft and ADR-0001 disagree, and which wins
+
+Where the draft and the ADR use different words for the same thing, the ADR and
+`scripts/CheckDependencyRule.fsx` win. In order of consequence:
+
+1. **ZIndex and ZForm are Infrastructure, not core.** The draft listed them among the pure
+   domain libraries; ADR-0001 §2 and the ring map say adapters. The core is `GenSOLVER`,
+   `GenORDER`, `GenFORM`, `GenUNITS`, `GenCORE`, `GenINTERACT` (plus `Utils.Lib` and
+   `Logging.Lib` as the script has them today, pending the split); `ZIndex`, `ZForm`, `NKF`,
+   `FTK` and `Agents` are Infrastructure, referenced only from a module server.
+2. **Module contracts are Contract-ring projects, and the ring map decides who may see them.**
+   Under the script's rule that only Presentation and Client reference Contract: a module server
+   (Presentation) may reference another module's contracts, a module client may reference its
+   own module's contracts, and neither Core nor Infrastructure may reference any contract. Two
+   consequences: a shared hosting library, being Infrastructure, may not reference any module's
+   contracts (it must not know what a treatment plan is); and the adapter that calls another
+   module over the network, which needs that module's contract types, lives in the calling
+   module's server project, not in the hosting library or a shared Infrastructure library. The
+   draft had said "core-ring" for contracts; under the script that is wrong.
+3. **A shared hosting library is Infrastructure and never a composition root.** ADR-0001 §3:
+   exactly one composition root per executable, and only composition roots construct loggers,
+   providers and caches. N module servers means N composition roots. The hosting library provides
+   ports and their live adapters (session store, credential store, launch verification, signing,
+   audit, mail, registry, platform); each module server's composition root constructs and wires
+   them from that server's settings. The hosting library constructs nothing on load, reads no
+   setting on its own and holds no singleton — a violation there is exactly the type-initializer
+   failure (#523, #526) the dependency rule ends.
+4. **The `GENPRES_*` rule needs a form that covers all modules.** ADR-0001 §4 and §5 and the
+   script's `settingPrefixes` assume one prefix. With a second module there are either
+   per-module prefixes, with the script taking the prefix per executable, or one prefix for all
+   of GenPRES. Small, but it has to be decided before the second module exists, because the
+   script hard-codes the pattern.
+5. **Vocabulary.** The draft used "onion" and "impure outer layer"; ADR-0001 uses rings, core,
+   adapters and DMZ. The draft's claim that the FHIR ADR backs a FHIR-facade route is replaced
+   by a plain statement that the facade is the hospital's interface and GenPRES has no FHIR code
+   on master: [ADR-0004](../adr/0004-fhir-r4-integration.md) is superseded (2026-08-28) and the
+   prototype was deleted.
+
+## Open before ADR-0006 can be written
+
+- The draft itself, so that ADR-0006 can state what was decided and what else was considered.
+- One prefix or one per executable (point 4).
+- Whether the modular decision lands as `Proposed` and what condition makes it `Accepted`.
+
+## Related
+
+- [ADR-0001: System Architecture](../adr/0001-system-architecture.md), § Dependency rule and effects
+- [ADR-0000: Documentation Rules](../adr/0000-documentation-rules.md), §2 on what an ADR is for
+- [Backlog](backlog.md) items 3–8, which a modular split would reshape
+- `scripts/CheckDependencyRule.fsx` — the ring map the discussion is checked against

--- a/scripts/CheckDependencyRule.fsx
+++ b/scripts/CheckDependencyRule.fsx
@@ -276,6 +276,19 @@ let allowances =
     ]
 
 
+/// The prefixes under which settings are read, as they appear in source (`"GENPRES_URL_ID"`).
+/// One entry today. If GenPRES is split into separately deployed modules, either every module
+/// keeps this prefix or each executable gets its own and this becomes a map from executable to
+/// prefix; that is decided with the modular design, not here. Until then the list is the single
+/// place to change.
+let settingPrefixes = [ "GENPRES_" ]
+
+
+/// True when a code line names a setting under any known prefix.
+let namesSetting (line: string) =
+    settingPrefixes |> List.exists (fun p -> line.Contains("\"" + p))
+
+
 /// Core files that may name a `GENPRES_*` setting today.
 let allowedConfigMentions =
     [
@@ -514,7 +527,7 @@ let dmzTests =
                         []
                     else
                         codeLines file
-                        |> Array.filter (fun (_, l) -> l.Contains "\"GENPRES_")
+                        |> Array.filter (fun (_, l) -> namesSetting l)
                         |> Array.map (fun (n, _) -> $"%s{rel}:%i{n}")
                         |> Array.toList
                 )
@@ -527,7 +540,7 @@ let dmzTests =
                     let full = Path.Combine(repoRoot, rel)
 
                     not (File.Exists full)
-                    || codeLines full |> Array.exists (fun (_, l) -> l.Contains "\"GENPRES_") |> not
+                    || codeLines full |> Array.exists (fun (_, l) -> namesSetting l) |> not
                 )
                 |> List.map fst
                 |> failWithAll "config allowances that no longer match; remove them"

--- a/scripts/CheckDependencyRule.fsx
+++ b/scripts/CheckDependencyRule.fsx
@@ -277,10 +277,8 @@ let allowances =
 
 
 /// The prefixes under which settings are read, as they appear in source (`"GENPRES_URL_ID"`).
-/// One entry today. If GenPRES is split into separately deployed modules, either every module
-/// keeps this prefix or each executable gets its own and this becomes a map from executable to
-/// prefix; that is decided with the modular design, not here. Until then the list is the single
-/// place to change.
+/// One entry today; the single place to change. Whether a second executable would get its own
+/// prefix is an open question in `docs/roadmap/modular-design-discussion.md`.
 let settingPrefixes = [ "GENPRES_" ]
 
 


### PR DESCRIPTION
## Summary

Follow-up to a cross-check of the amended ADR-0001 against master (`bdcb718`). Fixes what is current in the repository; the modular-design points from the same review go to a discussion document, not an ADR.

- **ADR-0001 §1** names the six rings of `scripts/CheckDependencyRule.fsx` (Core, Contract, Infrastructure, Presentation, Client, Tooling) and the Contract ring's stricter rule: `GenPRES.Shared` is referenced only by Presentation and Client, never by Core or Infrastructure. The decision was only in the script; now it is in the ADR.
- **ADR-0001 §5** says what the check settles: comment lines are skipped, and the setting check matches the `"GENPRES_` string literal, held in the script's `settingPrefixes` list.
- **ADR-0000 §3** permits an amendment section to carry its own status (`Proposed` inside an `Accepted` ADR) and requires the ADR-level status line to name it. ADR-0001's status line now reads `Accepted, amended (2026-09-06); § Dependency rule and effects: Proposed`.
- **`scripts/CheckDependencyRule.fsx`**: the hard-coded `"GENPRES_` literal becomes a `settingPrefixes` list read through `namesSetting`. Behaviour unchanged; one place to change.
- **`docs/roadmap/modular-design-discussion.md`** (new): the review's corrections to a modular design draft (ZIndex/ZForm as Infrastructure, contracts in the Contract ring, hosting library never a composition root, the setting-prefix question, vocabulary) and what is open before an ADR-0006 could be written. Explicitly discussion, not decision (ADR-0000 §2); the draft itself is not in the repository.

## Verification

- `dotnet fsi scripts/CheckDependencyRule.fsx`: 9 passed, 0 failed.
- `dotnet fantomas --check scripts/CheckDependencyRule.fsx`: clean.
- `markdownlint-cli2` on the changed Markdown files: 0 issues.

## Vibe coding disclosure

Drafted with Claude Code from a written review; reviewed by hand. Documentation plus a behaviour-preserving refactor of a CI script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9fayJFRi6STiZEkiTq9TF