### PR TITLE
docs(client): implementation plan for the client launch sequence (#409)

### DIFF
--- a/docs/implementation-plans/409-client-launch-sequence.md
+++ b/docs/implementation-plans/409-client-launch-sequence.md
@@ -141,7 +141,7 @@ type SessionEffect =
     | CallCloseSession
     | GoTo of url: string                            // window.location.assign, for RedirectTo
     | SetPatient of Patient option                   // interpreted as UpdatePatient
-    | KeepKey of thumbprint: string option           // Keys.keep: prune the other private keys
+    | KeepKey of thumbprint: string                  // Keys.keep: prune the other private keys
 
 val transition: SessionMsg -> Session -> Session * SessionEffect list
 ```
@@ -165,8 +165,10 @@ Rules encoded in `transition`:
   first time (Rule 2, see the server stub), so a response lost on the wire cannot turn a session
   that did open into `LaunchSpent`. Another browser has another key and is refused. The Launch
   exists only in this page load's memory (Rule 39); a reload has nothing left to present.
-- `Opened s` yields `Open s` plus `SetPatient (s.PatientContext |> Option.map _.Patient)` and
-  `KeepKey s.KeyThumbprint`.
+- `Opened s` yields `Open s` plus `SetPatient (s.PatientContext |> Option.map _.Patient)`, and
+  `KeepKey t` when `s.KeyThumbprint = Some t`. A session without a key (`None`: an anonymous
+  session, or a stub that has none) prunes nothing; stored keys of other launches are left
+  alone.
   Patient changes go through `UpdatePatient` so order context, order plan, formulary and
   parenteralia reload. `Patient` is never assigned directly.
 - `Closed` and `OpenAnonymous` yield `Anonymous` plus `SetPatient None`. A launched patient and
@@ -184,7 +186,7 @@ New file `src/Informedica.GenPRES.Client/Keys.fs`, the WebCrypto and IndexedDB i
   extractable, stores the private key in IndexedDB under the public key's thumbprint (RFC 7638),
   and returns the public key as a JWK string.
 - `keep: string -> JS.Promise<unit>`: deletes every stored key except the one with the given
-  thumbprint. Called on `Opened s` with `s.KeyThumbprint`. Keys are per thumbprint, not a single
+  thumbprint. Called on `Opened s` when `s.KeyThumbprint` is `Some`. Keys are per thumbprint, not a single
   entry, so a second launch in another tab that is refused cannot take away the key of the
   first tab's Session, which is still open and must still sign once step 7 lands. Pruning on
   open is safe: an open in the same browser closes the earlier Session anyway (Rule 8).
@@ -315,7 +317,9 @@ Each has a named extension point:
 - WorkPlan carry-over (#518).
 - The LaunchScript contract for a path query versus the hash form (decision D1).
 - Whether the production server exposes the stubbed session endpoints at all. That is a scope
-  question, tracked in #580 (scope switch), not a launch question.
+  question, tracked in #580 (scope switch), not a launch question. The stub of step 2 opens a
+  session for any Launch text outside its refusal vocabulary, so #580 is a prerequisite for
+  merging step 2: the stub does not ship to a server without the scope switch.
 
 ## Confidence
 

--- a/docs/implementation-plans/409-client-launch-sequence.md
+++ b/docs/implementation-plans/409-client-launch-sequence.md
@@ -55,6 +55,7 @@ the maintainer):
 
 ```fsharp
 type Launch = Launch of string                      // opaque, sealed by MainEHR LaunchScript
+type PresentationKey = PresentationKey of string    // random per page load, lives only in client memory
 type OpenedToken = OpenedToken of string
 type UserRole = Prescriber | Reader
 type UserContext = { UserId: string; DisplayName: string; Role: UserRole }
@@ -80,7 +81,7 @@ type LaunchOutcome =
     | Refused of LaunchRefusal
 
 // IServerApi additions
-presentLaunch: Launch -> Async<LaunchOutcome>
+presentLaunch: Launch * PresentationKey -> Async<LaunchOutcome>   // idempotent per key, Rule 2
 getSession: unit -> Async<SessionOpened option>     // cookie-authenticated
 closeSession: unit -> Async<unit>                   // Rule 10: explicit close
 ```
@@ -93,14 +94,14 @@ New file `src/Informedica.GenPRES.Client/Session.fs`, pure F# without React:
 [<RequireQualifiedAccess>]
 type Session =
     | Anonymous
-    | Launching of Launch * attempt: int
+    | Launching of Launch * PresentationKey * attempt: int
     | Resuming                                       // getSession in flight (reload, IdP return)
     | Open of SessionOpened
     | Refused of LaunchRefusal * retry: Launch option
-    | Unreachable of Launch * attempts: int          // ext 3a: server down after page served
+    | Unreachable of Launch * PresentationKey * attempts: int   // ext 3a: server down after page served
 
 type SessionMsg =
-    | Present of Launch
+    | Present of Launch * PresentationKey            // key minted by App.fs, once per page load
     | Outcome of Launch * Result<LaunchOutcome, string>   // Error = transport failure
     | Resume
     | Resumed of Result<SessionOpened option, string>
@@ -110,7 +111,7 @@ type SessionMsg =
     | Closed
 
 type SessionEffect =
-    | CallPresentLaunch of Launch
+    | CallPresentLaunch of Launch * PresentationKey
     | CallGetSession
     | CallCloseSession
     | GoTo of url: string                            // window.location.assign, for RedirectTo
@@ -121,14 +122,16 @@ val transition: SessionMsg -> Session -> Session * SessionEffect list
 
 Rules encoded in `transition`:
 
-- `Outcome (l, _)` is ignored unless the state is `Launching (l, _)` for the same Launch.
+- `Outcome (l, _)` is ignored unless the state is `Launching (l, _, _)` for the same Launch.
   `Resumed` is ignored unless the state is `Resuming`. This is the stale-request guard.
-- A transport error while `Launching (l, n)` with `n < 3` yields `Launching (l, n + 1)` plus
-  `CallPresentLaunch l`; at three attempts it becomes `Unreachable (l, 3)` and the UI offers
-  Retry. A retry always re-presents the same Launch. It is safe because presentation is
-  idempotent per browser within the Launch lifetime (Rule 2, see the server stub): a response
-  lost on the wire is answered again as the first was, so a retry can never turn a session that
-  did open into `LaunchSpent`.
+- A transport error while `Launching (l, k, n)` with `n < 3` yields `Launching (l, k, n + 1)`
+  plus `CallPresentLaunch (l, k)`; at three attempts it becomes `Unreachable (l, k, 3)` and the
+  UI offers Retry, which re-presents with the same key. A retry always carries the same Launch
+  and the same `PresentationKey`. The key is what makes the retry safe: the server answers a
+  repeated key as it answered the first time (Rule 2, see the server stub), so a response lost
+  on the wire cannot turn a session that did open into `LaunchSpent`, while a presentation with
+  another key, which is what any other browser has, is refused. The key exists only in this
+  page load's memory (Rule 39); a reload has no Launch left to present anyway.
 - `Opened s` yields `Open s` plus `SetPatient (s.PatientContext |> Option.map _.Patient)`.
   Patient changes go through `UpdatePatient` so order context, order plan, formulary and
   parenteralia reload. `Patient` is never assigned directly.
@@ -184,9 +187,11 @@ handles it and the `refused` return, so no client change is needed when 2.1.3 la
 
 - `State.Session: Session` and `Msg.SessionMsg of SessionMsg`.
 - `update` calls `Session.transition` and interprets each `SessionEffect` into a `Cmd`:
-  `CallPresentLaunch l` runs `serverApi.presentLaunch l` in a `try/with` that maps exceptions to
-  `Outcome (l, Error msg)`; `GoTo url` calls `window.location.assign url`; `SetPatient p` is
-  `Cmd.ofMsg (UpdatePatient p)`.
+  `CallPresentLaunch (l, k)` runs `serverApi.presentLaunch (l, k)` in a `try/with` that maps
+  exceptions to `Outcome (l, Error msg)`; `GoTo url` calls `window.location.assign url`;
+  `SetPatient p` is `Cmd.ofMsg (UpdatePatient p)`.
+- `init` and `UrlChanged` mint the `PresentationKey` with `window.crypto.randomUUID()` when they
+  dispatch `Present`; `transition` never creates one, so it stays pure.
 - An `ISession` capability on `ConcreteAppEnv` exposes the `Session` value and the `close`,
   `retry` and `openAnonymously` actions, instead of threading more props through `GenPres.fs` and
   `TitleBar.fs`.
@@ -214,20 +219,22 @@ Drafted in `src/Informedica.GenPRES.Server/Scripts/Session.fsx` and migrated by 
   `no-identity` map to the matching refusal; anything else opens a session with a stub
   Prescriber and the existing `PatientPort` stub patient. With `GENPRES_PROD=1` every launch is
   refused with `LaunchInvalid`, so the stub fails closed in production.
-- Presentation is idempotent per Rule 2. The stub keeps a spent-mark per Launch holding the
+- Presentation is idempotent per Rule 2, correlated by the `PresentationKey`, never by the
+  presence or absence of a cookie. The stub keeps a spent-mark per Launch holding the key, the
   outcome, the session id and a lifetime (Rule 29; two minutes in the stub). A second
-  presentation within the lifetime from the same browser, recognised by the session cookie that
-  the first answer set, or by no cookie at all when that answer was lost, is answered as the
-  first was and re-issues the same cookie; nothing opens twice. After the lifetime the Launch is
-  `LaunchExpired`. The real implementation keys the same-browser check on the BrowserIdentity
-  (Rule 2); the stub has none, which is the one place it is weaker than the design.
+  presentation within the lifetime with the same key is answered as the first was and re-issues
+  the same cookie; nothing opens twice. A presentation with a different key, or with no key, is
+  `LaunchSpent`: a request without a key cannot be told apart from another browser, so it is
+  treated as one. After the lifetime the Launch is `LaunchExpired`. The real implementation
+  keys the same-browser check on the BrowserIdentity (Rule 2); the key is the stand-in that the
+  stub, and the real server before the identity hop, can verify.
 - `ServerApi.CompositionRoot.fs`: `presentLaunch` sets the cookie `genpres_session` with HttpOnly,
   SameSite=Strict, Path=/ and Secure when the request is HTTPS. `getSession` reads it and
   `closeSession` deletes it.
 - Tests in `tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs`: refusal mapping, a
-  second presentation within the lifetime returns the first outcome and the same session, a
-  presentation after the lifetime is `LaunchExpired`, production fail-closed, close removes the
-  session.
+  second presentation within the lifetime with the same key returns the first outcome and the
+  same session, one with a different key is `LaunchSpent` and opens nothing, a presentation
+  after the lifetime is `LaunchExpired`, production fail-closed, close removes the session.
 
 ### Out of scope
 
@@ -324,10 +331,13 @@ Manual, with `dotnet run` and the demo sheet:
 - `launch=expired` and `launch=wrong-patient`: the modal asks for a relaunch. `launch=no-role`:
   the modal offers an anonymous open, which yields a plain anonymous state without a patient
   and no order context. `launch=spent`: the modal asks for a relaunch.
-- Open the same `launch=demo` url in a second tab within two minutes: the second tab shows the
-  same session, no second session is opened. Open it again after two minutes: `LaunchExpired`.
-- Throttle the network in DevTools so the first `presentLaunch` response is dropped: the retry
-  opens the session that the first call created, not a refusal.
+- Open the same `launch=demo` url in a second tab, or a second browser, within two minutes: the
+  second gets `LaunchSpent` and no second session is opened; the first tab keeps its session.
+  Open it again after two minutes: `LaunchExpired`.
+- Block the first `presentLaunch` response in DevTools (or stop the server between request and
+  reply): the automatic retry, carrying the same key, is answered with the session the first
+  call opened, not with a refusal. The key is visible in the request body and identical across
+  the attempts.
 - `#/session?refused=no-role`: the parameter is erased from the address bar and the modal offers
   an anonymous open.
 - Stop the server and open a launch URL: three attempts, then the Unreachable modal with Retry.

--- a/docs/implementation-plans/409-client-launch-sequence.md
+++ b/docs/implementation-plans/409-client-launch-sequence.md
@@ -76,7 +76,7 @@ type LaunchRefusal =
 
 type LaunchOutcome =
     | Opened of SessionOpened
-    | RedirectTo of url: string                      // IdP hop (UC-1 step 3); stub never returns it
+    | RedirectTo of url: string                      // IdP hop (UC-1 step 3), see below; stub never returns it
     | Refused of LaunchRefusal
 
 // IServerApi additions
@@ -104,6 +104,7 @@ type SessionMsg =
     | Outcome of Launch * Result<LaunchOutcome, string>   // Error = transport failure
     | Resume
     | Resumed of Result<SessionOpened option, string>
+    | RefusedAtCallback of LaunchRefusal             // from #/session?refused={reason}, see IdP return
     | OpenAnonymous
     | Close
     | Closed
@@ -124,17 +125,50 @@ Rules encoded in `transition`:
   `Resumed` is ignored unless the state is `Resuming`. This is the stale-request guard.
 - A transport error while `Launching (l, n)` with `n < 3` yields `Launching (l, n + 1)` plus
   `CallPresentLaunch l`; at three attempts it becomes `Unreachable (l, 3)` and the UI offers
-  Retry.
+  Retry. A retry always re-presents the same Launch. It is safe because presentation is
+  idempotent per browser within the Launch lifetime (Rule 2, see the server stub): a response
+  lost on the wire is answered again as the first was, so a retry can never turn a session that
+  did open into `LaunchSpent`.
 - `Opened s` yields `Open s` plus `SetPatient (s.PatientContext |> Option.map _.Patient)`.
   Patient changes go through `UpdatePatient` so order context, order plan, formulary and
   parenteralia reload. `Patient` is never assigned directly.
+- `Closed` and `OpenAnonymous` yield `Anonymous` plus `SetPatient None`. A launched patient and
+  everything derived from it (order context, order plan, formulary, parenteralia) leave the
+  screen with the session; an anonymous open carries nothing over (Rule 7).
 - `Refused NoRole` keeps `retry = None` and the UI offers an anonymous open. Other refusals keep
   the Launch only when a retry is meaningful (`NoBrowserIdentity`).
+- `RefusedAtCallback r` yields `Refused (r, None)`: the Launch was consumed server-side.
+
+### IdentityProvider return
+
+`RedirectTo` unloads the client, so the client cannot keep the Launch across the hop. It does not
+need to: from UC-1 step 3 and Rule 39, the Launch travels in the request state of the identity
+round trip, and the server finishes the launch before the client runs again.
+
+1. `presentLaunch` answers `RedirectTo url`. The server has put the Launch in the request state
+   of that url (the OIDC `state` parameter, encrypted, or a server-side entry keyed by the
+   `state` nonce; roadmap 2.1.3 decides which).
+2. The client calls `window.location.assign url`. The IdentityProvider signs the browser on and
+   redirects to a server callback, a plain GET outside Fable.Remoting, with the authorization
+   code and `state`.
+3. The callback redeems the code back-channel (edge C6), verifies the Launch, opens the Session
+   and sets the cookie on its own redirect response, then redirects the browser to `/#/session`.
+   On refusal it opens nothing and redirects to `/#/session?refused={reason}` with a fixed
+   reason vocabulary (`expired`, `spent`, `invalid`, `no-identity`, `no-role`,
+   `wrong-patient`, `enrolment`). A reason is not a secret; the token never appears in that url.
+4. The client loads without a Launch, erases a `refused` parameter the same way it erases a
+   launch, and dispatches `Resume` (cookie present, `getSession` answers `Some`) or
+   `RefusedAtCallback`.
+
+Only step 4 is client work in this plan. The stub never returns `RedirectTo`, but the client
+handles it and the `refused` return, so no client change is needed when 2.1.3 lands.
 
 ### URL handling in `App.fs`
 
 - Split `parseUrl` into `parsePatient` and `parseLaunch`, as PR #574 does. The launch URL form is
   `#/session?launch={token}`. In hash mode the token never reaches the server request line.
+  `parseLaunch` also recognises `#/session?refused={reason}` from the IdentityProvider return
+  and yields `RefusedAtCallback`; both forms are erased the same way.
 - In `init`, when a Launch is present, call `history.replaceState(null, "", "#/session")` through
   `Browser.Dom` directly, not through `Router.navigate`: `Router.nav` in `FelizRouter.fs` always
   fires the navigation event and would re-enter `UrlChanged` and `UpdatePatient`. Do the same in
@@ -176,15 +210,24 @@ Drafted in `src/Informedica.GenPRES.Server/Scripts/Session.fsx` and migrated by 
 - `ServerApi.Ports.fs`: `SessionPort` with `open: Launch -> Async<LaunchOutcome>`,
   `find: string -> Async<SessionOpened option>` and `close: string -> Async<unit>`.
 - `ServerApi.Adapters.fs`: an in-memory stub keyed by a random session id. Token conventions
-  `expired`, `spent` (second presentation), `no-role`, `wrong-patient` and `no-identity` map to
-  the matching refusal; anything else opens a session with a stub Prescriber and the existing
-  `PatientPort` stub patient. With `GENPRES_PROD=1` every launch is refused with `LaunchInvalid`,
-  so the stub fails closed in production.
+  `expired`, `spent` (marked as used by another browser), `no-role`, `wrong-patient` and
+  `no-identity` map to the matching refusal; anything else opens a session with a stub
+  Prescriber and the existing `PatientPort` stub patient. With `GENPRES_PROD=1` every launch is
+  refused with `LaunchInvalid`, so the stub fails closed in production.
+- Presentation is idempotent per Rule 2. The stub keeps a spent-mark per Launch holding the
+  outcome, the session id and a lifetime (Rule 29; two minutes in the stub). A second
+  presentation within the lifetime from the same browser, recognised by the session cookie that
+  the first answer set, or by no cookie at all when that answer was lost, is answered as the
+  first was and re-issues the same cookie; nothing opens twice. After the lifetime the Launch is
+  `LaunchExpired`. The real implementation keys the same-browser check on the BrowserIdentity
+  (Rule 2); the stub has none, which is the one place it is weaker than the design.
 - `ServerApi.CompositionRoot.fs`: `presentLaunch` sets the cookie `genpres_session` with HttpOnly,
   SameSite=Strict, Path=/ and Secure when the request is HTTPS. `getSession` reads it and
   `closeSession` deletes it.
-- Tests in `tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs`: refusal mapping, spent
-  on second presentation, production fail-closed, close removes the session.
+- Tests in `tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs`: refusal mapping, a
+  second presentation within the lifetime returns the first outcome and the same session, a
+  presentation after the lifetime is `LaunchExpired`, production fail-closed, close removes the
+  session.
 
 ### Out of scope
 
@@ -279,11 +322,18 @@ Manual, with `dotnet run` and the demo sheet:
 - DevTools: the cookie `genpres_session` is HttpOnly and SameSite=Strict; no request URL contains
   the token; a reload keeps the session.
 - `launch=expired` and `launch=wrong-patient`: the modal asks for a relaunch. `launch=no-role`:
-  the modal offers an anonymous open, which yields a plain anonymous state without a patient.
-  Presenting `launch=once` in two tabs: the second tab gets `LaunchSpent`.
+  the modal offers an anonymous open, which yields a plain anonymous state without a patient
+  and no order context. `launch=spent`: the modal asks for a relaunch.
+- Open the same `launch=demo` url in a second tab within two minutes: the second tab shows the
+  same session, no second session is opened. Open it again after two minutes: `LaunchExpired`.
+- Throttle the network in DevTools so the first `presentLaunch` response is dropped: the retry
+  opens the session that the first call created, not a refusal.
+- `#/session?refused=no-role`: the parameter is erased from the address bar and the modal offers
+  an anonymous open.
 - Stop the server and open a launch URL: three attempts, then the Unreachable modal with Retry.
   Start the server; Retry opens the session.
-- Close the session from the title bar: anonymous state, cookie gone.
+- Close the session from the title bar: anonymous state, cookie gone, patient and order context
+  cleared.
 - `GENPRES_PROD=1`: every launch is refused.
 - `dotnet run ServerTests` passes with the new stub tests; `dotnet run MarkdownLint` is clean for
   this document.

--- a/docs/implementation-plans/409-client-launch-sequence.md
+++ b/docs/implementation-plans/409-client-launch-sequence.md
@@ -4,6 +4,9 @@ Scope: the GenPRES Client half of UC-1 (launch), with every server-side action s
 final API contract. The plan is picked up in PR #574, which already scaffolds this flow, to
 correct that PR to the shape below; later steps follow as PRs on top of it.
 
+The sequence itself is [the launch sequence](../scenarios/integration/uc-01-launch.md). Step
+numbers below refer to that page.
+
 ## Problem description
 
 MainEHR opens GenPRES with a sealed Launch in the URL (UC-1). The client must present it, get a
@@ -23,7 +26,9 @@ obligations:
 - Rule 7 and UC-1 extensions 4a, 5a, 5b: on refusal nothing opens; the client asks for a relaunch,
   or on "no Role" offers a fresh anonymous open that carries nothing over.
 - Concept 17 and Rule 34: the OpenedToken comes back with the session and is returned with every
-  request. This plan only stores it; sending it with commands is a later step.
+  request. This plan only stores it; it travels inside the signed proof of step 7, a later step.
+- Launch step 3: the client generates a key pair at the launch. The public key correlates retries
+  now and signs every request later (step 7).
 
 Roadmap item 2.1.2 in `docs/roadmap/mvpap2019-gap-overview.md` (erase the launch, stop logging
 the raw URL) is the one unblocked 2.1.x item. Decision D1 is still open; this plan is D1-neutral on
@@ -41,12 +46,30 @@ kept; the redeem hop is replaced by the contract below.
    admin `AuthToken`. Rejected by Rule 12: a script-readable bearer.
 3. Cookie-based session set by the server; the client keeps only a `SessionOpened` snapshot and
    the OpenedToken. Chosen.
+4. To correlate a retry with its first presentation: a random per-page-load key held in memory,
+   or the public key of a browser key pair. Chosen: the key pair. One mechanism serves both the
+   retry now and the signed request of step 7 later; a random key would be thrown away when the
+   signed request lands.
 
 For the stub there were two options: an in-memory single session without a cookie, or a real
 cookie via `Remoting.fromContext`. Chosen: the cookie now, so the client is final and the server
 stub is replaced later behind the same contract.
 
 ## Chosen approach
+
+This plan implements the client side of steps 2 to 6 of the launch sequence and a server stub
+for steps 4 and 5. Step 7, the signed request, is out of scope; the stub only stores the public
+key.
+
+| Step | Client work in this plan | Server stub |
+|------|--------------------------|-------------|
+| 2 Erase | `parseLaunch`, erase from URL and history, drop the raw URL from the logs | |
+| 3 Key pair | `Keys.fs`: generate, store the private key in IndexedDB, export the public key | |
+| 4 Identity | `presentLaunch (Launch, PublicKey)`, retries, the `refused` return | never redirects; answers from the Launch text |
+| 5 Verify and open | | refusal mapping, spent-mark per Launch and public key, cookie |
+| 6 Session open | `Session.fs` state machine, `UpdatePatient`, title bar, session gate | `getSession`, `closeSession` |
+
+Any refusal ends the same: no Session, the client shows the reason (Rule 7).
 
 ### Shared contract
 
@@ -55,7 +78,7 @@ the maintainer):
 
 ```fsharp
 type Launch = Launch of string                      // opaque, sealed by MainEHR LaunchScript
-type PresentationKey = PresentationKey of string    // random per page load, lives only in client memory
+type PublicKey = PublicKey of string                 // public JWK of the browser key pair, step 3
 type OpenedToken = OpenedToken of string
 type UserRole = Prescriber | Reader
 type UserContext = { UserId: string; DisplayName: string; Role: UserRole }
@@ -66,6 +89,7 @@ type SessionOpened =                                 // no SessionId: it lives i
         User: UserContext option                     // None = anonymous session (Rule 14)
         PatientContext: PatientContext option        // None = launch without active patient (ext 1a)
         OpenedToken: OpenedToken option
+        KeyThumbprint: string option                 // which private key signs for this Session, step 7
     }
 
 type LaunchRefusal =
@@ -77,11 +101,11 @@ type LaunchRefusal =
 
 type LaunchOutcome =
     | Opened of SessionOpened
-    | RedirectTo of url: string                      // IdP hop (UC-1 step 3), see below; stub never returns it
+    | RedirectTo of url: string                      // step 4.2 as a payload, see below; the stub never returns it
     | Refused of LaunchRefusal
 
 // IServerApi additions
-presentLaunch: Launch * PresentationKey -> Async<LaunchOutcome>   // idempotent per key, Rule 2
+presentLaunch: Launch * PublicKey -> Async<LaunchOutcome>   // idempotent per public key, Rule 2
 getSession: unit -> Async<SessionOpened option>     // cookie-authenticated
 closeSession: unit -> Async<unit>                   // Rule 10: explicit close
 ```
