### PR TITLE
fix(config): seed .env from .env.example on run

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,10 @@ GENPRES_PROD=0
 GENPRES_DEBUG=1
 
 # Password for admin operations (settings, log analysis, resource reload)
-# If not set, admin operations are disabled (fail-closed).
+# Left EMPTY on purpose: empty or unset means admin operations are disabled
+# (fail-closed). `dotnet run` copies this file to .env on a fresh clone, and
+# the copy must not carry a password that is visible in the repository. Set
+# a value here only when you need the admin pages locally.
 #
 # SECURITY POLICY:
 #   - Development (GENPRES_PROD=0): any value is accepted, including the
@@ -33,7 +36,7 @@ GENPRES_DEBUG=1
 #         openssl rand -base64 32
 #     and inject it via your secret store (Docker secret, Kubernetes secret,
 #     vault, ...). Never commit a real password to the repository.
-GENPRES_PASSWORD=<your-password>
+GENPRES_PASSWORD=
 
 # --- Docker Compose only (compose.yaml at the repo root) ---
 

--- a/Build.fs
+++ b/Build.fs
@@ -145,9 +145,11 @@ Target.create
 
 // A fresh clone or worktree has no .env (it is gitignored), and the server refuses to start
 // without GENPRES_URL_ID. .env.example ships the public demo sheet ID and GENPRES_PROD=0, so
-// seeding .env from it gives a working demo run with no manual step. An existing .env is never
-// touched, so local or production settings stay as they are. Only the dev-server launch needs
-// this: Build, ServerTests and Bundle keep running without a .env, as they do in CI.
+// seeding .env from it gives a working demo run with no manual step. .env.example leaves
+// GENPRES_PASSWORD empty, so the seeded server has admin operations disabled (fail-closed)
+// rather than a repository-visible password. An existing .env is never touched, so local or
+// production settings stay as they are. Only the dev-server launch needs this: Build,
+// ServerTests and Bundle keep running without a .env, as they do in CI.
 let ensureEnvFile () =
     if not (File.exists envPath) then
         Shell.copyFile envPath envExamplePath

--- a/Build.fs
+++ b/Build.fs
@@ -16,6 +16,9 @@ let dataPath = Path.getFullName "data"
 
 let deployPath = Path.getFullName "deploy"
 
+let envPath = Path.getFullName ".env"
+let envExamplePath = Path.getFullName ".env.example"
+
 let clientTestsPath = Path.getFullName "tests/Client"
 
 Target.create
@@ -140,9 +143,22 @@ Target.create
     )
 
 
