### PR TITLE
refactor(server): section Server.fs into Config, Http and Host

### DIFF
--- a/src/Informedica.GenPRES.Server/Server.fs
+++ b/src/Informedica.GenPRES.Server/Server.fs
@@ -1,4 +1,4 @@
-//module Server
+module Server
 
 open Giraffe
 open Saturn
@@ -20,435 +20,499 @@ open Microsoft.AspNetCore.RateLimiting
 open System.Threading.RateLimiting
 
 
-// B3 — Returns the immediate peer IP. After UseForwardedHeaders runs
-// (registered via app_config below) this is the real client IP for
-// requests that arrived through a known proxy, and the actual peer
-// for direct connections. The previous version trusted X-Forwarded-For
-// from any source (finding B3); that path is now obsolete and the
-// rate limiter's partition cardinality is bounded by real ingress IPs.
-let getClientIP (context: HttpContext) =
-    match context.Connection.RemoteIpAddress with
-    | null -> "unknown"
-    | ip -> ip.ToString()
-
-
-// Load .env so GENPRES_* variables are available even when the server
-// binary is launched directly (e.g. via Rider/VS Code) without first
-// sourcing .env in the shell. loadDotEnv only sets variables that are
-// not already present, preserving the shell/CI/Docker > .env > defaults
-// override chain.
-let loadEnvironment () = Env.loadDotEnv () |> ignore
-
-
-loadEnvironment ()
-let tryGetEnv key = Env.getItem key
-
-
-// Banner display strings. Empty/whitespace is treated as not-set so an
-// empty `ENV GENPRES_PASSWORD=` / `ENV GENPRES_URL_ID=` from the Dockerfile
-// is reported truthfully instead of looking injected.
-let password =
-    tryGetEnv "GENPRES_PASSWORD"
-    |> Option.filter (System.String.IsNullOrWhiteSpace >> not)
-    |> Option.map (fun _ -> "***")
-    |> Option.defaultValue "NOT SET (admin operations disabled)"
-
-
-// Show only the last 5 chars of the Sheet ID so it never lands in logs or
-// screenshots intact. Built here, not in the format string below, so the
-// `NOT SET` path doesn't render as `***NOT SET`.
-let urlId =
-    tryGetEnv "GENPRES_URL_ID"
-    |> Option.filter (System.String.IsNullOrWhiteSpace >> not)
-    |> Option.map (fun s ->
-        if s.Length > 5 then
-            $"***%s{s.Substring(s.Length - 5)}"
-        else
-            "***<redacted>"
-    )
-    |> Option.defaultValue "NOT SET"
-
-
-$"""
-
-=== Environmental variables ===
-GENPRES_URL_ID = {urlId}
-GENPRES_LOG ={tryGetEnv "GENPRES_LOG" |> Option.defaultValue "0"}
-GENPRES_PROD = {tryGetEnv "GENPRES_PROD" |> Option.defaultValue "0"}
-GENPRES_DEBUG = {tryGetEnv "GENPRES_DEBUG" |> Option.defaultValue "i"}
-GENPRES_PASSWORD = {password}
-
-=== System Info ===
-
-{Env.getSystemInfo ()}
-
-"""
-|> writeInfoMessage
-
-
-let port =
-    "SERVER_PORT" |> tryGetEnv |> Option.map uint16 |> Option.defaultValue 8085us
-
-
-// B3 — Trusted reverse-proxy allow-list for ForwardedHeadersMiddleware.
-// Default = loopback only (matches the Plesk → Kestrel hop on the
-// public demo deployments and any local-dev setup). Override with
-// GENPRES_TRUSTED_PROXIES as a comma-separated list of IPs, e.g.
-//     GENPRES_TRUSTED_PROXIES="10.0.0.5, 10.0.0.6"
-// for a hospital LAN behind a known nginx fleet. Unparseable values
-// are silently dropped — fail-open on the parser, fail-closed on the
-// allow-list (no entry = no XFF trust).
-let trustedProxies =
-    tryGetEnv "GENPRES_TRUSTED_PROXIES"
-    |> Option.filter (System.String.IsNullOrWhiteSpace >> not)
-    |> Option.map (fun s ->
-        s.Split(',')
-        |> Array.choose (fun part ->
-            match System.Net.IPAddress.TryParse(part.Trim()) with
-            | true, ip -> Some ip
-            | false, _ -> None
-        )
-    )
-    |> Option.defaultValue
-        [|
-            System.Net.IPAddress.Loopback
-            System.Net.IPAddress.IPv6Loopback
-        |]
-
-
-// SECURITY: in production mode (GENPRES_PROD=1), refuse to start without
-// a GENPRES_PASSWORD of at least minProductionPasswordLength characters.
-// Fail-closed, runs before any listener binds. Demo/dev mode accepts any
-// value (or none — admin ops just stay disabled).
-let private minProductionPasswordLength = 16
-
-
-let private validateProductionPassword () =
-    let isProd =
-        tryGetEnv "GENPRES_PROD"
-        |> Option.map (fun v -> v = "1")
-        |> Option.defaultValue false
-
-    if isProd then
-        // Empty/whitespace = unset, so a forgotten Docker env hits the
-        // "not set" branch instead of "shorter than 16 characters".
-        match
-            tryGetEnv "GENPRES_PASSWORD"
-            |> Option.filter (System.String.IsNullOrWhiteSpace >> not)
-        with
-        | None ->
-            invalidOp
-                "GENPRES_PROD=1 but GENPRES_PASSWORD is not set (or is empty). \
-                 Refusing to start in production without an admin password. \
-                 Generate one with `openssl rand -base64 32` and inject it via a secret store. \
-                 See DEVELOPMENT.md → Password policy."
-        | Some pwd when pwd.Length < minProductionPasswordLength ->
-            invalidOp
-                $"GENPRES_PROD=1 but GENPRES_PASSWORD is shorter than %i{minProductionPasswordLength} characters. \
-                 Refusing to start in production with a weak admin password. \
-                 Generate a stronger one with `openssl rand -base64 32`. \
-                 See DEVELOPMENT.md → Password policy."
-        | Some _ -> ()
-
-
-validateProductionPassword ()
-
-
-let provider =
-    let logger =
-        Logging.loggingLevel
-        |> Option.map (fun level ->
-            Logging.getLogger level Logging.ResourcesLogger
-            |> (fun logger ->
-                logger |> Logging.setComponentName (Some "Provider") |> Async.RunSynchronously
-                logger
-            )
-        )
-        |> Option.map _.Logger
-        |> Option.defaultValue Informedica.GenOrder.Lib.Logging.noOp
-
-    // Empty/whitespace = unset, otherwise an empty Docker env would flow
-    // into getCachedProviderWithDataUrlId and surface much later as a
-    // confusing "cannot find column" error from GenForm.
-    tryGetEnv "GENPRES_URL_ID"
-    |> Option.filter (System.String.IsNullOrWhiteSpace >> not)
-    |> Option.defaultWith (fun () -> invalidOp "No GENPRES_URL_ID (or value is empty)")
-    |> Informedica.GenForm.Lib.Api.getCachedProviderWithDataUrlId logger
-
-
-let logClientIP: HttpHandler =
-    fun (next: HttpFunc) (ctx: HttpContext) ->
-        match Logging.loggingLevel with
-        | None -> next ctx
-        | Some level ->
-            let clientIP = getClientIP ctx
-            let path = ctx.Request.Path.ToString()
-            let method = ctx.Request.Method
-            let logger = Logging.getLogger level Logging.RequestLogger
-
-            async {
-                do! logger |> Logging.setComponentName (Some "Client_Request")
-
-                Logging.ServerLogging.logRequest logger method path clientIP
-                return ()
-            }
-            |> Async.Start
-
-            // Continue with the next handler
-            next ctx
-
-
 /// <summary>