@@ -94,29 +118,30 @@ New file `src/Informedica.GenPRES.Client/Session.fs`, pure F# without React:
 [<RequireQualifiedAccess>]
 type Session =
     | Anonymous
-    | Launching of Launch * PresentationKey * attempt: int
+    | Launching of Launch * PublicKey * attempt: int
     | Resuming                                       // getSession in flight (reload, IdP return)
     | Open of SessionOpened
-    | Refused of LaunchRefusal * retry: (Launch * PresentationKey) option
-    | Unreachable of Launch * PresentationKey * attempts: int   // ext 3a: server down after page served
+    | Refused of LaunchRefusal * retry: (Launch * PublicKey) option
+    | Unreachable of Launch * PublicKey * attempts: int   // ext 3a: server down after page served
 
 type SessionMsg =
-    | Present of Launch * PresentationKey            // key minted by App.fs, once per page load
-    | Outcome of Launch * PresentationKey * Result<LaunchOutcome, string>   // Error = transport failure
+    | Present of Launch * PublicKey                  // key pair made by Keys.fs, once per page load
+    | Outcome of Launch * PublicKey * Result<LaunchOutcome, string>   // Error = transport failure
     | Retry                                          // from Unreachable, or Refused with a retry
     | Resume
     | Resumed of Result<SessionOpened option, string>
-    | RefusedAtCallback of LaunchRefusal             // from #/session?refused={reason}, see IdP return
+    | RefusedAtCallback of LaunchRefusal             // from #/session?refused={reason}, step 4.5
     | OpenAnonymous
     | Close
     | Closed
 
 type SessionEffect =
-    | CallPresentLaunch of Launch * PresentationKey
+    | CallPresentLaunch of Launch * PublicKey
     | CallGetSession
     | CallCloseSession
     | GoTo of url: string                            // window.location.assign, for RedirectTo
     | SetPatient of Patient option                   // interpreted as UpdatePatient
+    | KeepKey of thumbprint: string option           // Keys.keep: prune the other private keys
 
 val transition: SessionMsg -> Session -> Session * SessionEffect list
 ```
@@ -124,27 +149,24 @@ val transition: SessionMsg -> Session -> Session * SessionEffect list
 Rules encoded in `transition`:
 
 - `Outcome (l, k, _)` is ignored unless the state is `Launching (l, k, _)` for the same Launch
-  and the same key. `Resumed` is ignored unless the state is `Resuming`. This is the
+  and the same public key. `Resumed` is ignored unless the state is `Resuming`. This is the
   stale-request guard: a response can only land on the presentation that sent it.
 - `Present (l, _)` while the state is `Launching (l, _, _)` is a no-op: an in-flight
-  presentation is never replaced by a second one for the same Launch, and the first key stays
-  the one the server will recognise. In every other state, `Unreachable` and `Refused`
-  included, `Present` starts a fresh presentation; only `Retry` re-uses the stored key. A
-  `Present` for a different Launch supersedes the current one, and the old one's outcome is then
-  dropped by the guard above.
+  presentation is never replaced by a second one for the same Launch. In every other state,
+  `Unreachable` and `Refused` included, `Present` starts a fresh presentation. A `Present` for a
+  different Launch supersedes the current one, and the old one's outcome is then dropped by the
+  guard above.
 - A transport error while `Launching (l, k, n)` with `n < 3` yields `Launching (l, k, n + 1)`
   plus `CallPresentLaunch (l, k)`; at three attempts it becomes `Unreachable (l, k, 3)` and the
   UI offers Retry.
 - `Retry` from `Unreachable (l, k, _)` or `Refused (_, Some (l, k))` yields `Launching (l, k, 1)`
-  plus `CallPresentLaunch (l, k)`: the same Launch and the same key, so the server answers a
-  session that did open as it did the first time, and re-verifies a Launch that did not. `Retry`
-  in any other state is a no-op. A retry always carries the same Launch
-  and the same `PresentationKey`. The key is what makes the retry safe: the server answers a
-  repeated key as it answered the first time (Rule 2, see the server stub), so a response lost
-  on the wire cannot turn a session that did open into `LaunchSpent`, while a presentation with
-  another key, which is what any other browser has, is refused. The key exists only in this
-  page load's memory (Rule 39); a reload has no Launch left to present anyway.
-- `Opened s` yields `Open s` plus `SetPatient (s.PatientContext |> Option.map _.Patient)`.
+  plus `CallPresentLaunch (l, k)`. `Retry` in any other state is a no-op. A retry always carries
+  the same Launch and the same public key: the server answers a repeated key as it answered the
+  first time (Rule 2, see the server stub), so a response lost on the wire cannot turn a session
+  that did open into `LaunchSpent`. Another browser has another key and is refused. The Launch
+  exists only in this page load's memory (Rule 39); a reload has nothing left to present.
+- `Opened s` yields `Open s` plus `SetPatient (s.PatientContext |> Option.map _.Patient)` and
+  `KeepKey s.KeyThumbprint`.
   Patient changes go through `UpdatePatient` so order context, order plan, formulary and
   parenteralia reload. `Patient` is never assigned directly.
 - `Closed` and `OpenAnonymous` yield `Anonymous` plus `SetPatient None`. A launched patient and
@@ -154,29 +176,55 @@ Rules encoded in `transition`:
   the Launch and key only when a retry is meaningful (`NoBrowserIdentity`).
 - `RefusedAtCallback r` yields `Refused (r, None)`: the Launch was consumed server-side.
 
+### Key pair
+
+New file `src/Informedica.GenPRES.Client/Keys.fs`, the WebCrypto and IndexedDB interop:
+
+- `generate: unit -> JS.Promise<PublicKey>`: creates a signing key pair with the private key not
+  extractable, stores the private key in IndexedDB under the public key's thumbprint (RFC 7638),
+  and returns the public key as a JWK string.
+- `keep: string -> JS.Promise<unit>`: deletes every stored key except the one with the given
+  thumbprint. Called on `Opened s` with `s.KeyThumbprint`. Keys are per thumbprint, not a single
+  entry, so a second launch in another tab that is refused cannot take away the key of the
+  first tab's Session, which is still open and must still sign once step 7 lands. Pruning on
+  open is safe: an open in the same browser closes the earlier Session anyway (Rule 8).
+- `sign` is left for the step 7 plan; the key is generated now so the SessionRecord already holds
+  the public key when it lands.
+- `init` and `UrlChanged` await `generate` before dispatching `Present`; `transition` never touches
+  the browser, so it stays pure.
+- A reload has no Launch, so it resumes on the cookie; `getSession` returns the thumbprint and
+  the client picks that private key. A new key pair is made only with a new Launch.
+
 ### IdentityProvider return
 
-`RedirectTo` unloads the client, so the client cannot keep the Launch across the hop. It does not
-need to: from UC-1 step 3 and Rule 39, the Launch travels in the request state of the identity
-round trip, and the server finishes the launch before the client runs again.
+The hop is step 4 of the launch sequence: `presentLaunch` answers `RedirectTo url`, the client
+calls `window.location.assign url`, and the server finishes the launch before the client runs
+again. `RedirectTo` is a payload, not an HTTP 302: Fable.Remoting's XHR would follow a 302 and
+try to parse the IdentityProvider's HTML as the response.
 
-1. `presentLaunch` answers `RedirectTo url`. The server has put the Launch in the request state
-   of that url (the OIDC `state` parameter, encrypted, or a server-side entry keyed by the
-   `state` nonce; roadmap 2.1.3 decides which).
-2. The client calls `window.location.assign url`. The IdentityProvider signs the browser on and
-   redirects to a server callback, a plain GET outside Fable.Remoting, with the authorization
-   code and `state`.
-3. The callback redeems the code back-channel (edge C6), verifies the Launch, opens the Session
-   and sets the cookie on its own redirect response, then redirects the browser to `/#/session`.
-   On refusal it opens nothing and redirects to `/#/session?refused={reason}` with a fixed
-   reason vocabulary (`expired`, `spent`, `invalid`, `no-identity`, `no-role`,
-   `wrong-patient`, `enrolment`). A reason is not a secret; the token never appears in that url.
-4. The client loads without a Launch, erases a `refused` parameter the same way it erases a
-   launch, and dispatches `Resume` (cookie present, `getSession` answers `Some`) or
-   `RefusedAtCallback`.
+Two server-side points the client shape depends on, for the plan that implements the hop:
 