+// A fresh clone or worktree has no .env (it is gitignored), and the server refuses to start
+// without GENPRES_URL_ID. .env.example ships the public demo sheet ID and GENPRES_PROD=0, so
+// seeding .env from it gives a working demo run with no manual step. An existing .env is never
+// touched, so local or production settings stay as they are. Only the dev-server launch needs
+// this: Build, ServerTests and Bundle keep running without a .env, as they do in CI.
+let ensureEnvFile () =
+    if not (File.exists envPath) then
+        Shell.copyFile envPath envExamplePath
+        Trace.logfn "No .env found; created %s from .env.example (demo settings)." envPath
+
+
 Target.create
     "Run"
     (fun _ ->
+        ensureEnvFile ()
+
         [
             "server", dotnet [ "run"; "--no-restore" ] serverPath
             "client",

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -103,7 +103,7 @@ packages for the Fable/Vite dev server).
 
 | Command | Target | Description |
 |---|---|---|
-| `dotnet run` | `Run` | Start server + Fable/Vite dev server with hot reload (default) |
+| `dotnet run` | `Run` | Start server + Fable/Vite dev server with hot reload (default). Creates `.env` from `.env.example` when it is missing |
 | `dotnet run list` | *(special)* | List all available FAKE targets |
 | `dotnet run Build` | `Build` | Compile the entire solution (`GenPRES.sln`) — libraries, server, tests, and the client `.fsproj`. No npm involved |
 | `dotnet run ServerBuild` | `ServerBuild` | Compile only the server and the libraries it depends on. Skips test projects and the client toolchain |
@@ -249,7 +249,12 @@ merge methods are enabled here, put it in the commit message.
 
 ### What Happens During `dotnet run` (the `Run` target)
 
-The `Run` target starts two long-running processes **in parallel**:
+The `Run` target first makes sure a `.env` file exists: when there is none, it copies
+`.env.example` (public demo sheet ID, `GENPRES_PROD=0`) and prints a notice, so a fresh clone or
+`git worktree` runs the demo without a manual `cp`. An existing `.env` is never touched. Only
+`Run` does this; `Build`, `ServerTests` and `Bundle` keep working without a `.env`, as they do in CI.
+
+Then it starts two long-running processes **in parallel**:
 
 1. **Server** – `dotnet run --no-restore` in `src/Informedica.GenPRES.Server/`
    - Saturn/Giraffe HTTP server on port `8085`
@@ -956,8 +961,10 @@ This project uses a `.env` file at the project root as the single source of trut
 
 #### Quick Setup
 
-1. Copy the example file: `cp .env.example .env`
+1. Nothing, for the demo: the first `dotnet run` copies `.env.example` to `.env` when no `.env` exists (see [What Happens During `dotnet run`](#what-happens-during-dotnet-run-the-run-target)). To create it by hand instead: `cp .env.example .env`
 2. `.env.example` ships with the public demo sheet ID, so the copy works as-is in demo mode. For production data, edit `.env` and replace `GENPRES_URL_ID` (ask a team member for the production URL ID)
+
+Put a `git worktree` **next to** the main checkout, not inside it: the root resolver (`AppPath`) and `Env.loadDotEnv` search upward for `.env`, so a worktree nested under the repo would pick up the main checkout's `.env` and `data/` instead of its own.
 
 The `.env` file uses standard `KEY=VALUE` format:
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -250,8 +250,10 @@ merge methods are enabled here, put it in the commit message.
 ### What Happens During `dotnet run` (the `Run` target)
 
 The `Run` target first makes sure a `.env` file exists: when there is none, it copies
-`.env.example` (public demo sheet ID, `GENPRES_PROD=0`) and prints a notice, so a fresh clone or
-`git worktree` runs the demo without a manual `cp`. An existing `.env` is never touched. Only
+`.env.example` (public demo sheet ID, `GENPRES_PROD=0`, empty `GENPRES_PASSWORD`) and prints a
+notice, so a fresh clone or `git worktree` runs the demo without a manual `cp`. The seeded server
+has admin operations disabled, because the password is empty; set `GENPRES_PASSWORD` in `.env` to
+enable them locally. An existing `.env` is never touched. Only
 `Run` does this; `Build`, `ServerTests` and `Bundle` keep working without a `.env`, as they do in CI.
 
 Then it starts two long-running processes **in parallel**:
@@ -962,7 +964,7 @@ This project uses a `.env` file at the project root as the single source of trut
 #### Quick Setup
 
 1. Nothing, for the demo: the first `dotnet run` copies `.env.example` to `.env` when no `.env` exists (see [What Happens During `dotnet run`](#what-happens-during-dotnet-run-the-run-target)). To create it by hand instead: `cp .env.example .env`
-2. `.env.example` ships with the public demo sheet ID, so the copy works as-is in demo mode. For production data, edit `.env` and replace `GENPRES_URL_ID` (ask a team member for the production URL ID)
+2. `.env.example` ships with the public demo sheet ID and an empty `GENPRES_PASSWORD`, so the copy works as-is in demo mode with admin operations disabled. Set `GENPRES_PASSWORD` to use the admin pages locally. For production data, edit `.env` and replace `GENPRES_URL_ID` (ask a team member for the production URL ID)
 
 Put a `git worktree` **next to** the main checkout, not inside it: the root resolver (`AppPath`) and `Env.loadDotEnv` search upward for `.env`, so a worktree nested under the repo would pick up the main checkout's `.env` and `data/` instead of its own.
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Open a browser to <http://localhost:5173> to view the site.
 
 The `GENPRES_URL_ID` environment variable selects the Google Sheet the server reads its rules from.
 On a fresh clone there is no `.env` yet, so the first `dotnet run` creates one by copying
-`.env.example`, which ships the public demo sheet ID and `GENPRES_PROD=0`. That gives a working demo
-with no manual step; it does need network access to `docs.google.com`, because the rule base is
+`.env.example`, which ships the public demo sheet ID, `GENPRES_PROD=0` and an empty
+`GENPRES_PASSWORD` (admin operations disabled). That gives a working demo with no manual step; it does need network access to `docs.google.com`, because the rule base is
 fetched from the sheet at startup even in demo mode. An existing `.env` is never overwritten, so
 edit it to switch to production data. After starting the application, the sheet ID in use is
 printed (masked) to the terminal. See [Environment Configuration](DEVELOPMENT.md#environment-configuration)

--- a/README.md
+++ b/README.md
@@ -60,8 +60,12 @@ Starting the application in developer mode is now super easy, just `dotnet run` 
 
 Open a browser to <http://localhost:5173> to view the site.
 
-The `GENPRES_URL_ID` environment variable selects the Google Sheet the server reads its rules from;
-`.env.example` ships the public demo sheet ID. After starting the application, the sheet ID in use is
+The `GENPRES_URL_ID` environment variable selects the Google Sheet the server reads its rules from.
+On a fresh clone there is no `.env` yet, so the first `dotnet run` creates one by copying
+`.env.example`, which ships the public demo sheet ID and `GENPRES_PROD=0`. That gives a working demo
+with no manual step; it does need network access to `docs.google.com`, because the rule base is
+fetched from the sheet at startup even in demo mode. An existing `.env` is never overwritten, so
+edit it to switch to production data. After starting the application, the sheet ID in use is
 printed (masked) to the terminal. See [Environment Configuration](DEVELOPMENT.md#environment-configuration)
 for the full variable list, the `.env` priority order, and Windows syntax.
 


### PR DESCRIPTION
## Overview

`dotnet run` on a fresh clone or `git worktree` failed: `.env` is gitignored, so the server refused to start with `No GENPRES_URL_ID (or value is empty)` (`Server.fs:175`), and the FAKE `Run` target then hung waiting on the still-running Vite client.

The `Run` target now calls `ensureEnvFile ()`, which copies `.env.example` to `.env` when none exists and prints a notice. `.env.example` ships the public demo sheet ID and `GENPRES_PROD=0`, so the copy is a working demo configuration. An existing `.env` is never touched. `Build`, `ServerTests` and `Bundle` are unchanged and keep running without a `.env`, as they do in CI.

Docs updated: README "Starting the application", DEVELOPMENT.md target table, the `Run` target section, and Quick Setup (plus a note that worktrees must sit next to the repo, not inside it, because `AppPath` / `Env.loadDotEnv` search upward for `.env`).

## Further information

- Everything else the demo reads is tracked: `data/cache/*.demo`, `data/cache/interactions/Data.JSON`, `data/zindex/*.test`. Local tools restore via `Build.fsproj`. So the missing `.env` was the only out-of-the-box blocker.
- Demo mode still fetches the rule base from Google Sheets at startup, so it needs network access to `docs.google.com`. Same as the Docker demo; documented, not changed.
- `.env.example` now ships `GENPRES_PASSWORD=` (empty), so a seeded demo run starts with admin operations disabled (fail-closed on every check path). Set it in `.env` to use the admin pages locally. This addresses the Greptile P1 (commit 481b07dc).
- Commit scope is `config` because commit-lint has no `build` scope.

## Divergence from plan

n/a (under 25 lines of code; no issue or plan).

## Verification

In a fresh sibling worktree (`git worktree add ../GenPRES-wt-demo`), with all `GENPRES_*` variables scrubbed from the shell:

- Before the fix: build and `npm ci` pass, server dies with `No GENPRES_URL_ID`, FAKE hangs on the client.
- After the fix, no `.env` present: log shows `No .env found; created .../.env from .env.example (demo settings).`, server banner prints the masked demo sheet ID and `GENPRES_PROD = 0`, server listens on 8085, Vite on 5173.
- Browser smoke test on `http://localhost:5173`: disclaimer accepted, five `processCommand` RPCs return 200, no console errors.
- Second `dotnet run` with `.env` present: no copy, `.env` mtime unchanged. The main checkout's `.env` untouched.
- `CI=true dotnet run ServerTests` with `.env` removed: 1515 passed, 0 failed, 6 skipped; no `.env` created.
- After the password change: fresh `dotnet run` seeds `.env` and the banner prints `GENPRES_PASSWORD = NOT SET (admin operations disabled)`; server listens on 8085.
- `dotnet fantomas --check Build.fs` clean.

To see it yourself: `git worktree add ../wt`, `cd ../wt`, `dotnet run`.

## Author checklist

I confirm that these changes:

- [x] Follow the process described in [CONTRIBUTING.md](../../CONTRIBUTING.md#pull-request-process).
- [x] Make the changes proposed in the linked issue (if applicable): n/a
- [x] Follow the approach documented in the linked implementation plan (if applicable): n/a
- [x] Are no more than 200 lines of changed code, ideally 25-100.
- [x] Are not more complex than necessary.
- [x] Cannot easily be split in a way that would make reviewing them significantly easier.
- [x] Follow the guidelines specified in [DEVELOPMENT.md](../../DEVELOPMENT.md).
- [x] Have been thoroughly tested.
- [x] Don't introduce new security vulnerabilities.
- [x] Follow the [AI/LLM Usage Policy](../../AGENTS.md#aillm-usage-policy) — LLMs were not given direct write access to `.fs` source files (except client-side UI code). The only `.fs` touched is the FAKE build script `Build.fs`, edited with explicit authorization.

### AI/Vibe Coding Disclosure

- [x] Some or all code in this PR is **vibe coded** (substantially AI-generated). If checked, describe below which parts were AI-generated, which tool was used, and how the code was verified.

The `ensureEnvFile` helper in `Build.fs` and the documentation wording were generated with Claude Code (Fable 5.1) and reviewed line by line. Verified as described above: reproduced the failure in a fresh worktree, then confirmed the fix end to end (server start, browser RPCs, no-overwrite re-run, ServerTests without `.env`).

I confirm that I have:

- [ ] Added appropriate automated tests. (None: the change is a file copy in the FAKE build script; verified manually as above.)
- [x] Updated documentation appropriately.
- [x] Added comments that highlight important changes and add justification, where necessary.

## Reviewer checklist

I confirm that:

- [ ] I am confident that the changes work.
- [ ] The changed code meets our guidelines and standards.
- [ ] The new code is not more complex than necessary.
- [ ] I have clearly labeled suggestions as blocking, required but not blocking, or optional (see [CONTRIBUTING.md](../../CONTRIBUTING.md#pull-request-process)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