-/// Cache-Control value for a response. Vite emits the client as
-/// content-hashed files under /assets/, so a successful response for one
-/// of those can be cached forever; everything else — "/", index.html,
-/// icons, the Fable.Remoting routes, and any error — is "no-cache": the
-/// browser may keep a copy but must revalidate it on every load. The ETag
-/// that StaticFileMiddleware already emits then answers with a 304 when
-/// nothing changed and a full fetch after a deploy.
+/// Everything the server reads from its environment, parsed once into a
+/// <c>Settings</c> record. Nothing in this module performs IO: <c>fromEnv</c>
+/// takes the getter, so <c>main</c> passes <c>Env.getItem</c> and tests pass
+/// a <c>Map</c>. Validation returns <c>Result</c>; deciding to abort is the
+/// entry point's job.
 /// </summary>
-/// <remarks>
-/// Without a Cache-Control header browsers apply heuristic freshness
-/// (RFC 9111 §4.2.2, typically 10 % of now − Last-Modified), which is how
-/// a long-running container ends up with clients that never see a new
-/// index.html and keep loading the previous hashed bundle (#568).
-///
-/// The status check matters: a 404 for an asset that this instance does
-/// not have yet (a rolling deploy, a stale index.html) must never be
-/// cached for a year, or the client stays broken after the asset arrives.
-/// The path can be null for a request without one, such as OPTIONS *.
-/// </remarks>
-let cacheControlFor (statusCode: int) (path: string) =
-    let isAsset =
-        not (System.String.IsNullOrEmpty path)
-        && path.StartsWith("/assets/", System.StringComparison.OrdinalIgnoreCase)
+module Config =
 