-Only step 4 is client work in this plan. The stub never returns `RedirectTo`, but the client
-handles it and the `refused` return, so no client change is needed when 2.1.3 lands.
+- If the state of 4.2 is kept in a cookie, that cookie must be `SameSite=Lax` (or `None`). The
+  callback is a cross-site top-level navigation, and a `Strict` cookie is not sent on it. The
+  session cookie stays `Strict`: it is set on the callback response and only read by same-site
+  requests afterwards. It is not sent on the landing GET of `#/session` either, which is fine,
+  since `index.html` does not need it.
+- The `state` record and the spent-mark are one record per Launch, holding `state`, the public
+  key, the outcome, the session id and the lifetime. So the server answers a repeated callback
+  (a reload of `/callback?code=...`, whose code is already redeemed) and a repeated presentation
+  with the same public key alike: the first outcome, the same cookie (Rule 45).
+
+The client work is the return:
+
+- The client loads without a Launch, erases a `refused` parameter the same way it erases a
+  launch, and dispatches `Resume` (cookie present, `getSession` answers `Some`) or
+  `RefusedAtCallback`. A refusal at the callback cannot be retried by the client, which has no
+  Launch left after the redirect: the modal asks for a relaunch, `no-identity` included.
+- The reason vocabulary in `#/session?refused={reason}` is fixed: `expired`, `spent`, `invalid`,
+  `no-identity`, `no-role`, `wrong-patient`, `enrolment`.
+
+The stub never returns `RedirectTo`, but the client handles it and the `refused` return, so no
+client change is needed when roadmap 2.1.3 lands.
 
 ### URL handling in `App.fs`
 
@@ -202,9 +250,9 @@ handles it and the `refused` return, so no client change is needed when 2.1.3 la
   `CallPresentLaunch (l, k)` runs `serverApi.presentLaunch (l, k)` and yields
   `Outcome (l, k, result)`, with a `try/with` that maps exceptions to `Error msg`;
   `GoTo url` calls `window.location.assign url`;
-  `SetPatient p` is `Cmd.ofMsg (UpdatePatient p)`.
-- `init` and `UrlChanged` mint the `PresentationKey` with `window.crypto.randomUUID()` when they
-  dispatch `Present`; `transition` never creates one, so it stays pure.
+  `SetPatient p` is `Cmd.ofMsg (UpdatePatient p)`;
+  `KeepKey t` runs `Keys.keep` for `t` and yields nothing.
+- `init` and `UrlChanged` get the public key from `Keys.generate` when they dispatch `Present`.
 - An `ISession` capability on `ConcreteAppEnv` exposes the `Session` value and the `close`,
   `retry` and `openAnonymously` actions, instead of threading more props through `GenPres.fs` and
   `TitleBar.fs`.
@@ -215,7 +263,8 @@ handles it and the `refused` return, so no client change is needed when 2.1.3 la
   "Close session" menu item. Show nothing for anonymous.
 - New `Views/SessionGate.fs`: a modal in the pattern of the disclaimer modal in `Pages/GenPres.fs`,
   shown for `Launching`, `Resuming`, `Refused` and `Unreachable`. Text per refusal. Actions: Retry
-  (for `Unreachable` and `NoBrowserIdentity`), "Continue without launch" (for `NoRole` only),
+  (for `Unreachable`, and for `NoBrowserIdentity` answered by `presentLaunch` itself, which the
+  stub does), "Continue without launch" (for `NoRole` only),
   otherwise the instruction to relaunch from MainEHR. Edge C4 is one-way, so the client cannot
   trigger a relaunch itself.
 
@@ -225,38 +274,43 @@ Drafted in `src/Informedica.GenPRES.Server/Scripts/Session.fsx` and migrated by 
 
 - `Server.fs`: `Remoting.fromValue` becomes `Remoting.fromContext`, so handlers can read and set
   the cookie. This is the one non-stub server change; it is already noted there as deferred.
-- `ServerApi.Ports.fs`: `SessionPort` with `open: Launch -> Async<LaunchOutcome>`,
+- `ServerApi.Ports.fs`: `SessionPort` with `open: Launch * PublicKey -> Async<LaunchOutcome>`,
   `find: string -> Async<SessionOpened option>` and `close: string -> Async<unit>`.
 - `ServerApi.Adapters.fs`: an in-memory stub keyed by a random session id. Token conventions
   `expired`, `spent` (marked as used by another browser), `no-role`, `wrong-patient` and
   `no-identity` map to the matching refusal; anything else opens a session with a stub
   Prescriber and the existing `PatientPort` stub patient.
-- Presentation is idempotent per Rule 2, correlated by the `PresentationKey`, never by the
-  presence or absence of a cookie. The spent-mark is written only in the act that opens a
-  Session (Rule 2, Rule 40); a refusal records nothing, so a retry after a transient refusal
-  such as `NoBrowserIdentity` re-verifies the Launch. The stub keeps the spent-mark per Launch
-  holding the key, the outcome, the session id and a lifetime (Rule 29; two minutes in the
-  stub). A second presentation within the lifetime with the same key is answered as the first
-  was and re-issues the same cookie; nothing opens twice. A presentation with a different key, or with no key, is
-  `LaunchSpent`: a request without a key cannot be told apart from another browser, so it is
-  treated as one. After the lifetime the Launch is `LaunchExpired`. The real implementation
-  keys the same-browser check on the BrowserIdentity (Rule 2); the key is the stand-in that the
-  stub, and the real server before the identity hop, can verify.
+- Presentation is idempotent per Rule 2, correlated by the public key, never by the presence or
+  absence of a cookie. The spent-mark is written only in the act that opens a Session (Rules 2,
+  40); a refusal records nothing, so a retry after a transient refusal such as
+  `NoBrowserIdentity` re-verifies the Launch. The stub keeps the spent-mark per Launch holding
+  the public key, the outcome, the session id and a lifetime (Rule 29; two minutes in the stub).
+  A second presentation within the lifetime with the same public key is answered as the first
+  was and re-issues the same cookie; nothing opens twice. A presentation with a different key,
+  or with none, is `LaunchSpent`: it cannot be told from another browser, so it is treated as
+  one. After the lifetime the Launch is `LaunchExpired`. The stub record is the same record the
+  real server keeps under `state` (see the IdentityProvider return), so the real server re-issues
+  at the callback and at a repeated presentation from the same place. Rule 2 names the
+  BrowserIdentity; the public key is what the stub, and the real server before the identity hop,
+  can check, and the BrowserIdentity is a second check after it.
+- The stub session record holds the public key's thumbprint; `getSession` returns it.
 - `ServerApi.CompositionRoot.fs`: `presentLaunch` sets the cookie `genpres_session` with HttpOnly,
   SameSite=Strict, Path=/ and Secure when the request is HTTPS. `getSession` reads it and
   `closeSession` deletes it.
 - Tests in `tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs`: refusal mapping, a
-  second presentation within the lifetime with the same key returns the first outcome and the
-  same session, one with a different key is `LaunchSpent` and opens nothing, a presentation
+  second presentation within the lifetime with the same public key returns the first outcome and
+  the same session, one with a different key is `LaunchSpent` and opens nothing, a presentation
   after the lifetime is `LaunchExpired`, close removes the session.
 
 ### Out of scope
 
 Each has a named extension point:
 
+- The signed request on every call (launch step 7, DPoP): `Keys.sign` and a request
+  interceptor, once the server verifies proofs. The OpenedToken travels inside that proof, so
+  sending it is part of the same step.
 - Session endings and the Rule 11 notice (roadmap 2.1.6): add `Session.Ended of SessionEnding`
   when the server can report it.
-- Sending the OpenedToken with every command.
 - UC-2 PIN enrolment.
 - WorkPlan carry-over (#518).
 - The LaunchScript contract for a path query versus the hash form (decision D1).
@@ -265,9 +319,10 @@ Each has a named extension point:
 
 ## Confidence
 
-Medium-high on the client shape: it follows UC-1 step by step and is D1-neutral. Medium on the
-cookie in development: Vite proxies `/api` with `changeOrigin: true`, which should pass a
-host-only cookie unchanged. To be confirmed in step 2.
+Medium-high on the client shape: it follows the launch sequence step by step and is D1-neutral.
+Medium on the cookie in development: Vite proxies `/api` with `changeOrigin: true`, which should
+pass a host-only cookie unchanged. To be confirmed in step 2. Medium on WebCrypto and IndexedDB
+from Fable: the client has no such interop yet.
 
 ## Steps
 
@@ -281,11 +336,13 @@ maintainer.
    the launch from URL and history in `init` and `UrlChanged`. Drop the raw URL from the warning
    logs. No session state yet: a launch URL simply becomes `#/session`. Closes roadmap 2.1.2.
 2. **Shared contract and server stub.** Types and `IServerApi` additions in Shared, `SessionPort`,
-   the stub adapter, cookie handling via `fromContext`, stub tests. Verify the cookie round trip
-   through the Vite proxy.
-3. **Client session state machine.** `Session.fs` with `transition`, `State.Session`,
-   `SessionMsg` interpretation in `update`, `Resume` on load, `UpdatePatient` on open, disclaimer
-   suppression, the `ISession` capability on `ConcreteAppEnv`.
+   the stub adapter storing the public key, cookie handling via `fromContext`, stub tests. Verify
+   the cookie round trip through the Vite proxy.
+3. **Key pair and client session state machine.** `Keys.fs` (generate, keep, IndexedDB per
+   thumbprint), `Session.fs`
+   with `transition`, `State.Session`, `SessionMsg` interpretation in `update`, `Resume` on load,
+   `UpdatePatient` on open, disclaimer suppression, the `ISession` capability on
+   `ConcreteAppEnv`.
 4. **UI.** Title bar session indicator and close, the `SessionGate` modal with retry, anonymous
    open and relaunch texts, localisation terms for the new strings.
 5. **Docs.** Tick roadmap 2.1.2.
@@ -298,7 +355,8 @@ Manual, with `dotnet run` and the demo sheet:
   first server call, the back button leaves the site (no history entry), the title bar shows the
   stub user, the patient is loaded through `UpdatePatient`, and no disclaimer appears.
 - DevTools: the cookie `genpres_session` is HttpOnly and SameSite=Strict; no request URL contains
-  the token; a reload keeps the session.
+  the token; a reload keeps the session. Application > IndexedDB shows the private key entry,
+  and `exportKey` on it fails from the console.
 - `launch=expired` and `launch=wrong-patient`: the modal asks for a relaunch. `launch=no-role`:
   the modal offers an anonymous open, which yields a plain anonymous state without a patient
   and no order context. `launch=spent`: the modal asks for a relaunch.
@@ -306,14 +364,19 @@ Manual, with `dotnet run` and the demo sheet:
   second gets `LaunchSpent` and no second session is opened; the first tab keeps its session.
   Open it again after two minutes: `LaunchExpired`.
 - Block the first `presentLaunch` response in DevTools (or stop the server between request and
-  reply): the automatic retry, carrying the same key, is answered with the session the first
-  call opened, not with a refusal. The key is visible in the request body and identical across
-  the attempts.
+  reply): the automatic retry, carrying the same public key, is answered with the session the
+  first call opened, not with a refusal. The public key is visible in the request body and
+  identical across the attempts.
 - `#/session?refused=no-role`: the parameter is erased from the address bar and the modal offers
   an anonymous open.
 - Stop the server and open a launch URL: three attempts, then the Unreachable modal with Retry.
   Start the server; Retry opens the session.
 - Close the session from the title bar: anonymous state, cookie gone, patient and order context
   cleared.
+- Two tabs, once step 7 exists: launch in tab 1, then `launch=no-role` in tab 2. Tab 2 is
+  refused, tab 1 still signs its requests: its private key was not removed. Then a successful
+  launch in tab 2: tab 1's Session is closed and its key is gone.
+- Reload of `/callback?code=...&state=...`, once the real identity hop exists (the stub never
+  redirects): the second load lands in the same Session, no refusal.
 - `dotnet run ServerTests` passes with the new stub tests; `dotnet run MarkdownLint` is clean for
   this document.

--- a/docs/implementation-plans/409-client-launch-sequence.md
+++ b/docs/implementation-plans/409-client-launch-sequence.md
@@ -102,7 +102,7 @@ type Session =
 
 type SessionMsg =
     | Present of Launch * PresentationKey            // key minted by App.fs, once per page load
-    | Outcome of Launch * Result<LaunchOutcome, string>   // Error = transport failure
+    | Outcome of Launch * PresentationKey * Result<LaunchOutcome, string>   // Error = transport failure
     | Resume
     | Resumed of Result<SessionOpened option, string>
     | RefusedAtCallback of LaunchRefusal             // from #/session?refused={reason}, see IdP return
