### PR TITLE
fix(docker): exit the container when the server refuses to start

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -282,7 +282,9 @@ jobs:
       # The smoke test above cannot see issue #572: a container that never exits after the server
       # refuses to start looks exactly like one that is still starting. This starts the image with a
       # configuration the server refuses (production mode without a password) and requires the
-      # container to exit non-zero, which proves PID 1 (tini) passes the exit on.
+      # container to exit with code 1: the controlled refusal in `main`, not the 134 of an unhandled
+      # exception, so the check proves both that PID 1 (tini) passes the exit on and that the
+      # server took its documented exit path.
       run: |
         set -euo pipefail
         container=$(docker run -d -e GENPRES_PROD=1 -e GENPRES_PASSWORD= "$IMAGE")
@@ -296,8 +298,8 @@ jobs:
           echo "::error::Container still running 30s after a refused start-up (issue #572)"
           exit 1
         fi
-        if [ "$code" -eq 0 ]; then
-          echo "::error::Refused start-up exited 0; expected a non-zero exit code"
+        if [ "$code" -ne 1 ]; then
+          echo "::error::Refused start-up exited $code; expected exit code 1"
           exit 1
         fi
         echo "Refusal check passed: container exited $code"

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -276,6 +276,32 @@ jobs:
         echo "::error::Smoke test failed: / did not return 200 within 60s of container start"
         exit 1
 
+    - name: Check that a refused start-up exits the container
+      env:
+        IMAGE: ${{ steps.tags.outputs.version_tag }}
+      # The smoke test above cannot see issue #572: a container that never exits after the server
+      # refuses to start looks exactly like one that is still starting. This starts the image with a
+      # configuration the server refuses (production mode without a password) and requires the
+      # container to exit non-zero, which proves PID 1 (tini) passes the exit on.
+      run: |
+        set -euo pipefail
+        container=$(docker run -d -e GENPRES_PROD=1 -e GENPRES_PASSWORD= "$IMAGE")
+        cleanup() {
+          docker logs "$container" || true
+          docker rm -f "$container" >/dev/null 2>&1 || true
+        }
+        trap cleanup EXIT
+
+        if ! code=$(timeout 30 docker wait "$container"); then
+          echo "::error::Container still running 30s after a refused start-up (issue #572)"
+          exit 1
+        fi
+        if [ "$code" -eq 0 ]; then
+          echo "::error::Refused start-up exited 0; expected a non-zero exit code"
+          exit 1
+        fi
+        echo "Refusal check passed: container exited $code"
+
     - name: Push image
       # The image already built and passed its smoke test above, tagged locally under every tag
       # from steps.tags. Pushing each tag directly here avoids building the image a second time.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -459,8 +459,8 @@ Now a refused start-up (the production password policy, or no `GENPRES_URL_ID`) 
 and exits `1`, a crash exits `134`, and `docker stop` still reaches Kestrel for a graceful shutdown.
 `compose.yaml`'s `restart: unless-stopped` and any orchestrator act on those codes; read them with
 `docker ps -a`. No `--init` or `init: true` is needed. The release workflow proves this on every