-    if isAsset && statusCode >= 200 && statusCode < 300 then
-        "public, max-age=31536000, immutable"
-    else
-        "no-cache"
-
-
-// B2 — Security response header baseline. ASP.NET middleware (wired via
-// app_config) using Response.OnStarting so headers land on every flushed
-// response: static files, Giraffe routes, the 404 fallback, and
-// Fable.Remoting error responses alike. Also owns the Cache-Control
-// policy (cacheControlFor above), because this is the one hook that
-// runs on static responses and Saturn's use_static does not expose
-// StaticFileOptions.OnPrepareResponse.
-//
-// CSP allow-list reflects the SPA's actual fetches: same-origin scripts
-// (Fable bundle), maxcdn + Google Fonts for CSS, gstatic for fonts,
-// docs.google.com for the runtime Sheet fetches. Drop docs.google.com
-// once Sheet access is proxied server-side. X-Powered-By is stripped in
-// case nginx/Plesk injects it.
-//
-// style-src includes 'unsafe-inline' because MUI's styling engine
-// (Emotion) injects per-component <style> tags at runtime. Without it
-// every MUI component renders unstyled. script-src remains strict
-// ('self' only) so XSS exposure is bounded to CSS injection, which
-// cannot execute code. Tightening this further requires wiring an
-// Emotion CacheProvider with a per-request nonce — tracked as a
-// follow-up to the security review.
-let private securityHeadersMiddleware (ctx: HttpContext) (next: System.Func<Task>) : Task =
-    ctx.Response.OnStarting(fun () ->
-        let h = ctx.Response.Headers
-        h["Strict-Transport-Security"] <- "max-age=31536000; includeSubDomains"
-        h["X-Content-Type-Options"] <- "nosniff"
-        h["X-Frame-Options"] <- "DENY"
-        h["Referrer-Policy"] <- "no-referrer"
-        h["Permissions-Policy"] <- "geolocation=(), camera=(), microphone=()"
-        h["Cache-Control"] <- cacheControlFor ctx.Response.StatusCode ctx.Request.Path.Value
-
-        h["Content-Security-Policy"] <-
-            "default-src 'self'; \
-             script-src 'self'; \
-             style-src 'self' 'unsafe-inline' https://maxcdn.bootstrapcdn.com https://fonts.googleapis.com; \
-             font-src 'self' https://fonts.gstatic.com https://maxcdn.bootstrapcdn.com; \
-             img-src 'self' data:; \
-             connect-src 'self' https://docs.google.com; \
-             frame-ancestors 'none'"
-
-        h.Remove "X-Powered-By" |> ignore
-        Task.CompletedTask
-    )
-
-    next.Invoke()
-
-
-// A2 — Per-IP fixed-window rate limiter applied to every HTTP request.
-// 60 requests / 10 s window / IP (= 6 r/s sustained, 60-request burst),
-// no queue: overflow = 429 instantly.
-//
-// Sized for actual SPA usage: a single Gender radio click fans out to
-// ~4 RPCs, a clinician filling a form chains ~10 such actions in a few
-// seconds — 60-burst absorbs it. Sustained 6 r/s still cuts scripted
-// brute force on ValidatePassword by an order of magnitude.
-//
-// Partition key uses getClientIP, which now returns the real client IP
-// resolved by ASP.NET's ForwardedHeadersMiddleware (configured with the
-// trustedProxies allow-list). XFF is honoured only when the immediate
-// connection comes from a known proxy, so spoofed XFF cannot bypass
-// the limiter and cannot inflate partition cardinality (finding B3
-// addressed for C1, configurable via GENPRES_TRUSTED_PROXIES for C2).
-//
-// QueueLimit = 0 = no queue, no QueueProcessingOrder needed (overflow
-// is rejected with 429 immediately).
-//
-// Proper per-attempt auth lockout — which would only touch the password
-// path — needs Remoting.fromContext to lift client-IP into
-// validatePassword and is still deferred.
-let addRateLimiting (services: IServiceCollection) =
-    services.AddRateLimiter(fun (opts: RateLimiterOptions) ->
-        opts.RejectionStatusCode <- 429
-
-        opts.GlobalLimiter <-
-            PartitionedRateLimiter.Create<HttpContext, string>(fun ctx ->
-                let ip = getClientIP ctx
-
-                RateLimitPartition.GetFixedWindowLimiter(
-                    ip,
-                    fun _ ->
-                        FixedWindowRateLimiterOptions(
-                            PermitLimit = 60,
-                            Window = System.TimeSpan.FromSeconds(10.0),
-                            QueueLimit = 0
-                        )
-                )
-            )
-    )
-
-
-let webApi =
-    Remoting.createApi ()
-    |> Remoting.fromValue (createServerApi provider)
-    |> Remoting.withRouteBuilder routerPaths
-    |> Remoting.buildHttpHandler
-
-
-// L1 — Defense-in-depth wrapper. The original Fable.Remoting.Giraffe 5.24
-// ABI drift against Giraffe 7+ (MissingMethodException / TypeLoadException
-// from Giraffe.Core.setBodyFromString, leaking full .NET type signatures)
-// is resolved upstream in Fable.Remoting.Giraffe 6.1.0. This wrapper is
-// retained as belt-and-braces so any future reflection/ABI fault returns
-// a clean 400 instead of a raw exception body.
-let safeWebApi: HttpHandler =
-    fun (next: HttpFunc) (ctx: HttpContext) ->
-        task {
-            try
-                return! webApi next ctx
-            with ex when (ex :? System.MissingMethodException || ex :? System.TypeLoadException) ->
-                // Record the ABI fault so neither branch can fail silently.
-                // Stderr fires unconditionally; logger fires only if
-                // GENPRES_LOG is set. The mid-stream branch (HasStarted = true)
-                // cannot rewrite the response, so this log is the only signal
-                // the caller will ever get.
-                let msg =
-                    $"safeWebApi caught %s{ex.GetType().Name} on %s{ctx.Request.Path.ToString()}: %s{ex.Message}"
-
-                eprintfn $"{msg}"
-
-                match Logging.loggingLevel with
-                | Some level ->
-                    let logger = Logging.getLogger level Logging.RequestLogger
-
-                    async {
-                        do! logger |> Logging.setComponentName (Some "safeWebApi")
-
-                        Logging.ServerLogging.Error msg
-                        |> Informedica.Logging.Lib.Logging.logError logger.Logger
-                    }
-                    |> Async.Start
-                | None -> ()
-
-                if not ctx.Response.HasStarted then
-                    ctx.Response.StatusCode <- 400
-                    ctx.Response.ContentType <- "application/json; charset=utf-8"
-                    do! ctx.Response.WriteAsync "\"Bad Request\""
-
-                return Some ctx
+    /// The GENPRES_* settings (and SERVER_PORT) as the server uses them.
+    type Settings =
+        {
+            // SERVER_PORT, default 8085
+            Port: uint16
+            // GENPRES_PROD = "1"
+            IsProd: bool
+            // GENPRES_URL_ID; None when unset or blank
+            UrlId: string option
+            // GENPRES_PASSWORD; None when unset or blank
+            Password: string option
+            // GENPRES_TRUSTED_PROXIES, parsed; loopback pair when unset
+            TrustedProxies: System.Net.IPAddress[]
+            // GENPRES_LOG, raw, banner only (Logging.fs reads it itself)
+            Log: string
+            // GENPRES_DEBUG, raw, banner only
+            Debug: string
         }
 
 
-// Security headers come from securityHeadersMiddleware (app_config below),
-// so this stays handler-only. The 404 arm replaces a legacy
-// "GenInteractions App. Use localhost: 8080 for the GUI" string that
-// leaked an old app name and hinted at port 8080 (L2 / B5).
-let webApp =
-    choose
-        [
-            logClientIP >=> safeWebApi
-            setStatusCode 404 >=> text "Not Found"
-        ]
+    // Empty/whitespace is treated as not-set so an empty
+    // `ENV GENPRES_PASSWORD=` / `ENV GENPRES_URL_ID=` from a Dockerfile is
+    // reported truthfully instead of looking injected, and so an empty
+    // Docker env never flows into getCachedProviderWithDataUrlId to
+    // surface much later as a confusing "cannot find column" error.
+    let nonBlank (raw: string option) =
+        raw |> Option.filter (System.String.IsNullOrWhiteSpace >> not)
 
 
-type LoggerShutdown() =
-    interface IHostedService with
-        member _.StartAsync _ = Task.CompletedTask
-
-        member _.StopAsync _ =
-            lock
-                Logging.loggerLock
-                (fun () ->
-                    [|
-                        for kv in Logging.loggers do
-                            let logger = kv.Value
-
-                            writeInfoMessage $"Trying to Stop {kv.Key}"
-
-                            try
-                                logger.StopAsync()
-                            with ex ->
-                                writeDebugMessage $"Logger shutdown failed: {ex.Message}"
-                                async { return () }
-                    |]
-                    |> Async.Parallel
-                    |> Async.StartAsTask
-                    :> Task
-                )
+    /// Banner display string for the password: never the value itself.
+    let displayPassword (raw: string option) =
+        raw
+        |> nonBlank
+        |> Option.map (fun _ -> "***")
+        |> Option.defaultValue "NOT SET (admin operations disabled)"
 
 
-let application =
-    application {
-        url ("http://*:" + port.ToString() + "/")
-        use_mime_types [ ".svg", "image/svg+xml"; ".png", "image/png" ]
-        use_static "public" //publicPath
-        use_router webApp
+    /// Banner display string for the Sheet ID: only the last 5 chars, so it
+    /// never lands in logs or screenshots intact. Built here, not in the
+    /// banner template, so the `NOT SET` path doesn't render as `***NOT SET`.
+    let redactUrlId (raw: string option) =
+        raw
+        |> nonBlank
+        |> Option.map (fun s ->
+            if s.Length > 5 then
+                $"***%s{s.Substring(s.Length - 5)}"
+            else
+                "***<redacted>"
+        )
+        |> Option.defaultValue "NOT SET"
 
-        service_config (fun services ->
-            services.AddHostedService<LoggerShutdown>() |> ignore
 
-            // B3 — Configure ForwardedHeadersMiddleware so XFF is only
-            // honoured for connections from the trustedProxies allow-list
-            // (loopback by default, overridable via GENPRES_TRUSTED_PROXIES).
-            services.Configure<ForwardedHeadersOptions>(fun (opts: ForwardedHeadersOptions) ->
-                opts.ForwardedHeaders <- ForwardedHeaders.XForwardedFor
-                opts.KnownProxies.Clear()
-
-                for ip in trustedProxies do
-                    opts.KnownProxies.Add(ip)
+    // B3 — Trusted reverse-proxy allow-list for ForwardedHeadersMiddleware.
+    // Default = loopback only (matches the Plesk → Kestrel hop on the
+    // public demo deployments and any local-dev setup). Override with
+    // GENPRES_TRUSTED_PROXIES as a comma-separated list of IPs, e.g.
+    //     GENPRES_TRUSTED_PROXIES="10.0.0.5, 10.0.0.6"
+    // for a hospital LAN behind a known nginx fleet. Unparseable values
+    // are silently dropped — fail-open on the parser, fail-closed on the
+    // allow-list (no entry = no XFF trust).
+    let parseTrustedProxies (raw: string option) =
+        raw
+        |> nonBlank
+        |> Option.map (fun s ->
+            s.Split(',')
+            |> Array.choose (fun part ->
+                match System.Net.IPAddress.TryParse(part.Trim()) with
+                | true, ip -> Some ip
+                | false, _ -> None
             )
-            |> ignore
+        )
+        |> Option.defaultValue
+            [|
+                System.Net.IPAddress.Loopback
+                System.Net.IPAddress.IPv6Loopback
+            |]
 
-            addRateLimiting services |> ignore
-            services
+
+    // SECURITY: in production mode (GENPRES_PROD=1), refuse to start without
+    // a GENPRES_PASSWORD of at least minProductionPasswordLength characters.
+    // Fail-closed, checked before any listener binds. Demo/dev mode accepts
+    // any value (or none — admin ops just stay disabled).
+    let minProductionPasswordLength = 16
+
+
+    /// <summary>
+    /// The production password policy. <c>Ok</c> outside production or with
+    /// a password of at least <c>minProductionPasswordLength</c> characters;
+    /// otherwise the message the server refuses to start with.
+    /// </summary>
+    let validateProductionPassword (isProd: bool) (password: string option) : Result<unit, string> =
+        if not isProd then
+            Ok()
+        else
+            // Blank = unset, so a forgotten Docker env hits the "not set"
+            // branch instead of "shorter than 16 characters".
+            match password |> nonBlank with
+            | None ->
+                Error
+                    "GENPRES_PROD=1 but GENPRES_PASSWORD is not set (or is empty). \
+                     Refusing to start in production without an admin password. \
+                     Generate one with `openssl rand -base64 32` and inject it via a secret store. \
+                     See DEVELOPMENT.md → Password policy."
+            | Some pwd when pwd.Length < minProductionPasswordLength ->
+                Error
+                    $"GENPRES_PROD=1 but GENPRES_PASSWORD is shorter than %i{minProductionPasswordLength} characters. \
+                     Refusing to start in production with a weak admin password. \
+                     Generate a stronger one with `openssl rand -base64 32`. \
+                     See DEVELOPMENT.md → Password policy."
+            | Some _ -> Ok()
+
+
+    /// Reads every setting through <c>getEnv</c>. Pure: pass <c>Env.getItem</c>
+    /// for the real environment, a <c>Map.tryFind</c> in tests.
+    let fromEnv (getEnv: string -> string option) : Settings =
+        {
+            Port = "SERVER_PORT" |> getEnv |> Option.map uint16 |> Option.defaultValue 8085us
+            IsProd =
+                getEnv "GENPRES_PROD"
+                |> Option.map (fun v -> v = "1")
+                |> Option.defaultValue false
+            UrlId = getEnv "GENPRES_URL_ID" |> nonBlank
+            Password = getEnv "GENPRES_PASSWORD" |> nonBlank
+            TrustedProxies = getEnv "GENPRES_TRUSTED_PROXIES" |> parseTrustedProxies
+            Log = getEnv "GENPRES_LOG" |> Option.defaultValue "0"
+            Debug = getEnv "GENPRES_DEBUG" |> Option.defaultValue "i"
+        }
+
+
+    /// The start-up banner. Secrets are redacted; <c>systemInfo</c> is passed
+    /// in because collecting it is an effect.
+    let banner (systemInfo: string) (settings: Settings) =
+        $"""
+
+=== Environmental variables ===
+GENPRES_URL_ID = {settings.UrlId |> redactUrlId}
+GENPRES_LOG ={settings.Log}
+GENPRES_PROD = {if settings.IsProd then "1" else "0"}
+GENPRES_DEBUG = {settings.Debug}
+GENPRES_PASSWORD = {settings.Password |> displayPassword}
+
+=== System Info ===
+
+{systemInfo}
+
+"""
+
+
+/// HTTP handlers, middleware and the hosted service: everything that runs
+/// per request or per host lifetime. Nothing here reads the environment;
+/// the values it needs arrive as parameters from <c>Host.build</c>.
+module Http =
+
+    // B3 — Returns the immediate peer IP. After UseForwardedHeaders runs
+    // (registered via app_config in Host.build) this is the real client IP
+    // for requests that arrived through a known proxy, and the actual peer
+    // for direct connections. The previous version trusted X-Forwarded-For
+    // from any source (finding B3); that path is now obsolete and the
+    // rate limiter's partition cardinality is bounded by real ingress IPs.
+    let getClientIP (context: HttpContext) =
+        match context.Connection.RemoteIpAddress with
+        | null -> "unknown"
+        | ip -> ip.ToString()
+
+
+    /// <summary>
+    /// Cache-Control value for a response. Vite emits the client as
+    /// content-hashed files under /assets/, so a successful response for one
+    /// of those can be cached forever; everything else — "/", index.html,
+    /// icons, the Fable.Remoting routes, and any error — is "no-cache": the
+    /// browser may keep a copy but must revalidate it on every load. The ETag
+    /// that StaticFileMiddleware already emits then answers with a 304 when
+    /// nothing changed and a full fetch after a deploy.
+    /// </summary>
+    /// <remarks>
+    /// Without a Cache-Control header browsers apply heuristic freshness
+    /// (RFC 9111 §4.2.2, typically 10 % of now − Last-Modified), which is how
+    /// a long-running container ends up with clients that never see a new
+    /// index.html and keep loading the previous hashed bundle (#568).
+    ///
+    /// The status check matters: a 404 for an asset that this instance does
+    /// not have yet (a rolling deploy, a stale index.html) must never be
+    /// cached for a year, or the client stays broken after the asset arrives.
+    /// The path can be null for a request without one, such as OPTIONS *.
+    /// </remarks>
+    let cacheControlFor (statusCode: int) (path: string) =
+        let isAsset =
+            not (System.String.IsNullOrEmpty path)
+            && path.StartsWith("/assets/", System.StringComparison.OrdinalIgnoreCase)
+
+        if isAsset && statusCode >= 200 && statusCode < 300 then
+            "public, max-age=31536000, immutable"
+        else
+            "no-cache"
+
+
+    // B2 — Security response header baseline. ASP.NET middleware (wired via
+    // app_config) using Response.OnStarting so headers land on every flushed
+    // response: static files, Giraffe routes, the 404 fallback, and
+    // Fable.Remoting error responses alike. Also owns the Cache-Control
+    // policy (cacheControlFor above), because this is the one hook that
+    // runs on static responses and Saturn's use_static does not expose
+    // StaticFileOptions.OnPrepareResponse.
+    //
+    // CSP allow-list reflects the SPA's actual fetches: same-origin scripts
+    // (Fable bundle), maxcdn + Google Fonts for CSS, gstatic for fonts,
+    // docs.google.com for the runtime Sheet fetches. Drop docs.google.com
+    // once Sheet access is proxied server-side. X-Powered-By is stripped in
+    // case nginx/Plesk injects it.
+    //
+    // style-src includes 'unsafe-inline' because MUI's styling engine
+    // (Emotion) injects per-component <style> tags at runtime. Without it
+    // every MUI component renders unstyled. script-src remains strict
+    // ('self' only) so XSS exposure is bounded to CSS injection, which
+    // cannot execute code. Tightening this further requires wiring an
+    // Emotion CacheProvider with a per-request nonce — tracked as a
+    // follow-up to the security review.
+    let securityHeadersMiddleware (ctx: HttpContext) (next: System.Func<Task>) : Task =
+        ctx.Response.OnStarting(fun () ->
+            let h = ctx.Response.Headers
+            h["Strict-Transport-Security"] <- "max-age=31536000; includeSubDomains"
+            h["X-Content-Type-Options"] <- "nosniff"
+            h["X-Frame-Options"] <- "DENY"
+            h["Referrer-Policy"] <- "no-referrer"
+            h["Permissions-Policy"] <- "geolocation=(), camera=(), microphone=()"
+            h["Cache-Control"] <- cacheControlFor ctx.Response.StatusCode ctx.Request.Path.Value
+
+            h["Content-Security-Policy"] <-
+                "default-src 'self'; \
+                 script-src 'self'; \
+                 style-src 'self' 'unsafe-inline' https://maxcdn.bootstrapcdn.com https://fonts.googleapis.com; \
+                 font-src 'self' https://fonts.gstatic.com https://maxcdn.bootstrapcdn.com; \
+                 img-src 'self' data:; \
+                 connect-src 'self' https://docs.google.com; \
+                 frame-ancestors 'none'"
+
+            h.Remove "X-Powered-By" |> ignore
+            Task.CompletedTask
         )
 
-        // B3 ForwardedHeaders → B2 security headers → A2 rate limiter.
-        // UseForwardedHeaders must run first so the rate limiter sees the
-        // real client IP via ctx.Connection.RemoteIpAddress.
-        // UseRateLimiter activates the limiter registered via
-        // addRateLimiting; without it the service is registered but
-        // never invoked.
-        app_config (fun app ->
-            app
-                .UseForwardedHeaders()
-                .Use(System.Func<HttpContext, System.Func<Task>, Task>(securityHeadersMiddleware))
-                .UseRateLimiter()
+        next.Invoke()
+
+
+    // A2 — Per-IP fixed-window rate limiter applied to every HTTP request.
+    // 60 requests / 10 s window / IP (= 6 r/s sustained, 60-request burst),
+    // no queue: overflow = 429 instantly.
+    //
+    // Sized for actual SPA usage: a single Gender radio click fans out to
+    // ~4 RPCs, a clinician filling a form chains ~10 such actions in a few
+    // seconds — 60-burst absorbs it. Sustained 6 r/s still cuts scripted
+    // brute force on ValidatePassword by an order of magnitude.
+    //
+    // Partition key uses getClientIP, which now returns the real client IP
+    // resolved by ASP.NET's ForwardedHeadersMiddleware (configured with the
+    // trustedProxies allow-list). XFF is honoured only when the immediate
+    // connection comes from a known proxy, so spoofed XFF cannot bypass
+    // the limiter and cannot inflate partition cardinality (finding B3
+    // addressed for C1, configurable via GENPRES_TRUSTED_PROXIES for C2).
+    //
+    // QueueLimit = 0 = no queue, no QueueProcessingOrder needed (overflow
+    // is rejected with 429 immediately).
+    //
+    // Proper per-attempt auth lockout — which would only touch the password
+    // path — needs Remoting.fromContext to lift client-IP into
+    // validatePassword and is still deferred.
+    let addRateLimiting (services: IServiceCollection) =
+        services.AddRateLimiter(fun (opts: RateLimiterOptions) ->
+            opts.RejectionStatusCode <- 429
+
+            opts.GlobalLimiter <-
+                PartitionedRateLimiter.Create<HttpContext, string>(fun ctx ->
+                    let ip = getClientIP ctx
+
+                    RateLimitPartition.GetFixedWindowLimiter(
+                        ip,
+                        fun _ ->
+                            FixedWindowRateLimiterOptions(
+                                PermitLimit = 60,
+                                Window = System.TimeSpan.FromSeconds(10.0),
+                                QueueLimit = 0
+                            )
+                    )
+                )
         )
 
-        memory_cache
-        use_gzip
-    }
 
-run application
+    let logClientIP: HttpHandler =
+        fun (next: HttpFunc) (ctx: HttpContext) ->
+            match Logging.loggingLevel with
+            | None -> next ctx
+            | Some level ->
+                let clientIP = getClientIP ctx
+                let path = ctx.Request.Path.ToString()
+                let method = ctx.Request.Method
+                let logger = Logging.getLogger level Logging.RequestLogger
+
+                async {
+                    do! logger |> Logging.setComponentName (Some "Client_Request")
+
+                    Logging.ServerLogging.logRequest logger method path clientIP
+                    return ()
+                }
+                |> Async.Start
+
+                // Continue with the next handler
+                next ctx
+
+
+    // L1 — Defense-in-depth wrapper. The original Fable.Remoting.Giraffe 5.24
+    // ABI drift against Giraffe 7+ (MissingMethodException / TypeLoadException
+    // from Giraffe.Core.setBodyFromString, leaking full .NET type signatures)
+    // is resolved upstream in Fable.Remoting.Giraffe 6.1.0. This wrapper is
+    // retained as belt-and-braces so any future reflection/ABI fault returns
+    // a clean 400 instead of a raw exception body.
+    let safeWebApi (webApi: HttpHandler) : HttpHandler =
+        fun (next: HttpFunc) (ctx: HttpContext) ->
+            task {
+                try
+                    return! webApi next ctx
+                with ex when (ex :? System.MissingMethodException || ex :? System.TypeLoadException) ->
+                    // Record the ABI fault so neither branch can fail silently.
+                    // Stderr fires unconditionally; logger fires only if
+                    // GENPRES_LOG is set. The mid-stream branch (HasStarted = true)
+                    // cannot rewrite the response, so this log is the only signal
+                    // the caller will ever get.
+                    let msg =
+                        $"safeWebApi caught %s{ex.GetType().Name} on %s{ctx.Request.Path.ToString()}: %s{ex.Message}"
+
+                    eprintfn $"{msg}"
+
+                    match Logging.loggingLevel with
+                    | Some level ->
+                        let logger = Logging.getLogger level Logging.RequestLogger
+
+                        async {
+                            do! logger |> Logging.setComponentName (Some "safeWebApi")
+
+                            Logging.ServerLogging.Error msg
+                            |> Informedica.Logging.Lib.Logging.logError logger.Logger
+                        }
+                        |> Async.Start
+                    | None -> ()
+
+                    if not ctx.Response.HasStarted then
+                        ctx.Response.StatusCode <- 400
+                        ctx.Response.ContentType <- "application/json; charset=utf-8"
+                        do! ctx.Response.WriteAsync "\"Bad Request\""
+
+                    return Some ctx
+            }
+
+
+    /// Stops every logger agent when the host shuts down.
+    type LoggerShutdown() =
+        interface IHostedService with
+            member _.StartAsync _ = Task.CompletedTask
+
+            member _.StopAsync _ =
+                lock
+                    Logging.loggerLock
+                    (fun () ->
+                        [|
+                            for kv in Logging.loggers do
+                                let logger = kv.Value
+
+                                writeInfoMessage $"Trying to Stop {kv.Key}"
+
+                                try
+                                    logger.StopAsync()
+                                with ex ->
+                                    writeDebugMessage $"Logger shutdown failed: {ex.Message}"
+                                    async { return () }
+                        |]
+                        |> Async.Parallel
+                        |> Async.StartAsTask
+                        :> Task
+                    )
+
+
+/// The composition root: wires settings, the resource provider and the
+/// Http pieces into a Saturn application. Only <c>main</c> calls this.
+module Host =
+
+    /// The cached GenFORM resource provider for a Sheet ID, with the
+    /// resources logger attached when GENPRES_LOG is set.
+    let resourceProvider (urlId: string) =
+        let logger =
+            Logging.loggingLevel
+            |> Option.map (fun level ->
+                Logging.getLogger level Logging.ResourcesLogger
+                |> (fun logger ->
+                    logger |> Logging.setComponentName (Some "Provider") |> Async.RunSynchronously
+                    logger
+                )
+            )
+            |> Option.map _.Logger
+            |> Option.defaultValue Informedica.GenOrder.Lib.Logging.noOp
+
+        urlId |> Informedica.GenForm.Lib.Api.getCachedProviderWithDataUrlId logger
+
+
+    let build (settings: Config.Settings) (provider: Informedica.GenForm.Lib.Resources.IResourceProvider) =
+        let webApi =
+            Remoting.createApi ()
+            |> Remoting.fromValue (createServerApi provider)
+            |> Remoting.withRouteBuilder routerPaths
+            |> Remoting.buildHttpHandler
+
+        // Security headers come from securityHeadersMiddleware (app_config
+        // below), so this stays handler-only. The 404 arm replaces a legacy
+        // "GenInteractions App. Use localhost: 8080 for the GUI" string that
+        // leaked an old app name and hinted at port 8080 (L2 / B5).
+        let webApp =
+            choose
+                [
+                    Http.logClientIP >=> Http.safeWebApi webApi
+                    setStatusCode 404 >=> text "Not Found"
+                ]
+
+        application {
+            url ("http://*:" + settings.Port.ToString() + "/")
+            use_mime_types [ ".svg", "image/svg+xml"; ".png", "image/png" ]
+            use_static "public" //publicPath
+            use_router webApp
+
+            service_config (fun services ->
+                services.AddHostedService<Http.LoggerShutdown>() |> ignore
+
+                // B3 — Configure ForwardedHeadersMiddleware so XFF is only
+                // honoured for connections from the trustedProxies allow-list
+                // (loopback by default, overridable via GENPRES_TRUSTED_PROXIES).
+                services.Configure<ForwardedHeadersOptions>(fun (opts: ForwardedHeadersOptions) ->
+                    opts.ForwardedHeaders <- ForwardedHeaders.XForwardedFor
+                    opts.KnownProxies.Clear()
+
+                    for ip in settings.TrustedProxies do
+                        opts.KnownProxies.Add(ip)
+                )
+                |> ignore
+
+                Http.addRateLimiting services |> ignore
+                services
+            )
+
+            // B3 ForwardedHeaders → B2 security headers → A2 rate limiter.
+            // UseForwardedHeaders must run first so the rate limiter sees the
+            // real client IP via ctx.Connection.RemoteIpAddress.
+            // UseRateLimiter activates the limiter registered via
+            // addRateLimiting; without it the service is registered but
+            // never invoked.
+            app_config (fun app ->
+                app
+                    .UseForwardedHeaders()
+                    .Use(System.Func<HttpContext, System.Func<Task>, Task>(Http.securityHeadersMiddleware))
+                    .UseRateLimiter()
+            )
+
+            memory_cache
+            use_gzip
+        }
+
+
+[<EntryPoint>]
+let main _ =
+    // Load .env so GENPRES_* variables are available even when the server
+    // binary is launched directly (e.g. via Rider/VS Code) without first
+    // sourcing .env in the shell. loadDotEnv only sets variables that are
+    // not already present, preserving the shell/CI/Docker > .env > defaults
+    // override chain.
+    Env.loadDotEnv () |> ignore
+
+    let settings = Config.fromEnv Env.getItem
+
+    settings |> Config.banner (Env.getSystemInfo ()) |> writeInfoMessage
+
+    // Fail-closed, before any listener binds.
+    match Config.validateProductionPassword settings.IsProd settings.Password with
+    | Error msg -> invalidOp msg
+    | Ok() -> ()
+
+    let provider =
+        settings.UrlId
+        |> Option.defaultWith (fun () -> invalidOp "No GENPRES_URL_ID (or value is empty)")
+        |> Host.resourceProvider
+
+    Host.build settings provider |> run
+    0

--- a/tests/Informedica.GenPRES.Server.Tests/ConfigTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/ConfigTests.fs
@@ -1,0 +1,163 @@
+module Informedica.GenPRES.Server.Tests.ConfigTests
+
+open Expecto
+open Expecto.Flip
+open Server
+
+
+let loopback =
+    [|
+        System.Net.IPAddress.Loopback
+        System.Net.IPAddress.IPv6Loopback
+    |]
+
+
+let trustedProxiesTests =
+    testList
+        "parseTrustedProxies"
+        [
+            test "unset falls back to the loopback pair" {
+                None |> Config.parseTrustedProxies |> Expect.equal "loopback pair" loopback
+            }
+
+            test "whitespace only falls back to the loopback pair" {
+                Some "   "
+                |> Config.parseTrustedProxies
+                |> Expect.equal "loopback pair" loopback
+            }
+
+            test "keeps the parseable entries and drops the rest" {
+                let exp =
+                    [|
+                        System.Net.IPAddress.Parse "10.0.0.5"
+                        System.Net.IPAddress.Parse "10.0.0.6"
+                    |]
+
+                Some "10.0.0.5, bad, 10.0.0.6"
+                |> Config.parseTrustedProxies
+                |> Expect.equal "two addresses" exp
+            }
+        ]
+
+
+let passwordTests =
+    let sixteen = String.replicate 16 "x"
+    let fifteen = String.replicate 15 "x"
+
+    testList
+        "validateProductionPassword"
+        [
+            test "demo mode accepts no password" {
+                Config.validateProductionPassword false None |> Expect.equal "Ok" (Ok())
+            }
+
+            test "production without a password is refused" {
+                match Config.validateProductionPassword true None with
+                | Error msg -> msg |> Expect.stringContains "names the cause" "not set"
+                | Ok() -> failtest "expected Error"
+            }
+
+            test "production with a blank password is refused as not set" {
+                match Config.validateProductionPassword true (Some "  ") with
+                | Error msg -> msg |> Expect.stringContains "names the cause" "not set"
+                | Ok() -> failtest "expected Error"
+            }
+
+            test "production with 15 characters is refused" {
+                match Config.validateProductionPassword true (Some fifteen) with
+                | Error msg -> msg |> Expect.stringContains "names the minimum" "16"
+                | Ok() -> failtest "expected Error"
+            }
+
+            test "production with 16 characters is accepted" {
+                Config.validateProductionPassword true (Some sixteen)
+                |> Expect.equal "Ok" (Ok())
+            }
+        ]
+
+
+let redactionTests =
+    testList
+        "banner redaction"
+        [
+            test "urlId unset" { None |> Config.redactUrlId |> Expect.equal "NOT SET" "NOT SET" }
+
+            test "urlId of five characters or fewer is fully redacted" {
+                Some "abcde" |> Config.redactUrlId |> Expect.equal "redacted" "***<redacted>"
+            }
+
+            test "urlId keeps only the last five characters" {
+                Some "1234567890" |> Config.redactUrlId |> Expect.equal "last five" "***67890"
+            }
+
+            test "password unset" {
+                None
+                |> Config.displayPassword
+                |> Expect.equal "not set" "NOT SET (admin operations disabled)"
+            }
+
+            test "password set is never shown" { Some "secret" |> Config.displayPassword |> Expect.equal "stars" "***" }
+        ]
+
+
+let fromEnvTests =
+    let getEnv (m: Map<string, string>) key = m |> Map.tryFind key
+
+    testList
+        "fromEnv"
+        [
+            test "defaults when nothing is set" {
+                let s = Config.fromEnv (getEnv Map.empty)
+                s.Port |> Expect.equal "port" 8085us
+                s.IsProd |> Expect.isFalse "not prod"
+                s.UrlId |> Expect.isNone "no url id"
+                s.Password |> Expect.isNone "no password"
+                s.TrustedProxies |> Expect.equal "loopback" loopback
+                s.Log |> Expect.equal "log" "0"
+            }
+
+            test "reads every setting" {
+                let env =
+                    Map
+                        [
+                            "SERVER_PORT", "9000"
+                            "GENPRES_PROD", "1"
+                            "GENPRES_URL_ID", "sheet-id"
+                            "GENPRES_PASSWORD", "pw"
+                            "GENPRES_TRUSTED_PROXIES", "10.0.0.5"
+                            "GENPRES_LOG", "d"
+                            "GENPRES_DEBUG", "1"
+                        ]
+
+                let s = Config.fromEnv (getEnv env)
+                s.Port |> Expect.equal "port" 9000us
+                s.IsProd |> Expect.isTrue "prod"
+                s.UrlId |> Expect.equal "url id" (Some "sheet-id")
+                s.Password |> Expect.equal "password" (Some "pw")
+
+                s.TrustedProxies
+                |> Expect.equal "proxy" [| System.Net.IPAddress.Parse "10.0.0.5" |]
+
+                s.Log |> Expect.equal "log" "d"
+                s.Debug |> Expect.equal "debug" "1"
+            }
+
+            test "blank secrets are treated as unset" {
+                let env = Map [ "GENPRES_URL_ID", " "; "GENPRES_PASSWORD", "" ]
+                let s = Config.fromEnv (getEnv env)
+                s.UrlId |> Expect.isNone "blank url id"
+                s.Password |> Expect.isNone "blank password"
+            }
+        ]
+
+
+[<Tests>]
+let tests =
+    testList
+        "Config Tests"
+        [
+            trustedProxiesTests
+            passwordTests
+            redactionTests
+            fromEnvTests
+        ]

--- a/tests/Informedica.GenPRES.Server.Tests/HttpTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/HttpTests.fs
@@ -35,7 +35,7 @@ let cacheControlTests =
             for status, path, expected in cacheControlCases do
                 test $"%i{status} %A{path} -> %s{expected}" {
                     path
-                    |> Server.cacheControlFor status
+                    |> Server.Http.cacheControlFor status
                     |> Expect.equal $"%i{status} %A{path} should get {expected}" expected
                 }
         ]

--- a/tests/Informedica.GenPRES.Server.Tests/Informedica.GenPRES.Server.Tests.fsproj
+++ b/tests/Informedica.GenPRES.Server.Tests/Informedica.GenPRES.Server.Tests.fsproj
@@ -14,6 +14,7 @@
     <Compile Include="DoseCheckTests.fs" />
     <Compile Include="TotalsTests.fs" />
     <Compile Include="HttpTests.fs" />
+    <Compile Include="ConfigTests.fs" />
     <Compile Include="Program.fs" />
     <None Include="Scripts/load.fsx" />
     <None Include="Scripts/Tests.fsx" />


### PR DESCRIPTION
Follows #570 (merged); the diff is the restructure alone, one commit on top of master.

## Change

`Server.fs` becomes `module Server` with an explicit `[<EntryPoint>] main` and three nested modules:

- **Config** — a `Settings` record and pure parsing of the environment: `fromEnv` over an injected `string -> string option` getter, `parseTrustedProxies`, `validateProductionPassword` (returns `Result` instead of raising), `redactUrlId`, `displayPassword`, `banner`. Unit-tested in `ConfigTests.fs` (16 cases).
- **Http** — `getClientIP`, `cacheControlFor`, `securityHeadersMiddleware`, `addRateLimiting`, `logClientIP`, `safeWebApi` (now takes the inner handler as a parameter instead of closing over a top-level value) and `LoggerShutdown`.
- **Host** — `resourceProvider` and `build`: the composition root that wires settings and the provider into the Saturn `application` block.

Every side effect runs from `main` in the original order (load `.env`, banner, password check, provider, run). No top-level `let` value performs IO any more (AGENTS.md, "Never Perform IO in a Top-Level let Value"). The security-review tag comments (B2, B3, A2, L1, L2/B5) stay with the code they annotate.

Pure move; one cosmetic difference: the banner renders `GENPRES_PROD` as `1`/`0` from the parsed flag rather than echoing the raw string. (Unchanged and worth a look separately: the banner's `GENPRES_DEBUG` default is `"i"`, which looks copied from `GENPRES_LOG`.)

## Size

Well over the 200-line guideline because the whole file moves. If preferred, the `Config` extraction can be split out as its own PR; say so and I will.

## Verified

- 64 server tests pass (`CI=true`), `dotnet fantomas` unchanged, `scripts/CheckDependencyRule.fsx` passes.
- Docker image built from this tree and run in demo mode: banner prints redacted values, `/` is `no-cache`, `/assets/*` immutable, security headers intact; `GENPRES_PROD=1` without a password still refuses to start with the same message. (The container then stays up instead of exiting; that is pre-existing, PID 1 ignoring SIGABRT, and tracked in #572.)

Fixes #568

## AI-assisted

Vibe coded: generated with Claude Code from the plan in #569 and reviewed against the previous file line by line for behaviour changes; verified by the tests and the Docker run above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mSmuXp7EWqw2pWS7eLiVs