@@ -122,8 +122,13 @@ val transition: SessionMsg -> Session -> Session * SessionEffect list
 
 Rules encoded in `transition`:
 
-- `Outcome (l, _)` is ignored unless the state is `Launching (l, _, _)` for the same Launch.
-  `Resumed` is ignored unless the state is `Resuming`. This is the stale-request guard.
+- `Outcome (l, k, _)` is ignored unless the state is `Launching (l, k, _)` for the same Launch
+  and the same key. `Resumed` is ignored unless the state is `Resuming`. This is the
+  stale-request guard: a response can only land on the presentation that sent it.
+- `Present (l, _)` while the state is `Launching (l, _, _)` or `Unreachable (l, _, _)` is a
+  no-op: an in-flight presentation is never replaced by a second one for the same Launch, and
+  the first key stays the one the server will recognise. A `Present` for a different Launch
+  supersedes the current one, and the old one's outcome is then dropped by the guard above.
 - A transport error while `Launching (l, k, n)` with `n < 3` yields `Launching (l, k, n + 1)`
   plus `CallPresentLaunch (l, k)`; at three attempts it becomes `Unreachable (l, k, 3)` and the
   UI offers Retry, which re-presents with the same key. A retry always carries the same Launch
@@ -187,8 +192,9 @@ handles it and the `refused` return, so no client change is needed when 2.1.3 la
 
 - `State.Session: Session` and `Msg.SessionMsg of SessionMsg`.
 - `update` calls `Session.transition` and interprets each `SessionEffect` into a `Cmd`:
-  `CallPresentLaunch (l, k)` runs `serverApi.presentLaunch (l, k)` in a `try/with` that maps
-  exceptions to `Outcome (l, Error msg)`; `GoTo url` calls `window.location.assign url`;
+  `CallPresentLaunch (l, k)` runs `serverApi.presentLaunch (l, k)` and yields
+  `Outcome (l, k, result)`, with a `try/with` that maps exceptions to `Error msg`;
+  `GoTo url` calls `window.location.assign url`;
   `SetPatient p` is `Cmd.ofMsg (UpdatePatient p)`.
 - `init` and `UrlChanged` mint the `PresentationKey` with `window.crypto.randomUUID()` when they
   dispatch `Present`; `transition` never creates one, so it stays pure.

--- a/docs/implementation-plans/409-client-launch-sequence.md
+++ b/docs/implementation-plans/409-client-launch-sequence.md
@@ -288,30 +288,7 @@ maintainer.
    suppression, the `ISession` capability on `ConcreteAppEnv`.
 4. **UI.** Title bar session indicator and close, the `SessionGate` modal with retry, anonymous
    open and relaunch texts, localisation terms for the new strings.
-5. **Docs.** Tick roadmap 2.1.2. Nothing is written to `CHANGELOG.md` by hand: EasyBuild.ShipIt
-   generates it on every push to `master` from the conventional-commit history and bumps the
-   version in `Directory.Build.props` (see DEVELOPMENT.md, "Changelog & Release Automation").
-
-### Commit conventions for the release notes
-
-Only `feat` and `fix` commits render in the changelog; `docs`, `chore` and `build` never do. So
-each step above lands as a `feat(client)`, `feat(api)` or `fix(client)` commit, and the docs step
-as `docs(...)`. Where a step deserves more than its subject line in the release notes, put a
-`=== changelog ===` block in the commit message body, opened and closed with the marker, for
-example:
-
-```text
-fix(client): erase the launch token from URL and history
-
-=== changelog ===
-A launch token in the address bar ended up in browser history, referrer
-headers and logs. The client now removes it on first presentation (Rule 39)
-and no longer logs unparseable URLs verbatim.
-=== changelog ===
-```
-
-The block must be in the commit message, not the PR body: with all three merge methods enabled,
-only squash merges copy a PR body into the commit.
+5. **Docs.** Tick roadmap 2.1.2.
 
 ## Verification
 

--- a/docs/implementation-plans/409-client-launch-sequence.md
+++ b/docs/implementation-plans/409-client-launch-sequence.md
@@ -206,13 +206,15 @@ try to parse the IdentityProvider's HTML as the response.
 
 Two server-side points the client shape depends on, for the plan that implements the hop:
 
-- The state of 4.2 is a LaunchRecord appended to the GenPRES Database, not a cookie. The
+- The state of 4.2 is a LaunchRecord appended to the GenPRES Database, not a cookie. It holds
+  the Launch's verified contents (nonce, PatientId, expiry), the `state` and the public key,
+  never the sealed Launch, and is dropped whole after the expiry. The
   callback is a cross-site top-level navigation, on which a `SameSite=Strict` cookie is not
   sent, so a cookie could not carry it anyway. The session cookie stays `Strict`: it is set on
   the callback response and only read by same-site requests afterwards. It is not sent on the
   landing GET of `#/session` either, which is fine, since `index.html` does not need it.
-- The LaunchRecord and the spent-mark are one record per Launch, holding `state`, the public
-  key, the outcome, the session id and the lifetime. So the server answers a repeated callback
+- The LaunchRecord and the spent-mark are one record per Launch, keyed by the nonce, holding
+  `state`, the public key, the outcome and the session id. So the server answers a repeated callback
   (a reload of `/callback?code=...`, whose code is already redeemed) and a repeated presentation
   with the same public key alike: the first outcome, the same cookie (Rule 45). A refusal
   answered directly by `presentLaunch`, before the hop, records nothing, so a retry re-verifies
@@ -288,8 +290,9 @@ Drafted in `src/Informedica.GenPRES.Server/Scripts/Session.fsx` and migrated by 
 - Presentation is idempotent per Rule 2, correlated by the public key, never by the presence or
   absence of a cookie. The spent-mark is written only in the act that opens a Session (Rules 2,
   40); a refusal records nothing, so a retry after a transient refusal such as
-  `NoBrowserIdentity` re-verifies the Launch. The stub keeps the spent-mark per Launch holding
-  the public key, the outcome, the session id and a lifetime (Rule 29; two minutes in the stub).
+  `NoBrowserIdentity` re-verifies the Launch. The stub keeps the spent-mark per Launch, keyed by
+  the Launch text as its stand-in for the nonce, holding the public key, the outcome, the session
+  id and an expiry (Rule 29; two minutes in the stub), and drops it after the expiry.
   A second presentation within the lifetime with the same public key is answered as the first
   was and re-issues the same cookie; nothing opens twice. A presentation with a different key,
   or with none, is `LaunchSpent`: it cannot be told from another browser, so it is treated as