-image it publishes by starting it with `GENPRES_PROD=1` and no password and requiring a non-zero
-exit within 30 seconds.
+image it publishes by starting it with `GENPRES_PROD=1` and no password and requiring exit code
+`1` within 30 seconds.
 
 **Browser caching after an update** — the server sets `Cache-Control` on every response
 (`securityHeadersMiddleware` in `src/Informedica.GenPRES.Server/Server.fs`, issue

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -451,6 +451,17 @@ The image is published by `tag-release.yml` a few minutes *after* the release PR
 
 Demo or production is whatever `GENPRES_PROD` says in `.env`. The image itself defaults to demo (`GENPRES_PROD=0`, public demo sheet ID, no password — issue [#541](https://github.com/informedica/GenPRES/issues/541)), so a bare `docker run -p 8080:8085 informedica/genpres:<tag>` or the Docker Desktop "Run" button also works with no flags. `GENPRES_PROD=1` additionally needs the proprietary `GENPRES_URL_ID`, a 16+ character `GENPRES_PASSWORD`, and the `data/cache` bind mount that `compose.yaml` already declares: production reads `*.cache`, and the image ships only the `*.demo` files. `compose.yaml` forwards only the `GENPRES_*` keys, not the whole `.env`, so unrelated local secrets stay out of the container. Unlike `dotnet run DockerRun`, this needs no .NET SDK on the host, runs the exact published image rather than a local build, and includes the cache mount.
 
+**Process 1 and exit codes** — the image runs [`tini`](https://github.com/krallin/tini) as PID 1
+and starts `dotnet` under it (issue [#572](https://github.com/informedica/GenPRES/issues/572)).
+With `dotnet` itself as PID 1, the `SIGABRT` the runtime sends itself after an unhandled exception
+was dropped, so a container whose server refused to start stayed "running" with nothing listening.
+Now a refused start-up (the production password policy, or no `GENPRES_URL_ID`) prints one message
+and exits `1`, a crash exits `134`, and `docker stop` still reaches Kestrel for a graceful shutdown.
+`compose.yaml`'s `restart: unless-stopped` and any orchestrator act on those codes; read them with
+`docker ps -a`. No `--init` or `init: true` is needed. The release workflow proves this on every
+image it publishes by starting it with `GENPRES_PROD=1` and no password and requiring a non-zero
+exit within 30 seconds.
+
 **Browser caching after an update** — the server sets `Cache-Control` on every response
 (`securityHeadersMiddleware` in `src/Informedica.GenPRES.Server/Server.fs`, issue
 [#568](https://github.com/informedica/GenPRES/issues/568)): `no-cache` for `index.html` and

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,16 @@ FROM mcr.microsoft.com/dotnet/aspnet:10.0
 ARG APP_VERSION=0.0.0
 LABEL org.opencontainers.image.version="${APP_VERSION}"
 
+# tini as PID 1 (issue #572). With dotnet itself as PID 1 the runtime never died from
+# the SIGABRT it sends itself after an unhandled exception, because Linux drops the
+# default action of a signal for PID 1: a refused start-up left the container "running"
+# with nothing listening. tini reaps and forwards signals, so an abort now ends the
+# container (exit 134), a refused start-up exits 1 (see Server.fs, main), and
+# `docker stop` still reaches Kestrel for a graceful shutdown. No `--init` needed.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends tini \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY --from=app-build /workspace/deploy /app
 
 ENV GENPRES_LOG=0
@@ -86,4 +96,4 @@ ENV GENPRES_PASSWORD=
 
 WORKDIR /app
 EXPOSE 8085
-ENTRYPOINT [ "dotnet", "Informedica.GenPRES.Server.dll" ]
+ENTRYPOINT [ "tini", "--", "dotnet", "Informedica.GenPRES.Server.dll" ]

--- a/src/Informedica.GenPRES.Server/Server.fs
+++ b/src/Informedica.GenPRES.Server/Server.fs
@@ -141,6 +141,20 @@ module Config =
             | Some _ -> Ok()
 
 
+    /// <summary>
+    /// Every start-up guard in one place: the production password policy,
+    /// then the presence of <c>GENPRES_URL_ID</c>. <c>Ok</c> carries the URL
+    /// ID the host needs; <c>Error</c> is the message the server exits with.
+    /// </summary>
+    let validateStartup (settings: Settings) : Result<string, string> =
+        validateProductionPassword settings.IsProd settings.Password
+        |> Result.bind (fun () ->
+            match settings.UrlId with
+            | Some urlId -> Ok urlId
+            | None -> Error "No GENPRES_URL_ID (or value is empty)"
+        )
+
+
     /// Reads every setting through <c>getEnv</c>. Pure: pass <c>Env.getItem</c>
     /// for the real environment, a <c>Map.tryFind</c> in tests.
     let fromEnv (getEnv: string -> string option) : Settings =
@@ -504,15 +518,16 @@ let main _ =
 
     settings |> Config.banner (Env.getSystemInfo ()) |> writeInfoMessage
 
-    // Fail-closed, before any listener binds.
-    match Config.validateProductionPassword settings.IsProd settings.Password with
-    | Error msg -> invalidOp msg
-    | Ok() -> ()
-
-    let provider =
-        settings.UrlId
-        |> Option.defaultWith (fun () -> invalidOp "No GENPRES_URL_ID (or value is empty)")
-        |> Host.resourceProvider
-
-    Host.build settings provider |> run
-    0
+    // Fail-closed, before any listener binds. A refused configuration is
+    // reported with an exit code, not an exception: in the Docker image the
+    // runtime used to be PID 1, and the SIGABRT it sends itself after an
+    // unhandled exception was dropped, leaving the container "running" with
+    // nothing listening (issue #572). A genuine crash elsewhere is still an
+    // unhandled exception on purpose; tini as PID 1 turns it into exit 134.
+    match Config.validateStartup settings with
+    | Error msg ->
+        writeErrorMessage msg
+        1
+    | Ok urlId ->
+        Host.build settings (Host.resourceProvider urlId) |> run
+        0

--- a/tests/Informedica.GenPRES.Server.Tests/ConfigTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/ConfigTests.fs
@@ -76,6 +76,52 @@ let passwordTests =
         ]
 
 
+let validateStartupTests =
+    let settings (m: Map<string, string>) =
+        Config.fromEnv (fun key -> m |> Map.tryFind key)
+
+    let sixteen = String.replicate 16 "x"
+
+    testList
+        "validateStartup"
+        [
+            test "demo with a url id starts" {
+                Map [ "GENPRES_URL_ID", "sheet-id" ]
+                |> settings
+                |> Config.validateStartup
+                |> Expect.equal "Ok with the url id" (Ok "sheet-id")
+            }
+
+            test "demo without a url id is refused" {
+                match Map.empty |> settings |> Config.validateStartup with
+                | Error msg -> msg |> Expect.stringContains "names the setting" "GENPRES_URL_ID"
+                | Ok _ -> failtest "expected Error"
+            }
+
+            test "production without a password is refused before the url id is checked" {
+                match
+                    Map [ "GENPRES_PROD", "1"; "GENPRES_URL_ID", "sheet-id" ]
+                    |> settings
+                    |> Config.validateStartup
+                with
+                | Error msg -> msg |> Expect.stringContains "names the cause" "not set"
+                | Ok _ -> failtest "expected Error"
+            }
+
+            test "production with a valid password and a url id starts" {
+                Map
+                    [
+                        "GENPRES_PROD", "1"
+                        "GENPRES_PASSWORD", sixteen
+                        "GENPRES_URL_ID", "sheet-id"
+                    ]
+                |> settings
+                |> Config.validateStartup
+                |> Expect.equal "Ok with the url id" (Ok "sheet-id")
+            }
+        ]
+
+
 let redactionTests =
     testList
         "banner redaction"
@@ -158,6 +204,7 @@ let tests =
         [
             trustedProxiesTests
             passwordTests
+            validateStartupTests
             redactionTests
             fromEnvTests
         ]


### PR DESCRIPTION
## Overview

Fixes #572. Implements options 2 + 3 from the issue, per the plan in #576 (`docs/implementation-plans/572-container-exit-on-startup-refusal.md`):

- **`Dockerfile`**: the runtime stage installs `tini` and the entry point becomes `tini -- dotnet Informedica.GenPRES.Server.dll`. With dotnet as PID 1 the `SIGABRT` it sends itself after an unhandled exception was dropped, so a refused start-up left the container "running" with nothing listening.
- **`Server.fs`**: new pure `Config.validateStartup : Settings -> Result<string, string>` (password policy, then `GENPRES_URL_ID`; `Ok` carries the URL ID). `main` writes the message and returns `1` on `Error` instead of `invalidOp`. A crash anywhere else is deliberately still an unhandled exception, which now exits 134 through tini.
- **`ConfigTests.fs`**: four tests for `validateStartup`.
- **`tag-release.yml`**: a new step after the smoke test starts the built image with `GENPRES_PROD=1` and an empty password and fails unless the container exits non-zero within 30 s. The happy-path smoke test cannot see this bug: a container that never exits looks the same as one still starting.
- **`DEVELOPMENT.md`**: "Process 1 and exit codes" paragraph in the Docker section.

## Further information

This deviates from the #419 table row that maps "missing configuration" to `invalidOp` with "startup guards stay fail-fast". They stay fail-fast, but via an exit code, since an exception is not a reliable exit path for a process that may be PID 1. The plan doc records this.

`init: true` in `compose.yaml` (option 1) is intentionally not added: with tini in the image it would only add a second init process.

## Divergence from plan

None.

## Verification

- `dotnet test tests/Informedica.GenPRES.Server.Tests/`: 74 passed (70 existing + 4 new).
- `dotnet fantomas --check` on the two `.fs` files: clean.
- `dotnet run DockerBuild` on this branch, then:
  - `docker run -d -e GENPRES_PROD=1 -e GENPRES_PASSWORD= informedica/genpres` → exited **1 after 1 s**; logs show the password message once, zero stack-trace lines.
  - `docker run -d -e GENPRES_URL_ID= informedica/genpres` → exited **1**, logs show `No GENPRES_URL_ID (or value is empty)`.
  - `docker run -d -p 8090:8085 informedica/genpres` → `/` returns 200; `docker top` shows `tini` as PID 1 with `dotnet` as its child; `docker stop` returns immediately with exit 0 and "Application is shutting down..." in the log (SIGTERM forwarded, graceful shutdown intact).
- The new workflow step was syntax-checked with `bash -n`; it runs for real on the next release.

To reproduce the bug on `master`: build the image from `master` and run the first command above — `docker inspect` keeps reporting `running`.

## Author checklist

I confirm that these changes:

- [x] Follow the process described in [CONTRIBUTING.md](../../CONTRIBUTING.md#pull-request-process).
- [x] Make the changes proposed in the linked issue (if applicable): #572
- [x] Follow the approach documented in the linked implementation plan (if applicable): #576
- [x] Are no more than 200 lines of changed code, ideally 25-100.
- [x] Are not more complex than necessary.
- [x] Cannot easily be split in a way that would make reviewing them significantly easier.
- [x] Follow the guidelines specified in [DEVELOPMENT.md](../../DEVELOPMENT.md).
- [x] Have been thoroughly tested.
- [x] Don't introduce new security vulnerabilities.
- [ ] Follow the [AI/LLM Usage Policy](../../AGENTS.md#aillm-usage-policy) — LLMs were not given direct write access to `.fs` source files (except client-side UI code).

### AI/Vibe Coding Disclosure

- [x] Some or all code in this PR is **vibe coded** (substantially AI-generated). If checked, describe below which parts were AI-generated, which tool was used, and how the code was verified.

All five files were written by Claude Code (Fable 5.1) under an explicit, issue-scoped authorization to edit `Server.fs` and the server tests directly, with the maintainer choosing the approach. Verified by the unit tests, Fantomas, a local image build, and the four container runs listed above.

I confirm that I have:

- [x] Added appropriate automated tests.
- [x] Updated documentation appropriately.
- [x] Added comments that highlight important changes and add justification, where necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mSmuXp7EWqw2pWS7eLiVs