--- a/docs/implementation-plans/409-client-launch-sequence.md
+++ b/docs/implementation-plans/409-client-launch-sequence.md
@@ -1,0 +1,289 @@
+# Implementation plan for issue 409: client side of the launch sequence
+
+Scope: the GenPRES Client half of UC-1 (launch), with every server-side action stubbed behind the
+final API contract. The plan is picked up in PR #574, which already scaffolds this flow, to
+correct that PR to the shape below; later steps follow as PRs on top of it.
+
+## Problem description
+
+MainEHR opens GenPRES with a sealed Launch in the URL (UC-1). The client must present it, get a
+Session back, and from then on carry only the session cookie and the OpenedToken. Today the client
+has no notion of a session: any URL is parsed for patient parameters only, unparseable URLs are
+logged raw (which would leak a Launch to the log), and the vendored router never fires
+`UrlChanged`.
+
+The V8 design (`docs/scenarios/integration/GenPRES-MainEHR-Integration-V8.md`) fixes the client
+obligations:
+
+- Rule 39: erase the Launch from URL and history at first presentation; keep it only in memory for
+  retries within its lifetime (Rule 29: a page load, the IdentityProvider round trip, a retry or
+  two).
+- Rule 12: the SessionId is a bearer credential, never in a URL, never readable by script: an
+  HttpOnly, Secure, SameSite=Strict cookie.
+- Rule 7 and UC-1 extensions 4a, 5a, 5b: on refusal nothing opens; the client asks for a relaunch,
+  or on "no Role" offers a fresh anonymous open that carries nothing over.
+- Concept 17 and Rule 34: the OpenedToken comes back with the session and is returned with every
+  request. This plan only stores it; sending it with commands is a later step.
+
+Roadmap item 2.1.2 in `docs/roadmap/mvpap2019-gap-overview.md` (erase the launch, stop logging
+the raw URL) is the one unblocked 2.1.x item. Decision D1 is still open; this plan is D1-neutral on
+the client because the Launch is opaque to it.
+
+PR #574 diverges from V8 on three points: a redeem token in the URL, the SessionId in the response
+body, and a launch that is never erased. Its `FelizRouter` fix and the split of the URL parser are
+kept; the redeem hop is replaced by the contract below.
+
+## Approaches considered
+
+1. Keep PR #574's redeem-token flow and validate the redeem token later. Rejected: the redeem
+   hop has no counterpart in V8 and puts a second secret in the URL.
+2. Client holds the session credential in memory and sends it in every command payload, like the
+   admin `AuthToken`. Rejected by Rule 12: a script-readable bearer.
+3. Cookie-based session set by the server; the client keeps only a `SessionOpened` snapshot and
+   the OpenedToken. Chosen.
+
+For the stub there were two options: an in-memory single session without a cookie, or a real
+cookie via `Remoting.fromContext`. Chosen: the cookie now, so the client is final and the server
+stub is replaced later behind the same contract.
+
+## Chosen approach
+
+### Shared contract
+
+Added to `src/Informedica.GenPRES.Shared/Types.fs` and `Api.fs` (drafted in a script, migrated by
+the maintainer):
+
+```fsharp
+type Launch = Launch of string                      // opaque, sealed by MainEHR LaunchScript
+type OpenedToken = OpenedToken of string
+type UserRole = Prescriber | Reader
+type UserContext = { UserId: string; DisplayName: string; Role: UserRole }
+type PatientContext = { PatientId: string; Patient: Patient }
+
+type SessionOpened =                                 // no SessionId: it lives in the cookie
+    {
+        User: UserContext option                     // None = anonymous session (Rule 14)
+        PatientContext: PatientContext option        // None = launch without active patient (ext 1a)
+        OpenedToken: OpenedToken option
+    }
+
+type LaunchRefusal =
+    | LaunchExpired | LaunchSpent | LaunchInvalid    // ext 4a: ask for a relaunch
+    | NoBrowserIdentity                              // ext 3c: retry, then relaunch
+    | NoRole                                         // ext 5a: offer anonymous open
+    | WrongActivePatient                             // ext 5b: relaunch after fixing MainEHR
+    | EnrolmentRequired                              // UC-2, shown as text only for now
+
+type LaunchOutcome =
+    | Opened of SessionOpened
+    | RedirectTo of url: string                      // IdP hop (UC-1 step 3); stub never returns it
+    | Refused of LaunchRefusal
+
+// IServerApi additions
+presentLaunch: Launch -> Async<LaunchOutcome>
+getSession: unit -> Async<SessionOpened option>     // cookie-authenticated
+closeSession: unit -> Async<unit>                   // Rule 10: explicit close
+```
+
+### Client session state machine
+
+New file `src/Informedica.GenPRES.Client/Session.fs`, pure F# without React:
+
+```fsharp
+[<RequireQualifiedAccess>]
+type Session =
+    | Anonymous
+    | Launching of Launch * attempt: int
+    | Resuming                                       // getSession in flight (reload, IdP return)
+    | Open of SessionOpened
+    | Refused of LaunchRefusal * retry: Launch option
+    | Unreachable of Launch * attempts: int          // ext 3a: server down after page served
+
+type SessionMsg =
+    | Present of Launch
+    | Outcome of Launch * Result<LaunchOutcome, string>   // Error = transport failure
+    | Resume
+    | Resumed of Result<SessionOpened option, string>
+    | OpenAnonymous
+    | Close
+    | Closed
+
+type SessionEffect =
+    | CallPresentLaunch of Launch
+    | CallGetSession
+    | CallCloseSession
+    | GoTo of url: string                            // window.location.assign, for RedirectTo
+    | SetPatient of Patient option                   // interpreted as UpdatePatient
+
+val transition: SessionMsg -> Session -> Session * SessionEffect list
+```
+
+Rules encoded in `transition`:
+
+- `Outcome (l, _)` is ignored unless the state is `Launching (l, _)` for the same Launch.
+  `Resumed` is ignored unless the state is `Resuming`. This is the stale-request guard.
+- A transport error while `Launching (l, n)` with `n < 3` yields `Launching (l, n + 1)` plus
+  `CallPresentLaunch l`; at three attempts it becomes `Unreachable (l, 3)` and the UI offers
+  Retry.
+- `Opened s` yields `Open s` plus `SetPatient (s.PatientContext |> Option.map _.Patient)`.
+  Patient changes go through `UpdatePatient` so order context, order plan, formulary and
+  parenteralia reload. `Patient` is never assigned directly.
+- `Refused NoRole` keeps `retry = None` and the UI offers an anonymous open. Other refusals keep
+  the Launch only when a retry is meaningful (`NoBrowserIdentity`).
+
+### URL handling in `App.fs`
+
+- Split `parseUrl` into `parsePatient` and `parseLaunch`, as PR #574 does. The launch URL form is
+  `#/session?launch={token}`. In hash mode the token never reaches the server request line.
+- In `init`, when a Launch is present, call `history.replaceState(null, "", "#/session")` through
+  `Browser.Dom` directly, not through `Router.navigate`: `Router.nav` in `FelizRouter.fs` always
+  fires the navigation event and would re-enter `UrlChanged` and `UpdatePatient`. Do the same in
+  `UrlChanged` for an in-app launch URL.
+- Remove the raw-URL argument from both `Logging.warning "could not parse url…"` calls
+  (roadmap 2.1.2).
+- Patient parameters in the URL are ignored while a launch is present; the session supplies the
+  patient.
+- `init` without a Launch dispatches `Resume`, so a reload keeps a launched session via the cookie.
+- `ShowDisclaimer` is false whenever the session is not `Anonymous`.
+
+### Wiring in `App.fs`
+
+- `State.Session: Session` and `Msg.SessionMsg of SessionMsg`.
+- `update` calls `Session.transition` and interprets each `SessionEffect` into a `Cmd`:
+  `CallPresentLaunch l` runs `serverApi.presentLaunch l` in a `try/with` that maps exceptions to
+  `Outcome (l, Error msg)`; `GoTo url` calls `window.location.assign url`; `SetPatient p` is
+  `Cmd.ofMsg (UpdatePatient p)`.
+- An `ISession` capability on `ConcreteAppEnv` exposes the `Session` value and the `close`,
+  `retry` and `openAnonymously` actions, instead of threading more props through `GenPres.fs` and
+  `TitleBar.fs`.
+
+### UI
+
+- `TitleBar.fs`: when `Open` with a user, show display name and role next to the hospital, and a
+  "Close session" menu item. Show nothing for anonymous.
+- New `Views/SessionGate.fs`: a modal in the pattern of the disclaimer modal in `Pages/GenPres.fs`,
+  shown for `Launching`, `Resuming`, `Refused` and `Unreachable`. Text per refusal. Actions: Retry
+  (for `Unreachable` and `NoBrowserIdentity`), "Continue without launch" (for `NoRole` only),
+  otherwise the instruction to relaunch from MainEHR. Edge C4 is one-way, so the client cannot
+  trigger a relaunch itself.
+
+### Server stub
+
+Drafted in `src/Informedica.GenPRES.Server/Scripts/Session.fsx` and migrated by the maintainer:
+
+- `Server.fs`: `Remoting.fromValue` becomes `Remoting.fromContext`, so handlers can read and set
+  the cookie. This is the one non-stub server change; it is already noted there as deferred.
+- `ServerApi.Ports.fs`: `SessionPort` with `open: Launch -> Async<LaunchOutcome>`,
+  `find: string -> Async<SessionOpened option>` and `close: string -> Async<unit>`.
+- `ServerApi.Adapters.fs`: an in-memory stub keyed by a random session id. Token conventions
+  `expired`, `spent` (second presentation), `no-role`, `wrong-patient` and `no-identity` map to
+  the matching refusal; anything else opens a session with a stub Prescriber and the existing
+  `PatientPort` stub patient. With `GENPRES_PROD=1` every launch is refused with `LaunchInvalid`,
+  so the stub fails closed in production.
+- `ServerApi.CompositionRoot.fs`: `presentLaunch` sets the cookie `genpres_session` with HttpOnly,
+  SameSite=Strict, Path=/ and Secure when the request is HTTPS. `getSession` reads it and
+  `closeSession` deletes it.
+- Tests in `tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs`: refusal mapping, spent
+  on second presentation, production fail-closed, close removes the session.
+
+### Out of scope
+
+Each has a named extension point:
+
+- Session endings and the Rule 11 notice (roadmap 2.1.6): add `Session.Ended of SessionEnding`
+  when the server can report it.
+- Sending the OpenedToken with every command.
+- UC-2 PIN enrolment.
+- WorkPlan carry-over (#518).
+- The LaunchScript contract for a path query versus the hash form (decision D1).
+
+## Confidence
+
+Medium-high on the client shape: it follows UC-1 step by step and is D1-neutral. Medium on the
+cookie in development: Vite proxies `/api` with `changeOrigin: true`, which should pass a
+host-only cookie unchanged. To be confirmed in step 2.
+
+## Steps
+
+Each step is one PR under 200 changed lines. Client `.fs` files are edited directly (the UI
+exception in `AGENTS.md`); Shared and Server changes are drafted in scripts and migrated by the
+maintainer.
+
+1. **Correct PR #574 to the router fix and URL hygiene** (client only). Keep the `FelizRouter`
+   latest-callback fix and the `parsePatient`/`parseLaunch` split. Remove the redeem-token
+   navigation, the `SessionContext` state, the session API stubs and the simulated delays. Erase
+   the launch from URL and history in `init` and `UrlChanged`. Drop the raw URL from the warning
+   logs. No session state yet: a launch URL simply becomes `#/session`. Closes roadmap 2.1.2.
+2. **Shared contract and server stub.** Types and `IServerApi` additions in Shared, `SessionPort`,
+   the stub adapter, cookie handling via `fromContext`, stub tests. Verify the cookie round trip
+   through the Vite proxy.
+3. **Client session state machine.** `Session.fs` with `transition`, `State.Session`,
+   `SessionMsg` interpretation in `update`, `Resume` on load, `UpdatePatient` on open, disclaimer
+   suppression, the `ISession` capability on `ConcreteAppEnv`.
+4. **UI.** Title bar session indicator and close, the `SessionGate` modal with retry, anonymous
+   open and relaunch texts, localisation terms for the new strings.
+5. **Docs.** Tick roadmap 2.1.2. Nothing is written to `CHANGELOG.md` by hand: EasyBuild.ShipIt
+   generates it on every push to `master` from the conventional-commit history and bumps the
+   version in `Directory.Build.props` (see DEVELOPMENT.md, "Changelog & Release Automation").
+
+### Commit conventions for the release notes
+
+Only `feat` and `fix` commits render in the changelog; `docs`, `chore` and `build` never do. So
+each step above lands as a `feat(client)`, `feat(api)` or `fix(client)` commit, and the docs step
+as `docs(...)`. Where a step deserves more than its subject line in the release notes, put a
+`=== changelog ===` block in the commit message body, opened and closed with the marker, for
+example:
+
+```text
+fix(client): erase the launch token from URL and history
+
+=== changelog ===
+A launch token in the address bar ended up in browser history, referrer
+headers and logs. The client now removes it on first presentation (Rule 39)
+and no longer logs unparseable URLs verbatim.
+=== changelog ===
+```
+
+The block must be in the commit message, not the PR body: with all three merge methods enabled,
+only squash merges copy a PR body into the commit.
+
+### Release gating
+
+ShipIt offers no per-commit way to hold back a release: its CLI has no skip list or footer for
+that, and a `[skip ci]` on one push only delays the run, because the next push walks history
+back to `last_commit_released` and picks the commits up anyway. Two gates exist instead:
+
+1. **Commit type.** A push whose commits are all non-rendering (`chore`, `docs`, `build`, merge
+   commits) makes ShipIt report "nothing to ship" and open no release PR. Verified with
+   `dotnet shipit --dry-run --allow-branch master --skip-merge-commit` on the current `master`.
+   This is not a tool for hiding a feature: the launch steps are `feat`/`fix` and must render.
+2. **The release PR.** ShipIt runs in pull-request mode and never releases by itself. The tag,
+   the GitHub Release and the Docker push in `tag-release.yml` fire only when a maintainer merges
+   the `release/master` PR. Leaving that PR open holds every release, for every change on
+   `master`, until it is merged.
+
+Because gate 2 holds all of `master`, this plan does not rely on it. The stubbed launch is safe to
+ship in an alpha because the server stub fails closed under `GENPRES_PROD=1` (every launch is
+refused) and an anonymous open is unchanged. That is the feature-flag approach CONTRIBUTING asks
+for with incomplete work, and it keeps the release line free for unrelated fixes. If a step is
+ever unsafe to ship, keep it on the feature branch until it is, rather than merging and holding
+the release PR.
+
+## Verification
+
+Manual, with `dotnet run` and the demo sheet:
+
+- Open `http://localhost:5173/#/session?launch=demo`. The address bar shows `#/session` before the
+  first server call, the back button leaves the site (no history entry), the title bar shows the
+  stub user, the patient is loaded through `UpdatePatient`, and no disclaimer appears.
+- DevTools: the cookie `genpres_session` is HttpOnly and SameSite=Strict; no request URL contains
+  the token; a reload keeps the session.
+- `launch=expired` and `launch=wrong-patient`: the modal asks for a relaunch. `launch=no-role`:
+  the modal offers an anonymous open, which yields a plain anonymous state without a patient.
+  Presenting `launch=once` in two tabs: the second tab gets `LaunchSpent`.
+- Stop the server and open a launch URL: three attempts, then the Unreachable modal with Retry.
+  Start the server; Retry opens the session.
+- Close the session from the title bar: anonymous state, cookie gone.
+- `GENPRES_PROD=1`: every launch is refused.
+- `dotnet run ServerTests` passes with the new stub tests; `dotnet run MarkdownLint` is clean for
+  this document.

--- a/docs/implementation-plans/409-client-launch-sequence.md
+++ b/docs/implementation-plans/409-client-launch-sequence.md
@@ -206,15 +206,18 @@ try to parse the IdentityProvider's HTML as the response.
 
 Two server-side points the client shape depends on, for the plan that implements the hop:
 
-- If the state of 4.2 is kept in a cookie, that cookie must be `SameSite=Lax` (or `None`). The
-  callback is a cross-site top-level navigation, and a `Strict` cookie is not sent on it. The
-  session cookie stays `Strict`: it is set on the callback response and only read by same-site
-  requests afterwards. It is not sent on the landing GET of `#/session` either, which is fine,
-  since `index.html` does not need it.
-- The `state` record and the spent-mark are one record per Launch, holding `state`, the public
+- The state of 4.2 is a LaunchRecord appended to the GenPRES Database, not a cookie. The
+  callback is a cross-site top-level navigation, on which a `SameSite=Strict` cookie is not
+  sent, so a cookie could not carry it anyway. The session cookie stays `Strict`: it is set on
+  the callback response and only read by same-site requests afterwards. It is not sent on the
+  landing GET of `#/session` either, which is fine, since `index.html` does not need it.
+- The LaunchRecord and the spent-mark are one record per Launch, holding `state`, the public
   key, the outcome, the session id and the lifetime. So the server answers a repeated callback
   (a reload of `/callback?code=...`, whose code is already redeemed) and a repeated presentation
-  with the same public key alike: the first outcome, the same cookie (Rule 45).
+  with the same public key alike: the first outcome, the same cookie (Rule 45). A refusal
+  answered directly by `presentLaunch`, before the hop, records nothing, so a retry re-verifies
+  the Launch; a refusal at the callback is appended to the LaunchRecord, so a reload of the
+  callback gets the same answer.
 
 The client work is the return:
 
@@ -290,8 +293,8 @@ Drafted in `src/Informedica.GenPRES.Server/Scripts/Session.fsx` and migrated by 
   A second presentation within the lifetime with the same public key is answered as the first
   was and re-issues the same cookie; nothing opens twice. A presentation with a different key,
   or with none, is `LaunchSpent`: it cannot be told from another browser, so it is treated as
-  one. After the lifetime the Launch is `LaunchExpired`. The stub record is the same record the
-  real server keeps under `state` (see the IdentityProvider return), so the real server re-issues
+  one. After the lifetime the Launch is `LaunchExpired`. The stub record is the same LaunchRecord
+  the real server appends at 4.2 (see the IdentityProvider return), so the real server re-issues
   at the callback and at a repeated presentation from the same place. Rule 2 names the
   BrowserIdentity; the public key is what the stub, and the real server before the identity hop,
   can check, and the BrowserIdentity is a second check after it.

--- a/docs/implementation-plans/409-client-launch-sequence.md
+++ b/docs/implementation-plans/409-client-launch-sequence.md
@@ -97,12 +97,13 @@ type Session =
     | Launching of Launch * PresentationKey * attempt: int
     | Resuming                                       // getSession in flight (reload, IdP return)
     | Open of SessionOpened
-    | Refused of LaunchRefusal * retry: Launch option
+    | Refused of LaunchRefusal * retry: (Launch * PresentationKey) option
     | Unreachable of Launch * PresentationKey * attempts: int   // ext 3a: server down after page served
 
 type SessionMsg =
     | Present of Launch * PresentationKey            // key minted by App.fs, once per page load
     | Outcome of Launch * PresentationKey * Result<LaunchOutcome, string>   // Error = transport failure
+    | Retry                                          // from Unreachable, or Refused with a retry
     | Resume
     | Resumed of Result<SessionOpened option, string>
     | RefusedAtCallback of LaunchRefusal             // from #/session?refused={reason}, see IdP return
@@ -125,13 +126,19 @@ Rules encoded in `transition`:
 - `Outcome (l, k, _)` is ignored unless the state is `Launching (l, k, _)` for the same Launch
   and the same key. `Resumed` is ignored unless the state is `Resuming`. This is the
   stale-request guard: a response can only land on the presentation that sent it.
-- `Present (l, _)` while the state is `Launching (l, _, _)` or `Unreachable (l, _, _)` is a
-  no-op: an in-flight presentation is never replaced by a second one for the same Launch, and
-  the first key stays the one the server will recognise. A `Present` for a different Launch
-  supersedes the current one, and the old one's outcome is then dropped by the guard above.
+- `Present (l, _)` while the state is `Launching (l, _, _)` is a no-op: an in-flight
+  presentation is never replaced by a second one for the same Launch, and the first key stays
+  the one the server will recognise. In every other state, `Unreachable` and `Refused`
+  included, `Present` starts a fresh presentation; only `Retry` re-uses the stored key. A
+  `Present` for a different Launch supersedes the current one, and the old one's outcome is then
+  dropped by the guard above.
 - A transport error while `Launching (l, k, n)` with `n < 3` yields `Launching (l, k, n + 1)`
   plus `CallPresentLaunch (l, k)`; at three attempts it becomes `Unreachable (l, k, 3)` and the
-  UI offers Retry, which re-presents with the same key. A retry always carries the same Launch
+  UI offers Retry.
+- `Retry` from `Unreachable (l, k, _)` or `Refused (_, Some (l, k))` yields `Launching (l, k, 1)`
+  plus `CallPresentLaunch (l, k)`: the same Launch and the same key, so the server answers a
+  session that did open as it did the first time, and re-verifies a Launch that did not. `Retry`
+  in any other state is a no-op. A retry always carries the same Launch
   and the same `PresentationKey`. The key is what makes the retry safe: the server answers a
   repeated key as it answered the first time (Rule 2, see the server stub), so a response lost
   on the wire cannot turn a session that did open into `LaunchSpent`, while a presentation with
@@ -144,7 +151,7 @@ Rules encoded in `transition`:
   everything derived from it (order context, order plan, formulary, parenteralia) leave the
   screen with the session; an anonymous open carries nothing over (Rule 7).
 - `Refused NoRole` keeps `retry = None` and the UI offers an anonymous open. Other refusals keep
-  the Launch only when a retry is meaningful (`NoBrowserIdentity`).
+  the Launch and key only when a retry is meaningful (`NoBrowserIdentity`).
 - `RefusedAtCallback r` yields `Refused (r, None)`: the Launch was consumed server-side.
 
 ### IdentityProvider return
@@ -226,10 +233,12 @@ Drafted in `src/Informedica.GenPRES.Server/Scripts/Session.fsx` and migrated by 
   Prescriber and the existing `PatientPort` stub patient. With `GENPRES_PROD=1` every launch is
   refused with `LaunchInvalid`, so the stub fails closed in production.
 - Presentation is idempotent per Rule 2, correlated by the `PresentationKey`, never by the
-  presence or absence of a cookie. The stub keeps a spent-mark per Launch holding the key, the
-  outcome, the session id and a lifetime (Rule 29; two minutes in the stub). A second
-  presentation within the lifetime with the same key is answered as the first was and re-issues
-  the same cookie; nothing opens twice. A presentation with a different key, or with no key, is
+  presence or absence of a cookie. The spent-mark is written only in the act that opens a
+  Session (Rule 2, Rule 40); a refusal records nothing, so a retry after a transient refusal
+  such as `NoBrowserIdentity` re-verifies the Launch. The stub keeps the spent-mark per Launch
+  holding the key, the outcome, the session id and a lifetime (Rule 29; two minutes in the
+  stub). A second presentation within the lifetime with the same key is answered as the first
+  was and re-issues the same cookie; nothing opens twice. A presentation with a different key, or with no key, is
   `LaunchSpent`: a request without a key cannot be told apart from another browser, so it is
   treated as one. After the lifetime the Launch is `LaunchExpired`. The real implementation
   keys the same-browser check on the BrowserIdentity (Rule 2); the key is the stand-in that the

--- a/docs/implementation-plans/409-client-launch-sequence.md
+++ b/docs/implementation-plans/409-client-launch-sequence.md
@@ -206,13 +206,18 @@ try to parse the IdentityProvider's HTML as the response.
 
 Two server-side points the client shape depends on, for the plan that implements the hop:
 
-- The state of 4.2 is a LaunchRecord appended to the GenPRES Database, not a cookie. It holds
-  the Launch's verified contents (nonce, PatientId, expiry), the `state` and the public key,
-  never the sealed Launch, and is dropped whole after the expiry. The
-  callback is a cross-site top-level navigation, on which a `SameSite=Strict` cookie is not
-  sent, so a cookie could not carry it anyway. The session cookie stays `Strict`: it is set on
-  the callback response and only read by same-site requests afterwards. It is not sent on the
-  landing GET of `#/session` either, which is fine, since `index.html` does not need it.
+- The state of 4.2 is a LaunchRecord appended to the GenPRES Database. It holds the Launch's
+  verified contents (nonce, PatientId, expiry), the `state` and the public key, never the
+  sealed Launch, and is dropped whole after the expiry.
+- The redirect of 4.2 also sets a `state` cookie (`HttpOnly`, `Secure`, `SameSite=Lax`,
+  `Path=/callback`, `Max-Age` the Launch lifetime) and the callback refuses when it does not
+  match the `state` in the URL, before the code is redeemed. This is the OpenID Connect
+  correlation check (ASP.NET's OIDC handler does the same) and it is what stops a captured
+  callback URL from opening the Session in another browser before step 7 exists. `Lax`
+  because the callback is a cross-site top-level GET, on which `Strict` is not sent. The
+  session cookie stays `Strict`: it is set on the callback response and only read by
+  same-site requests afterwards. It is not sent on the landing GET of `#/session` either,
+  which is fine, since `index.html` does not need it.
 - The LaunchRecord and the spent-mark are one record per Launch, keyed by the nonce, holding
   `state`, the public key, the outcome and the session id. So the server answers a repeated callback
   (a reload of `/callback?code=...`, whose code is already redeemed) and a repeated presentation

--- a/docs/implementation-plans/409-client-launch-sequence.md
+++ b/docs/implementation-plans/409-client-launch-sequence.md
@@ -230,8 +230,7 @@ Drafted in `src/Informedica.GenPRES.Server/Scripts/Session.fsx` and migrated by 
 - `ServerApi.Adapters.fs`: an in-memory stub keyed by a random session id. Token conventions
   `expired`, `spent` (marked as used by another browser), `no-role`, `wrong-patient` and
   `no-identity` map to the matching refusal; anything else opens a session with a stub
-  Prescriber and the existing `PatientPort` stub patient. With `GENPRES_PROD=1` every launch is
-  refused with `LaunchInvalid`, so the stub fails closed in production.
+  Prescriber and the existing `PatientPort` stub patient.
 - Presentation is idempotent per Rule 2, correlated by the `PresentationKey`, never by the
   presence or absence of a cookie. The spent-mark is written only in the act that opens a
   Session (Rule 2, Rule 40); a refusal records nothing, so a retry after a transient refusal
@@ -249,7 +248,7 @@ Drafted in `src/Informedica.GenPRES.Server/Scripts/Session.fsx` and migrated by 
 - Tests in `tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs`: refusal mapping, a
   second presentation within the lifetime with the same key returns the first outcome and the
   same session, one with a different key is `LaunchSpent` and opens nothing, a presentation
-  after the lifetime is `LaunchExpired`, production fail-closed, close removes the session.
+  after the lifetime is `LaunchExpired`, close removes the session.
 
 ### Out of scope
 
@@ -261,6 +260,8 @@ Each has a named extension point:
 - UC-2 PIN enrolment.
 - WorkPlan carry-over (#518).
 - The LaunchScript contract for a path query versus the hash form (decision D1).
+- Whether the production server exposes the stubbed session endpoints at all. That is a scope
+  question, tracked in #580 (scope switch), not a launch question.
 
 ## Confidence
 
@@ -312,28 +313,6 @@ and no longer logs unparseable URLs verbatim.
 The block must be in the commit message, not the PR body: with all three merge methods enabled,
 only squash merges copy a PR body into the commit.
 
-### Release gating
-
-ShipIt offers no per-commit way to hold back a release: its CLI has no skip list or footer for
-that, and a `[skip ci]` on one push only delays the run, because the next push walks history
-back to `last_commit_released` and picks the commits up anyway. Two gates exist instead:
-
-1. **Commit type.** A push whose commits are all non-rendering (`chore`, `docs`, `build`, merge
-   commits) makes ShipIt report "nothing to ship" and open no release PR. Verified with
-   `dotnet shipit --dry-run --allow-branch master --skip-merge-commit` on the current `master`.
-   This is not a tool for hiding a feature: the launch steps are `feat`/`fix` and must render.
-2. **The release PR.** ShipIt runs in pull-request mode and never releases by itself. The tag,
-   the GitHub Release and the Docker push in `tag-release.yml` fire only when a maintainer merges
-   the `release/master` PR. Leaving that PR open holds every release, for every change on
-   `master`, until it is merged.
-
-Because gate 2 holds all of `master`, this plan does not rely on it. The stubbed launch is safe to
-ship in an alpha because the server stub fails closed under `GENPRES_PROD=1` (every launch is
-refused) and an anonymous open is unchanged. That is the feature-flag approach CONTRIBUTING asks
-for with incomplete work, and it keeps the release line free for unrelated fixes. If a step is
-ever unsafe to ship, keep it on the feature branch until it is, rather than merging and holding
-the release PR.
-
 ## Verification
 
 Manual, with `dotnet run` and the demo sheet:
@@ -359,6 +338,5 @@ Manual, with `dotnet run` and the demo sheet:
   Start the server; Retry opens the session.
 - Close the session from the title bar: anonymous state, cookie gone, patient and order context
   cleared.
-- `GENPRES_PROD=1`: every launch is refused.
 - `dotnet run ServerTests` passes with the new stub tests; `dotnet run MarkdownLint` is clean for
   this document.

--- a/docs/scenarios/integration/uc-01-launch.md
+++ b/docs/scenarios/integration/uc-01-launch.md
@@ -56,40 +56,44 @@ sequenceDiagram
     participant C as GenPRES Client
     participant S as GenPRES Server
     participant I as IdentityProvider
+    participant D as GenPRES Database
 
     C->>S: 4.1 PresentLaunch (Launch, public key)
-    Note over S: 4.2 store {state, Launch, public key}
+    S->>D: 4.2 append LaunchRecord {state, Launch, public key, lifetime}
     S-->>C: redirect to /authorize?...&state=...
     C->>I: 4.3 GET /authorize (silent device sign-on)
     I-->>C: redirect to /callback?code=...&state=...
     C->>S: GET /callback?code=...&state=...
-    Note over S: look up state: Launch, public key
+    S->>D: read LaunchRecord by state
+    D-->>S: Launch, public key
     S->>I: 4.4 POST /token (code, client secret), back channel
     I-->>S: BrowserIdentity (signed id_token)
     Note over S: 4.5 continue with step 5
+    S->>D: append the outcome to the LaunchRecord
     S-->>C: redirect to #35;/session, or #35;/session?refused={reason}
 ```
 
 - **4.1** The Client presents the Launch and the public key.
-- **4.2** The Server generates a random `state`, stores the Launch and the public key under
-  it (a server-side record, or an encrypted cookie), and redirects the browser to the
-  IdentityProvider with that `state`.
+- **4.2** The Server generates a random `state`, appends a LaunchRecord with the `state`, the
+  Launch, the public key and the Launch's lifetime, and redirects the browser to the
+  IdentityProvider with that `state`. Nothing is kept in a cookie or in Server memory
+  (Rules 32, 36).
 - **4.3** The IdentityProvider signs the device on silently and redirects the browser to the
   Server's callback with an authorization code and the `state`.
-- **4.4** The Server looks up the `state`, redeems the code on its own connection to the
+- **4.4** The Server reads the LaunchRecord by `state`, redeems the code on its own connection to the
   IdentityProvider (edge C6), and receives the signed BrowserIdentity (Rule 4).
 - **4.5** The Server continues with step 5 and answers the callback with a redirect to
   `#/session`. On refusal it opens nothing and redirects to `#/session?refused={reason}`.
-  A reason is not a secret; the Launch never appears in that URL. The Server keeps the
-  outcome under `state` for the Launch's lifetime: a browser that reloads the callback URL,
-  whose code the IdentityProvider has already redeemed, is answered as the first time
-  (Rule 45).
+  A reason is not a secret; the Launch never appears in that URL. The Server appends the
+  outcome to the LaunchRecord: a browser that reloads the callback URL within the Launch's
+  lifetime, whose code the IdentityProvider has already redeemed, is answered as the first
+  time (Rule 45).
 
 The redirect in 4.2 unloads the Client, so the Client cannot keep the Launch across the hop.
-It does not need to: the Launch stays on the Server from 4.2 to 4.5, and the Client only runs
-again when the launch is finished. For the same reason a refusal at 4.4 cannot be retried by
-the Client; it asks for a relaunch. The Server could offer the retry itself, since it still
-holds the Launch under `state`, by putting a link on the refusal that restarts 4.2. That is an
+It does not need to: the Launch stays in the LaunchRecord from 4.2 to 4.5, and the Client only
+runs again when the launch is finished. For the same reason a refusal at 4.4 cannot be retried
+by the Client; it asks for a relaunch. The Server could offer the retry itself, since the
+LaunchRecord still holds the Launch, by putting a link on the refusal that restarts 4.2. That is an
 option for the identity hop's own plan, not part of this page's sequence.
 
 ## Step 5: verify and open
@@ -128,7 +132,9 @@ sequenceDiagram
 - **5.6** Read the newest TreatmentPlan to start from (Rule 19) and this User's other open
   Sessions (Rule 8).
 - **5.7** Open the Session in one conditional act (Rule 40): spend the Launch, close the other
-  Sessions, write the SessionRecord with the public key. All of it commits, or none.
+  Sessions, write the SessionRecord with the public key. All of it commits, or none. The
+  spent-mark is appended to the LaunchRecord of 4.2, so one record per Launch carries the
+  `state`, the public key, the outcome, the SessionId and the lifetime.
 
 The check in 5.2 and the spend in 5.7 are two different things. By the time the open runs the
 check may be out of date. What decides is the open, which spends the Launch in the same act

--- a/docs/scenarios/integration/uc-01-launch.md
+++ b/docs/scenarios/integration/uc-01-launch.md
@@ -64,10 +64,11 @@ sequenceDiagram
     S->>D: CheckLaunchSpent (nonce)
     D-->>S: LaunchUnspent (a read, decides nothing)
     S->>D: append LaunchRecord {state, nonce, PatientId, expiry, public key}
-    S-->>C: redirect to /authorize?...&state=...
+    S-->>C: redirect to /authorize?...&state=... + Set-Cookie state (Lax, lifetime of the Launch)
     C->>I: 4.3 GET /authorize (silent device sign-on)
     I-->>C: redirect to /callback?code=...&state=...
-    C->>S: GET /callback?code=...&state=...
+    C->>S: GET /callback?code=...&state=... + cookie state
+    Note over S: the cookie must match the state in the URL
     S->>D: read LaunchRecord by state
     D-->>S: nonce, PatientId, expiry, public key
     S->>I: 4.4 POST /token (code, client secret), back channel
@@ -85,11 +86,19 @@ sequenceDiagram
   LaunchRecord with the `state`, the Launch's nonce, PatientId and expiry, and the public key.
   The sealed Launch itself is not stored: everything step 5 needs is in the record, and the
   spent-mark is keyed by the nonce (Rule 2). The browser is redirected to the IdentityProvider
-  with the `state`. Nothing is kept in a cookie or in Server memory (Rules 32, 36).
+  with the `state`, and the same redirect sets a cookie holding the `state`: `HttpOnly`,
+  `Secure`, `SameSite=Lax` (the callback is a cross-site top-level GET, on which `Strict` is
+  not sent), `Path=/callback`, `Max-Age` the Launch's lifetime. The cookie is a random value
+  with no meaning outside the LaunchRecord, not a bearer for anything (Rule 12 does not apply),
+  and the Server keeps nothing in memory (Rules 32, 36).
 - **4.3** The IdentityProvider signs the device on silently and redirects the browser to the
   Server's callback with an authorization code and the `state`.
-- **4.4** The Server reads the LaunchRecord by `state`, redeems the code on its own connection
-  to the IdentityProvider (edge C6), and receives the signed BrowserIdentity (Rule 4).
+- **4.4** The Server compares the `state` in the URL with the `state` cookie; without a match
+  the callback is refused before the code is redeemed. That is what proves the callback comes
+  from the browser that started the hop: a callback URL captured and opened elsewhere has no
+  matching cookie. The Server then reads the LaunchRecord by `state`, redeems the code on its
+  own connection to the IdentityProvider (edge C6), receives the signed BrowserIdentity
+  (Rule 4), and deletes the `state` cookie.
 - **4.5** The Server continues with step 5 and answers the callback with a redirect to
   `#/session`. On refusal it opens nothing and redirects to `#/session?refused={reason}`.
   A reason is not a secret; the Launch never appears in that URL. The Server appends the
@@ -97,6 +106,11 @@ sequenceDiagram
   lifetime, whose code the IdentityProvider has already redeemed, is answered as the first
   time (Rule 45). The record lives as long as the Launch: after the expiry it is dropped whole,
   never rewritten. The audit keeps the launch (Rule 46); the record does not.
+
+Two proofs, two moments: the `state` cookie proves the callback comes from the browser that
+started the hop; the public key proves, from step 7 on, that every request comes from the
+browser that presented the Launch. The cookie is gone after the callback, and the key pair
+cannot act before the Session exists, so neither replaces the other.
 
 The redirect in 4.2 unloads the Client, so the Client cannot keep the Launch across the hop.
 It does not need to: the LaunchRecord carries what the Launch said from 4.2 to 4.5, and the

--- a/docs/scenarios/integration/uc-01-launch.md
+++ b/docs/scenarios/integration/uc-01-launch.md
@@ -97,8 +97,10 @@ sequenceDiagram
   the callback is refused before the code is redeemed. That is what proves the callback comes
   from the browser that started the hop: a callback URL captured and opened elsewhere has no
   matching cookie. The Server then reads the LaunchRecord by `state`, redeems the code on its
-  own connection to the IdentityProvider (edge C6), receives the signed BrowserIdentity
-  (Rule 4), and deletes the `state` cookie.
+  own connection to the IdentityProvider (edge C6), and receives the signed BrowserIdentity
+  (Rule 4). The cookie is not deleted: it expires with the Launch, so a reload of the callback
+  within the lifetime still matches and is answered from the record (4.5). After the lifetime
+  the cookie and the record are both gone, and the callback is refused as expired.
 - **4.5** The Server continues with step 5 and answers the callback with a redirect to
   `#/session`. On refusal it opens nothing and redirects to `#/session?refused={reason}`.
   A reason is not a secret; the Launch never appears in that URL. The Server appends the
@@ -109,7 +111,7 @@ sequenceDiagram
 
 Two proofs, two moments: the `state` cookie proves the callback comes from the browser that
 started the hop; the public key proves, from step 7 on, that every request comes from the
-browser that presented the Launch. The cookie is gone after the callback, and the key pair
+browser that presented the Launch. The cookie expires with the Launch, and the key pair
 cannot act before the Session exists, so neither replaces the other.
 
 The redirect in 4.2 unloads the Client, so the Client cannot keep the Launch across the hop.

--- a/docs/scenarios/integration/uc-01-launch.md
+++ b/docs/scenarios/integration/uc-01-launch.md
@@ -1,117 +1,194 @@
-# The launch flow
+# The launch sequence
 
-How a User gets from a patient open in MainEHR to a GenPRES Session for that patient
-— UC-1's main path as the model specifies it. The messages below are the ones in
-its trace, not a sketch of them.
+How a User gets from a patient open in MainEHR to a GenPRES Session for that patient: UC-1's
+main path. The overview numbers the steps; the sections after it zoom in on the steps that
+have sub-steps. Rule and Concept numbers cite
+[GenPRES-MainEHR-Integration-V8.md](GenPRES-MainEHR-Integration-V8.md).
+
+This page goes one step beyond the trace in [`Integration.fsx`](Integration.fsx): the browser
+key pair of step 3 and the signed request of step 7 are not in the script yet.
+
+## Overview
 
 ```mermaid
 sequenceDiagram
-    actor U as User
-    participant W as MainEHR Workstation
     participant L as MainEHR LaunchScript
     participant C as GenPRES Client
+    participant S as GenPRES Server
     participant I as IdentityProvider
+    participant D as GenPRES Database
+
+    L->>C: 1. open #35;/session?launch=... (sealed PatientId, no login)
+    Note over L: exits, learns nothing after this
+    C->>C: 2. erase the Launch from URL and history, keep it in memory
+    C->>C: 3. generate key pair, private key stays in the browser
+    C->>S: 4. present Launch + public key
+    S-->>C: redirect to the IdentityProvider (Launch held server-side)
+    C->>I: silent device sign-on
+    I-->>C: redirect back with an authorization code
+    C->>S: callback with the code
+    S->>I: redeem the code (back channel)
+    I-->>S: BrowserIdentity, signed
+    S->>D: 5. verify the Launch, resolve the User, read data, open the Session
+    D-->>S: SessionRecord {SessionId, User, Role, Patient, public key}
+    S-->>C: 6. Set-Cookie SessionId + UserContext, PatientContext, OrderContexts, OpenedToken
+    Note over C,S: 7. every later request: cookie + proof signed with the private key + OpenedToken
+```
+
+| # | Step | What happens |
+|---|------|--------------|
+| 1 | Launch | The LaunchScript seals the PatientId under the key it shares with the Server, opens the browser on `#/session?launch={token}`, and exits. The Launch is single use and short-lived (Rules 2, 3, 29) and carries no login (Rule 4). |
+| 2 | Erase | The Client removes the Launch from the URL and the browser history and keeps it only in memory, for retries within its lifetime (Rule 39). |
+| 3 | Key pair | The Client generates a key pair with WebCrypto. The private key is not extractable and is stored in IndexedDB under the public key's thumbprint, next to keys of earlier launches in this browser. The public key goes with the Launch. |
+| 4 | Identity | The Client presents the Launch and the public key. The Server sends the browser to the IdentityProvider and gets it back with a signed BrowserIdentity over its own connection, never through the Client's hands. See [Step 4](#step-4-the-identity-round-trip). |
+| 5 | Verify and open | The Server verifies the Launch, asks the UserRegistry for the Role and the active Patient, reads the patient data and the record, and opens the Session in one act that stores the public key in the SessionRecord. See [Step 5](#step-5-verify-and-open). |
+| 6 | Session open | The response sets the SessionId as an HttpOnly, Secure, SameSite=Strict cookie (Rule 12) and returns UserContext, PatientContext, the OrderContexts to start from, the OpenedToken (Rule 34) and the thumbprint of the Session's public key. The Client deletes the private keys of other launches; the Session they belonged to is closed by this open (Rule 8). The Client keeps these in memory and shows the patient. |
+| 7 | Every later request | The cookie says which Session, a proof signed with the private key says which browser, the OpenedToken says which TreatmentPlan was opened. See [Step 7](#step-7-a-signed-request). |
+
+Two questions, two answers: *who is this* is the IdentityProvider's answer (step 4), *what may
+they do, and on which Patient* is the UserRegistry's (step 5). The Server asks both at every
+launch, and nothing the Launch says decides either.
+
+## Step 4: the identity round trip
+
+```mermaid
+sequenceDiagram
+    participant C as GenPRES Client
+    participant S as GenPRES Server
+    participant I as IdentityProvider
+
+    C->>S: 4.1 PresentLaunch (Launch, public key)
+    Note over S: 4.2 store {state, Launch, public key}
+    S-->>C: redirect to /authorize?...&state=...
+    C->>I: 4.3 GET /authorize (silent device sign-on)
+    I-->>C: redirect to /callback?code=...&state=...
+    C->>S: GET /callback?code=...&state=...
+    Note over S: look up state: Launch, public key
+    S->>I: 4.4 POST /token (code, client secret), back channel
+    I-->>S: BrowserIdentity (signed id_token)
+    Note over S: 4.5 continue with step 5
+    S-->>C: redirect to #35;/session, or #35;/session?refused={reason}
+```
+
+- **4.1** The Client presents the Launch and the public key.
+- **4.2** The Server generates a random `state`, stores the Launch and the public key under
+  it (a server-side record, or an encrypted cookie), and redirects the browser to the
+  IdentityProvider with that `state`.
+- **4.3** The IdentityProvider signs the device on silently and redirects the browser to the
+  Server's callback with an authorization code and the `state`.
+- **4.4** The Server looks up the `state`, redeems the code on its own connection to the
+  IdentityProvider (edge C6), and receives the signed BrowserIdentity (Rule 4).
+- **4.5** The Server continues with step 5 and answers the callback with a redirect to
+  `#/session`. On refusal it opens nothing and redirects to `#/session?refused={reason}`.
+  A reason is not a secret; the Launch never appears in that URL. The Server keeps the
+  outcome under `state` for the Launch's lifetime: a browser that reloads the callback URL,
+  whose code the IdentityProvider has already redeemed, is answered as the first time
+  (Rule 45).
+
+The redirect in 4.2 unloads the Client, so the Client cannot keep the Launch across the hop.
+It does not need to: the Launch stays on the Server from 4.2 to 4.5, and the Client only runs
+again when the launch is finished. For the same reason a refusal at 4.4 cannot be retried by
+the Client; it asks for a relaunch. The Server could offer the retry itself, since it still
+holds the Launch under `state`, by putting a link on the refusal that restarts 4.2. That is an
+option for the identity hop's own plan, not part of this page's sequence.
+
+## Step 5: verify and open
+
+```mermaid
+sequenceDiagram
     participant S as GenPRES Server
     participant R as UserRegistry
     participant P as PatientDataPlatform
     participant D as GenPRES Database
 
-    U->>W: LogIn, SelectPatient
-    U->>L: TriggerLaunch
-
-    Note over L: seals the PatientId under the shared key
-    L->>C: GET /genpres?launch=... (a Patient, no login)
-    Note over L: exits, and learns nothing after this
-
-    rect rgb(245,245,245)
-    Note over C,I: deployment, not modelled: Integration.fsx takes the<br/>BrowserIdentity as a value the browser presents
-    C->>S: PresentLaunch (Launch)
-    S-->>C: redirect to the IdentityProvider (Launch held in request state, Rule 39)
-    C->>I: authorize (silent device sign-on)
-    I-->>C: redirect back, carrying an authorization code
-    C->>S: Callback (authorization code)
-    S->>I: redeem the authorization code (back channel, edge C6)
-    I-->>S: BrowserIdentity, signed (Rule 4)
-    end
-
-    C->>S: RedeemLaunch (Launch, BrowserIdentity)
-    Note over S: verifies the Launch - key, lifetime (Rules 2, 3)
-
-    S->>D: CheckLaunchSpent (Rule 2)
-    D-->>S: LaunchUnspent
-    Note over S,D: a read: it can refuse a spent Launch early,<br/>but it writes nothing and does not decide
-
-    S->>R: ResolveUser (BrowserIdentity)
-    R-->>S: UserResolved (Role, mail address, active Patient)
-    Note over S: the Launch's Patient must be the active one (Rule 6)
-
-    S->>D: ReadCredential
-    D-->>S: CredentialRead (a PIN is set, Rule 24)
-
-    S->>P: ReadPatientData (once, Concept 2)
-    P-->>S: PatientDataRead
-    S->>D: ReadRecord
-    D-->>S: RecordRead (the TreatmentPlan to start from, Rule 19)
-    S->>D: ReadSessionRecords
-    D-->>S: SessionRecordsRead (this User's other Sessions, Rule 8)
-
-    Note over S,D: one conditional act (Rule 40) - all of it commits, or none:<br/>the nonce is spent here (Rule 2) and the other Sessions close (Rule 8)
+    Note over S: 5.1 verify the Launch: shared key, lifetime
+    S->>D: 5.2 CheckLaunchSpent
+    D-->>S: LaunchUnspent (a read, decides nothing)
+    S->>R: 5.3 ResolveUser (BrowserIdentity)
+    R-->>S: Role, mail address, active Patient
+    S->>D: 5.4 ReadCredential (User)
+    D-->>S: PIN is set
+    S->>P: 5.5 ReadPatientData (PatientId)
+    P-->>S: PatientData
+    S->>D: 5.6 ReadRecord (PatientId), ReadSessionRecords (User)
+    D-->>S: newest TreatmentPlan, this User's other Sessions
+    Note over S,D: 5.7 one conditional act: spend the Launch, close the other Sessions,<br/>write SessionRecord {SessionId, User, Role, Patient, public key}
     S->>D: OpenSessionClosingOthers
-    D-->>S: SessionWasOpened (the Launch is now spent)
-    S-->>C: SessionOpened (SessionId as cookie - UserContext, PatientContext, OrderContexts, OpenedToken)
+    D-->>S: SessionWasOpened
 ```
 
-## Reading it
+- **5.1** Verify the Launch: sealed under the shared key, within its lifetime (Rules 2, 3).
+- **5.2** Check whether the Launch is already spent. This is a read: it refuses a plainly spent
+  Launch before the Server fetches anything, but it decides nothing.
+- **5.3** Ask the UserRegistry for the Role (Rule 5), the mail address, and the Patient this
+  User has active in MainEHR. That Patient must be the Launch's (Rule 6).
+- **5.4** Check that a PIN is set (Rule 24). A Prescriber without one goes through UC-2 and
+  the launch continues at 5.5 afterwards.
+- **5.5** Read the patient data from the PatientDataPlatform, once (Concept 2).
+- **5.6** Read the newest TreatmentPlan to start from (Rule 19) and this User's other open
+  Sessions (Rule 8).
+- **5.7** Open the Session in one conditional act (Rule 40): spend the Launch, close the other
+  Sessions, write the SessionRecord with the public key. All of it commits, or none.
 
-Four things the shape is meant to make obvious.
+The check in 5.2 and the spend in 5.7 are two different things. By the time the open runs the
+check may be out of date. What decides is the open, which spends the Launch in the same act
+that writes the record. So a launch cannot spend a Launch and then fail to open, and two
+presentations that both passed the check cannot both open.
 
-**The Launch names a Patient and nothing else.** It carries no login, so nothing the
-LaunchScript says decides who the Session belongs to. Who is at the browser only the
-IdentityProvider can say, and its answer reaches the Server signed, on the Server's
-own connection — never through the Client's hands.
+## Step 7: a signed request
 
-**Two different questions, two different actors.** *Who is this* is the
-IdentityProvider's answer; *what may they do, and on which Patient* is the
-UserRegistry's. Neither answers the other's question, and the Server asks both at
-every launch.
+Every request after the launch carries two things:
 
-**The check and the spend are two different things.** `CheckLaunchSpent` is a read
-near the top: it refuses a Launch that was plainly spent before the Server fetches
-anything for it. It does not decide, and by the time the open runs its answer may be
-out of date. What decides is `OpenSessionClosingOthers`, which spends the nonce in the
-same act that writes the record — so a launch cannot spend a nonce and then fail to
-open, and two presentations that both passed the check cannot both open.
+- the SessionId cookie, which names the Session;
+- a proof signed with the private key from step 3, which names the browser. It covers the
+  HTTP method, the URL, a hash of the body, the time, a unique id, and the OpenedToken, which
+  names the TreatmentPlan the Session opened with (Rule 34). This is the DPoP pattern
+  ([RFC 9449](https://www.rfc-editor.org/rfc/rfc9449)).
 
-**The LaunchScript is gone after the third message.** It opens the browser and exits,
-so no failure after that point can reach it — every error from there on is the
-Client's to show, except a Server that is down, which leaves no Client to show
-anything.
+The Server reads the SessionRecord by SessionId, verifies the signature against the stored
+public key, checks method, URL, body hash, time and uniqueness, and compares the OpenedToken
+with the head of the record. If a newer TreatmentPlan exists, the response says so (Rule 21).
 
-## What it leaves out
+Implementing the signed proof is a later plan. The key pair is generated at the launch so
+that the SessionRecord already holds the public key when that plan lands. Keys are kept per
+thumbprint so that a second launch in another tab, if refused, cannot take the first tab's
+key away.
 
-- **The refusals.** A launch can fail at each step — no identity, no Role, another
-  active Patient, a Launch that is forged, expired or already spent. All of them end
-  the same way: no Session opens, and at most the Client offers an anonymous open
-  instead (Rule 7).
-- **The PIN detour.** A Prescriber with no PIN is not refused: the launch suspends
-  into UC-2 — a confirmation code is mailed, the PIN is set, and the launch continues
-  at the data fetch. Only an enrolment abandoned or failed leaves no Session (Rule 7),
-  and the cure is a relaunch.
-- **The audit.** Every launch, honored or refused, is appended to the audit
-  (Rule 46); drawing each append would double the diagram.
-- **Everything after the launch** — prescribing and signing, and the ten other use
-  cases.
-- **The second code.** UC-2 and UC-6 mail a *confirmation code* to set or replace a
-  PIN. It is a different thing from the authorization code above, which belongs to the
-  identity round trip and never leaves the browser and the two servers.
+## Retries
+
+A presentation can be repeated within the Launch's lifetime: after a lost response, or after
+a transient refusal such as an unreachable IdentityProvider. The public key correlates the
+repeat. A second presentation with the same public key is answered as the first was and gets
+the same cookie; nothing opens twice (Rule 2, same browser). A presentation with another public
+key, or with none, is refused as spent: the Server cannot tell it from another browser. After
+the lifetime the Launch is expired.
+
+Rule 2 names the BrowserIdentity as the same-browser test. This page uses the public key,
+because the Server has it at every presentation, before the identity is known; the
+BrowserIdentity is a second test once the hop is done. Naming both in Rule 2 is a follow-up
+on V8.
+
+## Refusals
+
+Every refusal ends the same way: no Session opens (Rule 7), and the Client shows the reason.
+
+| Refusal | Fails at | The Client offers | V8 |
+|---------|----------|-------------------|----|
+| Launch expired, spent, or not sealed under the key | 5.1, 5.2 | a relaunch from MainEHR | ext 4a |
+| No BrowserIdentity | 4.4 | a relaunch; the Client has no Launch left after the redirect | ext 3c |
+| No Role | 5.3 | a fresh anonymous open that carries nothing over (UC-7) | ext 5a |
+| Another active Patient, or none | 5.3 | a relaunch after activating the right Patient | ext 5b |
+| No PIN | 5.4 | enrolment (UC-2); abandoned enrolment leaves no Session | ext 5d |
+| Server unreachable after the page was served | 4 | automatic retries from memory, then a Retry button | ext 3a |
 
 ## Two launches at once (ext 8b)
 
-Rule 8 is a count, and a count read and then written back is a race. Two launches of
-User A — two Launches, two browsers — run through to the open together.
+Rule 8 is a count, and a count read and then written back is a race. Two launches of User A,
+two Launches in two browsers, run through to the open together.
 
 ```mermaid
 sequenceDiagram
+    autonumber
     actor U as User A
     participant C1 as Browser 1
     participant C2 as Browser 2
@@ -120,8 +197,8 @@ sequenceDiagram
 
     U->>C1: launch (Launch A)
     U->>C2: launch (Launch B)
-    C1->>S: RedeemLaunch (Launch A)
-    C2->>S: RedeemLaunch (Launch B)
+    C1->>S: PresentLaunch (Launch A)
+    C2->>S: PresentLaunch (Launch B)
 
     Note over S,D: two different Launches, so both nonces are unspent<br/>and both run the whole pipeline
 
@@ -145,19 +222,23 @@ sequenceDiagram
     Note over D: one open Session, whichever won. The other is Superseded<br/>and owes a notice, delivered as ext 8a
 ```
 
-Both browsers are told a Session opened, and only one of them still has it. That is not a
-lost update: the Database decided, and the loser's Client learns at its next request that
-the Session it holds has ended (Rule 11). Rule 8's limit is per User, so this is the same
-mechanism as ext 8a — an earlier Session closed by a later launch — arriving at once
-rather than in sequence.
-
-This is a different race from the one over a single Launch, where two presentations of the
-*same* nonce contend. There the spend inside the open decides and exactly one Session
-opens; here there are two Launches and two nonces, and what contends is the per-User
+Both browsers are told a Session opened, and only one still has it. The Database decided, and
+the loser's Client learns at its next request that its Session has ended (Rule 11). This is a
+different race from two presentations of the *same* Launch: there the spend inside the open
+(5.7) settles it and exactly one Session opens; here two Launches contend for the per-User
 limit.
+
+## Left out
+
+- **The PIN detour.** A Prescriber with no PIN is not refused: the launch suspends into UC-2
+  and continues at 5.5 once the PIN is set.
+- **The audit.** Every launch, honored or refused, is appended to the audit (Rule 46).
+- **Everything after the launch**: prescribing and signing, and the ten other use cases.
+- **The confirmation code.** UC-2 and UC-6 mail a code to set or replace a PIN. It is not the
+  authorization code of step 4, which never leaves the browser and the two servers.
 
 ---
 
-Drawn from UC-1 in [`Integration.fsx`](Integration.fsx), which carries this revision. The
-full trace of all eleven use cases is written to `Integration.run.txt` beside it when
-the script runs.
+The trace in [`Integration.fsx`](Integration.fsx) carries UC-1 without the key pair and the
+signed request. Bringing the script, and the README's rule that the trace is right, in line
+with this page is a follow-up.

--- a/docs/scenarios/integration/uc-01-launch.md
+++ b/docs/scenarios/integration/uc-01-launch.md
@@ -23,13 +23,14 @@ sequenceDiagram
     C->>C: 2. erase the Launch from URL and history, keep it in memory
     C->>C: 3. generate key pair, private key stays in the browser
     C->>S: 4. present Launch + public key
-    S-->>C: redirect to the IdentityProvider (Launch held server-side)
+    S->>D: verify the Launch, append LaunchRecord {state, nonce, PatientId, expiry, public key}
+    S-->>C: redirect to the IdentityProvider (the LaunchRecord holds what the Launch said)
     C->>I: silent device sign-on
     I-->>C: redirect back with an authorization code
     C->>S: callback with the code
     S->>I: redeem the code (back channel)
     I-->>S: BrowserIdentity, signed
-    S->>D: 5. verify the Launch, resolve the User, read data, open the Session
+    S->>D: 5. check the Launch unspent, resolve the User, read data, open the Session
     D-->>S: SessionRecord {SessionId, User, Role, Patient, public key}
     S-->>C: 6. Set-Cookie SessionId + UserContext, PatientContext, OrderContexts, OpenedToken
     Note over C,S: 7. every later request: cookie + proof signed with the private key + OpenedToken
@@ -40,8 +41,8 @@ sequenceDiagram
 | 1 | Launch | The LaunchScript seals the PatientId under the key it shares with the Server, opens the browser on `#/session?launch={token}`, and exits. The Launch is single use and short-lived (Rules 2, 3, 29) and carries no login (Rule 4). |
 | 2 | Erase | The Client removes the Launch from the URL and the browser history and keeps it only in memory, for retries within its lifetime (Rule 39). |
 | 3 | Key pair | The Client generates a key pair with WebCrypto. The private key is not extractable and is stored in IndexedDB under the public key's thumbprint, next to keys of earlier launches in this browser. The public key goes with the Launch. |
-| 4 | Identity | The Client presents the Launch and the public key. The Server sends the browser to the IdentityProvider and gets it back with a signed BrowserIdentity over its own connection, never through the Client's hands. See [Step 4](#step-4-the-identity-round-trip). |
-| 5 | Verify and open | The Server verifies the Launch, asks the UserRegistry for the Role and the active Patient, reads the patient data and the record, and opens the Session in one act that stores the public key in the SessionRecord. See [Step 5](#step-5-verify-and-open). |
+| 4 | Identity | The Client presents the Launch and the public key. The Server verifies the Launch, keeps its contents in a LaunchRecord, and sends the browser to the IdentityProvider and gets it back with a signed BrowserIdentity over its own connection, never through the Client's hands. See [Step 4](#step-4-the-identity-round-trip). |
+| 5 | Check and open | The Server checks that the Launch is unspent, asks the UserRegistry for the Role and the active Patient, reads the patient data and the record, and opens the Session in one act that stores the public key in the SessionRecord. See [Step 5](#step-5-check-and-open). |
 | 6 | Session open | The response sets the SessionId as an HttpOnly, Secure, SameSite=Strict cookie (Rule 12) and returns UserContext, PatientContext, the OrderContexts to start from, the OpenedToken (Rule 34) and the thumbprint of the Session's public key. The Client deletes the private keys of other launches; the Session they belonged to is closed by this open (Rule 8). The Client keeps these in memory and shows the patient. |
 | 7 | Every later request | The cookie says which Session, a proof signed with the private key says which browser, the OpenedToken says which TreatmentPlan was opened. See [Step 7](#step-7-a-signed-request). |
 
@@ -59,13 +60,16 @@ sequenceDiagram
     participant D as GenPRES Database
 
     C->>S: 4.1 PresentLaunch (Launch, public key)
-    S->>D: 4.2 append LaunchRecord {state, Launch, public key, lifetime}
+    Note over S: 4.2 verify the Launch: shared key, lifetime
+    S->>D: CheckLaunchSpent (nonce)
+    D-->>S: LaunchUnspent (a read, decides nothing)
+    S->>D: append LaunchRecord {state, nonce, PatientId, expiry, public key}
     S-->>C: redirect to /authorize?...&state=...
     C->>I: 4.3 GET /authorize (silent device sign-on)
     I-->>C: redirect to /callback?code=...&state=...
     C->>S: GET /callback?code=...&state=...
     S->>D: read LaunchRecord by state
-    D-->>S: Launch, public key
+    D-->>S: nonce, PatientId, expiry, public key
     S->>I: 4.4 POST /token (code, client secret), back channel
     I-->>S: BrowserIdentity (signed id_token)
     Note over S: 4.5 continue with step 5
@@ -74,29 +78,35 @@ sequenceDiagram
 ```
 
 - **4.1** The Client presents the Launch and the public key.
-- **4.2** The Server generates a random `state`, appends a LaunchRecord with the `state`, the
-  Launch, the public key and the Launch's lifetime, and redirects the browser to the
-  IdentityProvider with that `state`. Nothing is kept in a cookie or in Server memory
-  (Rules 32, 36).
+- **4.2** The Server verifies the Launch: sealed under the shared key, within its lifetime
+  (Rules 2, 3), and checks that it is not already spent. That check is a read: it refuses a
+  plainly spent Launch before any round trip, but it decides nothing. A Launch that fails here
+  is refused without a record. The Server then generates a random `state` and appends a
+  LaunchRecord with the `state`, the Launch's nonce, PatientId and expiry, and the public key.
+  The sealed Launch itself is not stored: everything step 5 needs is in the record, and the
+  spent-mark is keyed by the nonce (Rule 2). The browser is redirected to the IdentityProvider
+  with the `state`. Nothing is kept in a cookie or in Server memory (Rules 32, 36).
 - **4.3** The IdentityProvider signs the device on silently and redirects the browser to the
   Server's callback with an authorization code and the `state`.
-- **4.4** The Server reads the LaunchRecord by `state`, redeems the code on its own connection to the
-  IdentityProvider (edge C6), and receives the signed BrowserIdentity (Rule 4).
+- **4.4** The Server reads the LaunchRecord by `state`, redeems the code on its own connection
+  to the IdentityProvider (edge C6), and receives the signed BrowserIdentity (Rule 4).
 - **4.5** The Server continues with step 5 and answers the callback with a redirect to
   `#/session`. On refusal it opens nothing and redirects to `#/session?refused={reason}`.
   A reason is not a secret; the Launch never appears in that URL. The Server appends the
   outcome to the LaunchRecord: a browser that reloads the callback URL within the Launch's
   lifetime, whose code the IdentityProvider has already redeemed, is answered as the first
-  time (Rule 45).
+  time (Rule 45). The record lives as long as the Launch: after the expiry it is dropped whole,
+  never rewritten. The audit keeps the launch (Rule 46); the record does not.
 
 The redirect in 4.2 unloads the Client, so the Client cannot keep the Launch across the hop.
-It does not need to: the Launch stays in the LaunchRecord from 4.2 to 4.5, and the Client only
-runs again when the launch is finished. For the same reason a refusal at 4.4 cannot be retried
-by the Client; it asks for a relaunch. The Server could offer the retry itself, since the
-LaunchRecord still holds the Launch, by putting a link on the refusal that restarts 4.2. That is an
-option for the identity hop's own plan, not part of this page's sequence.
+It does not need to: the LaunchRecord carries what the Launch said from 4.2 to 4.5, and the
+Client only runs again when the launch is finished. For the same reason a refusal at 4.4
+cannot be retried by the Client; it asks for a relaunch. The Server could offer the retry
+itself, since the LaunchRecord still holds the nonce and the PatientId, by putting a link on
+the refusal that restarts the redirect. That is an option for the identity hop's own plan, not
+part of this page's sequence.
 
-## Step 5: verify and open
+## Step 5: check and open
 
 ```mermaid
 sequenceDiagram
@@ -105,8 +115,8 @@ sequenceDiagram
     participant P as PatientDataPlatform
     participant D as GenPRES Database
 
-    Note over S: 5.1 verify the Launch: shared key, lifetime
-    S->>D: 5.2 CheckLaunchSpent
+    Note over S: 5.1 the LaunchRecord's expiry has not passed
+    S->>D: 5.2 CheckLaunchSpent (nonce)
     D-->>S: LaunchUnspent (a read, decides nothing)
     S->>R: 5.3 ResolveUser (BrowserIdentity)
     R-->>S: Role, mail address, active Patient
@@ -121,9 +131,10 @@ sequenceDiagram
     D-->>S: SessionWasOpened
 ```
 
-- **5.1** Verify the Launch: sealed under the shared key, within its lifetime (Rules 2, 3).
-- **5.2** Check whether the Launch is already spent. This is a read: it refuses a plainly spent
-  Launch before the Server fetches anything, but it decides nothing.
+- **5.1** Check that the expiry in the LaunchRecord has not passed while the hop ran
+  (Rule 3). The Launch itself was verified at 4.2.
+- **5.2** Check again, by nonce, whether the Launch is spent: the hop took time. Still a read,
+  still deciding nothing.
 - **5.3** Ask the UserRegistry for the Role (Rule 5), the mail address, and the Patient this
   User has active in MainEHR. That Patient must be the Launch's (Rule 6).
 - **5.4** Check that a PIN is set (Rule 24). A Prescriber without one goes through UC-2 and
@@ -133,8 +144,9 @@ sequenceDiagram
   Sessions (Rule 8).
 - **5.7** Open the Session in one conditional act (Rule 40): spend the Launch, close the other
   Sessions, write the SessionRecord with the public key. All of it commits, or none. The
-  spent-mark is appended to the LaunchRecord of 4.2, so one record per Launch carries the
-  `state`, the public key, the outcome, the SessionId and the lifetime.
+  spent-mark is appended to the LaunchRecord of 4.2, keyed by the nonce, so one record per
+  Launch carries the `state`, the nonce, the PatientId, the expiry, the public key, the
+  outcome and the SessionId, and never the sealed Launch.
 
 The check in 5.2 and the spend in 5.7 are two different things. By the time the open runs the
 check may be out of date. What decides is the open, which spends the Launch in the same act
@@ -180,7 +192,7 @@ Every refusal ends the same way: no Session opens (Rule 7), and the Client shows
 
 | Refusal | Fails at | The Client offers | V8 |
 |---------|----------|-------------------|----|
-| Launch expired, spent, or not sealed under the key | 5.1, 5.2 | a relaunch from MainEHR | ext 4a |
+| Launch expired, spent, or not sealed under the key | 4.2 (5.1, 5.2 again after the hop) | a relaunch from MainEHR | ext 4a |
 | No BrowserIdentity | 4.4 | a relaunch; the Client has no Launch left after the redirect | ext 3c |
 | No Role | 5.3 | a fresh anonymous open that carries nothing over (UC-7) | ext 5a |
 | Another active Patient, or none | 5.3 | a relaunch after activating the right Patient | ext 5b |


### PR DESCRIPTION
## Description

Implementation plan for the client side of the launch sequence (UC-1) from the MainEHR integration design V8, with all server-side actions stubbed behind the final API contract.

Key points:

- Launch token erased from url and history at first presentation (Rule 39); session credential as an HttpOnly, SameSite=Strict cookie, never in a url or response body (Rule 12).
- Pure client session state machine (`Anonymous | Launching | Resuming | Open | Refused | Unreachable`) with a stale-request guard and retries; patient changes routed through `UpdatePatient`.
- IdentityProvider hop modelled as a `RedirectTo` launch outcome; the stub never returns it.
- Server stub fails closed under `GENPRES_PROD=1`, so the work can ship in alphas without holding the ShipIt release PR.
- Five PRs, each under 200 lines. The plan is to be picked up in #574 to correct that scaffold, whose redeem-token hop has no counterpart in V8.

Reviewer note: the D1 decision (url parameters versus sealed launch token) in `docs/roadmap/mvpap2019-gap-overview.md` is still open. The plan is D1-neutral on the client, because the launch is opaque there.

## Author checklist

- [x] The described changes have already been described in an issue: #409
- [x] This PR documents the plan in a markdown file in [docs/implementation-plans/](../../docs/implementation-plans/).
- [x] I have used [the implementation plan template](../../docs/implementation-plans/template.md).
- [x] The plan has enough detail: any suggestions that a reviewer adds to a PR that implements the plan are likely to be relatively quick to implement.

## Reviewer checklist

- [x] The chosen approach is a good choice.
- [x] The sequence of steps is complete and sensible.
- [x] I have documented resources that may help with implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
