### PR TITLE
fix(client): erase the launch from the URL and drop the redeem-token stub

### DIFF
--- a/src/Informedica.GenPRES.Client/App.fs
+++ b/src/Informedica.GenPRES.Client/App.fs
@@ -234,9 +234,14 @@ module private Elmish =
         tryParseInt "gd" paramsMap |> Option.map Measures.toDay,
         Map.tryFind "dp" paramsMap
 
-    let parseUrl sl =
+    // The patient, page, language, disclaimer and medication carried by an
+    // anonymous "#/patient?..." url. A "#/session..." url carries none of these:
+    // the session supplies the patient (plan 409), so it yields the defaults
+    // without a warning.
+    let parsePatient sl =
         match sl with
         | [] -> None, None, None, true, None
+        | "session" :: _ -> None, None, None, true, None
         | [ "patient"; Route.Query queryParams ] ->
             let paramsMap = Map.ofList queryParams
 
@@ -310,7 +315,8 @@ module private Elmish =
                     patient
 
                 | _ ->
-                    Logging.warning "could not parse url to patient" (sl |> String.concat ";")
+                    // only the parameter names: the values are patient data
+                    Logging.warning "could not parse url to patient" (paramsMap |> Map.toList |> List.map fst)
                     None
 
             let page =
@@ -351,9 +357,27 @@ module private Elmish =
             pat, page, lang, discl, med
 
         | _ ->
-            sl |> String.concat "" |> Logging.warning "could not parse url"
+            // only the route segment: the rest of the url is never logged
+            Logging.warning "could not parse url" (sl |> List.head)
 
             None, None, None, true, None
+
+
+    /// The launch token of a "#/session?launch={token}" url, the form MainEHR
+    /// opens GenPRES with (launch sequence step 1). Opaque to the client.
+    let parseLaunch sl =
+        match sl with
+        | [ "session"; Route.Query queryParams ] -> queryParams |> Map.ofList |> Map.tryFind "launch"
+        | _ -> None
+
+
+    /// Launch sequence step 2: replace the launch url with "#/session" in the
+    /// address bar and the history entry, so the token survives neither a
+    /// reload, the back button nor a copied url. Goes through the History API
+    /// directly: Router.navigate would dispatch the navigation event and
+    /// re-enter UrlChanged.
+    let eraseLaunch () =
+        Browser.Dom.history.replaceState (null, "", "#/session")
 
 
     let initialState
@@ -418,7 +442,12 @@ module private Elmish =
 
 
     let init () : State * Cmd<Msg> =
-        let pat, page, lang, discl, med = Router.currentUrl () |> parseUrl
+        let url = Router.currentUrl ()
+
+        if url |> parseLaunch |> Option.isSome then
+            eraseLaunch ()
+
+        let pat, page, lang, discl, med = url |> parsePatient
 
         let cmds =
             Cmd.batch
@@ -693,7 +722,10 @@ module private Elmish =
                 ]
 
         | UrlChanged sl ->
-            let pat, page, lang, discl, med = sl |> parseUrl
+            if sl |> parseLaunch |> Option.isSome then
+                eraseLaunch ()
+
+            let pat, page, lang, discl, med = sl |> parsePatient
 
             { state with
                 ShowDisclaimer = discl

--- a/src/Informedica.GenPRES.Client/App.fs
+++ b/src/Informedica.GenPRES.Client/App.fs
@@ -13,15 +13,9 @@ open Shared.Types
 open Shared.Models
 open Global
 
+
 module private Elmish =
 
-    [<RequireQualifiedAccess>]
-    type SessionContextMsg =
-        | Launch of SessionLaunchToken
-        | Launched of SessionRedeemToken
-        | Redeem of SessionRedeemToken
-        | Redeemed of SessionContent
-        | Error of string
 
     type State =
         {
@@ -55,7 +49,6 @@ module private Elmish =
             AuthToken: string
             LogFiles: Deferred<LogFileInfo[]>
             LogAnalysisReport: Deferred<string>
-            SessionContext: SessionContext
         }
 
 
@@ -111,8 +104,6 @@ module private Elmish =
         | LoadLogFilesResult of ApiResponse
         | AnalyzeLogFile of string
         | LoadLogAnalysisResult of ApiResponse
-
-        | SessionContextMsg of SessionContextMsg
 
 
     and ApiResponse = AsyncOperationStatus<Result<Api.Response, string[]>>
@@ -243,145 +234,127 @@ module private Elmish =
         tryParseInt "gd" paramsMap |> Option.map Measures.toDay,
         Map.tryFind "dp" paramsMap
 
-    let parsePatient (urlParts: string list) =
-        urlParts
-        |> List.pairwise
-        |> List.tryFind (fun (a, b) -> a = "patient")
-        |> function
-            | Some(_, Route.Query queryParams) ->
-                let paramsMap = Map.ofList queryParams
+    let parseUrl sl =
+        match sl with
+        | [] -> None, None, None, true, None
+        | [ "patient"; Route.Query queryParams ] ->
+            let paramsMap = Map.ofList queryParams
 
-                let pat =
-                    match Map.tryFind "by" paramsMap, Map.tryFind "ad" paramsMap with
-                    | Some(Route.Int year), _ ->
-                        // birthday year is required
-                        let month =
-                            match Map.tryFind "bm" paramsMap with
-                            | Some(Route.Int months) -> months
-                            | _ -> 1 // january is the default
+            let pat =
+                match Map.tryFind "by" paramsMap, Map.tryFind "ad" paramsMap with
+                | Some(Route.Int year), _ ->
+                    // birthday year is required
+                    let month =
+                        match Map.tryFind "bm" paramsMap with
+                        | Some(Route.Int months) -> months
+                        | _ -> 1 // january is the default
 
-                        let day =
-                            match Map.tryFind "bd" paramsMap with
-                            | Some(Route.Int days) -> days
-                            | _ -> 1 // first day of the month is the default
+                    let day =
+                        match Map.tryFind "bd" paramsMap with
+                        | Some(Route.Int days) -> days
+                        | _ -> 1 // first day of the month is the default
 
-                        let weight, height, gaWeeks, gaDays, dep = parsePatientParams paramsMap
+                    let weight, height, gaWeeks, gaDays, dep = parsePatientParams paramsMap
 
-                        let cvl =
-                            match Map.tryFind "cv" paramsMap with
-                            | Some s when s = "y" -> true
-                            | _ -> false
+                    let cvl =
+                        match Map.tryFind "cv" paramsMap with
+                        | Some s when s = "y" -> true
+                        | _ -> false
 
-                        let age = Patient.Age.fromBirthDate DateTime.Now (DateTime(year, month, day))
+                    let age = Patient.Age.fromBirthDate DateTime.Now (DateTime(year, month, day))
 
-                        let patient =
-                            Patient.create
-                                (Some age.Years)
-                                (Some age.Months)
-                                (Some age.Weeks)
-                                (Some age.Days)
-                                weight
-                                height
-                                gaWeeks
-                                gaDays
-                                UnknownGender
-                                [
-                                    if cvl then
-                                        CVL
-                                ]
-                                None
-                                dep
+                    let patient =
+                        Patient.create
+                            (Some age.Years)
+                            (Some age.Months)
+                            (Some age.Weeks)
+                            (Some age.Days)
+                            weight
+                            height
+                            gaWeeks
+                            gaDays
+                            UnknownGender
+                            [
+                                if cvl then
+                                    CVL
+                            ]
+                            None
+                            dep
 
-                        patient
-                    | _, Some(Route.Int days) ->
-                        let weight, height, gaWeeks, gaDays, dep = parsePatientParams paramsMap
+                    patient
+                | _, Some(Route.Int days) ->
+                    let weight, height, gaWeeks, gaDays, dep = parsePatientParams paramsMap
 
-                        let cvl =
-                            match Map.tryFind "cv" paramsMap with
-                            | Some "y" -> [ CVL ]
-                            | _ -> []
+                    let cvl =
+                        match Map.tryFind "cv" paramsMap with
+                        | Some s when s = "y" -> [ CVL ]
+                        | _ -> []
 
-                        let age = Patient.Age.fromDays days
+                    let age = Patient.Age.fromDays days
 
-                        let patient =
-                            Patient.create
-                                (Some age.Years)
-                                (Some age.Months)
-                                (Some age.Weeks)
-                                (Some age.Days)
-                                weight
-                                height
-                                gaWeeks
-                                gaDays
-                                UnknownGender
-                                cvl
-                                None
-                                dep
+                    let patient =
+                        Patient.create
+                            (Some age.Years)
+                            (Some age.Months)
+                            (Some age.Weeks)
+                            (Some age.Days)
+                            weight
+                            height
+                            gaWeeks
+                            gaDays
+                            UnknownGender
+                            cvl
+                            None
+                            dep
 
-                        patient
+                    patient
 
-                    | _ ->
-                        Logging.warning "could not parse url to patient" (urlParts |> String.concat ";")
-                        None
+                | _ ->
+                    Logging.warning "could not parse url to patient" (sl |> String.concat ";")
+                    None
 
-                let page =
-                    match paramsMap |> Map.tryFind "pg" with
-                    | Some s when s = "el" -> Some LifeSupport
-                    | Some s when s = "cm" -> Some ContinuousMeds
-                    | Some s when s = "pr" -> Some Prescribe
-                    | Some s when s = "fm" -> Some Formulary
-                    | Some s when s = "pe" -> Some Parenteralia
-                    | _ -> None
-
-                let lang =
-                    match paramsMap |> Map.tryFind "la" with
-                    | Some s when s = "en" -> Some Localization.English
-                    | Some s when s = "du" -> Some Localization.Dutch
-                    | Some s when s = "fr" -> Some Localization.French
-                    | Some s when s = "gr" -> Some Localization.German
-                    | Some s when s = "sp" -> Some Localization.Spanish
-                    | Some s when s = "it" -> Some Localization.Italian
-                    //                | Some s when s = "ch" -> Some Localization.Chinees // refact: to Chinese
-                    | _ -> None
-
-                let discl =
-                    match paramsMap |> Map.tryFind "dc" with
-                    | Some s when s = "n" -> false
-                    | _ -> true
-
-                let med =
-                    {|
-                        indication = paramsMap |> Map.tryFind "in"
-                        medication = paramsMap |> Map.tryFind "md"
-                        route = paramsMap |> Map.tryFind "rt"
-                        form = paramsMap |> Map.tryFind "fr"
-                        dosetype = paramsMap |> Map.tryFind "dt" |> Option.map DoseType.doseTypeFromString
-                    |}
-                    |> Some
-
-                pat, page, lang, discl, med
-            | _ -> None, None, None, true, None
-
-    // parses the session info from the url. The url can be in one of the following formats:
-    //  | -- "session?launch={token}" -> SessionContext.Launching token
-    //  | -- "session?redeem={token}" -> SessionContext.Redeeming token
-    //  | -- otherwise -> SessionContext.Anonymous
-    let parseSessionInfo (urlParts: string list) =
-        let parts = List.pairwise urlParts
-
-        let sessionPart part =
-            parts
-            |> List.tryFind (fun (a, b) -> a = "session")
-            |> function
-                | Some(_, Route.Query [ queryPart, value ]) when part = queryPart -> Some value
+            let page =
+                match paramsMap |> Map.tryFind "pg" with
+                | Some s when s = "el" -> Some LifeSupport
+                | Some s when s = "cm" -> Some ContinuousMeds
+                | Some s when s = "pr" -> Some Prescribe
+                | Some s when s = "fm" -> Some Formulary
+                | Some s when s = "pe" -> Some Parenteralia
                 | _ -> None
 
-        match sessionPart "launch" with
-        | Some token -> SessionContext.Launching(SessionLaunchToken token)
-        | None ->
-            match sessionPart "redeem" with
-            | Some token -> SessionContext.Redeeming(SessionRedeemToken token)
-            | None -> SessionContext.Anonymous
+            let lang =
+                match paramsMap |> Map.tryFind "la" with
+                | Some s when s = "en" -> Some Localization.English
+                | Some s when s = "du" -> Some Localization.Dutch
+                | Some s when s = "fr" -> Some Localization.French
+                | Some s when s = "gr" -> Some Localization.German
+                | Some s when s = "sp" -> Some Localization.Spanish
+                | Some s when s = "it" -> Some Localization.Italian
+                //                | Some s when s = "ch" -> Some Localization.Chinees // refact: to Chinese
+                | _ -> None
+
+            let discl =
+                match paramsMap |> Map.tryFind "dc" with
+                | Some s when s = "n" -> false
+                | _ -> true
+
+            let med =
+                {|
+                    indication = paramsMap |> Map.tryFind "in"
+                    medication = paramsMap |> Map.tryFind "md"
+                    route = paramsMap |> Map.tryFind "rt"
+                    form = paramsMap |> Map.tryFind "fr"
+                    dosetype = paramsMap |> Map.tryFind "dt" |> Option.map DoseType.doseTypeFromString
+                |}
+                |> Some
+
+            pat, page, lang, discl, med
+
+        | _ ->
+            sl |> String.concat "" |> Logging.warning "could not parse url"
+
+            None, None, None, true, None
+
 
     let initialState
         pat
@@ -396,10 +369,9 @@ module private Elmish =
                 form: string option
                 dosetype: DoseType option
             |} option)
-        sessionContext
         =
         {
-            ShowDisclaimer = discl && sessionContext = SessionContext.Anonymous
+            ShowDisclaimer = discl
             Page = page |> Option.defaultValue LifeSupport
             Patient = pat
             NormalValues = HasNotStartedYet
@@ -442,14 +414,11 @@ module private Elmish =
             AuthToken = ""
             LogFiles = HasNotStartedYet
             LogAnalysisReport = HasNotStartedYet
-            SessionContext = sessionContext
         }
 
 
     let init () : State * Cmd<Msg> =
-        let currentUrl = Router.currentUrl ()
-        let pat, page, lang, discl, med = parsePatient currentUrl
-        let sessionInfo = parseSessionInfo currentUrl
+        let pat, page, lang, discl, med = Router.currentUrl () |> parseUrl
 
         let cmds =
             Cmd.batch
@@ -463,13 +432,9 @@ module private Elmish =
                     Cmd.ofMsg (LoadFormulary Started)
                     Cmd.ofMsg (LoadParenteralia Started)
                     Cmd.ofMsg (LoadInteractionDrugNames Started)
-                    match sessionInfo with
-                    | SessionContext.Launching token -> Cmd.ofMsg (SessionContextMsg(SessionContextMsg.Launch token))
-                    | SessionContext.Redeeming token -> Cmd.ofMsg (SessionContextMsg(SessionContextMsg.Redeem token))
-                    | _ -> Cmd.none
                 ]
 
-        initialState pat page lang discl med sessionInfo, cmds
+        initialState pat page lang discl med, cmds
 
 
     let applyNormalValues (normalValues: Deferred<NormalValues>) (pat: Patient option) =
@@ -727,12 +692,11 @@ module private Elmish =
                     Cmd.ofMsg (LoadParenteralia Started)
                 ]
 
-        | UrlChanged newUrl ->
-            let pat, page, lang, discl, med = parsePatient newUrl
-            let sessionInfo = parseSessionInfo newUrl
+        | UrlChanged sl ->
+            let pat, page, lang, discl, med = sl |> parseUrl
 
             { state with
-                ShowDisclaimer = discl && sessionInfo = SessionContext.Anonymous
+                ShowDisclaimer = discl
                 Page = page |> Option.defaultValue LifeSupport
                 Patient = pat
                 OrderContext =
@@ -753,14 +717,7 @@ module private Elmish =
                 // State. prefix needed: disambiguates State.Context field from Global.Context type
                 State.Context.Localization = lang |> Option.defaultValue Localization.English
             },
-            Cmd.batch
-                [
-                    Cmd.ofMsg (UpdatePatient pat)
-                    match sessionInfo with
-                    | SessionContext.Launching token -> Cmd.ofMsg (SessionContextMsg(SessionContextMsg.Launch token))
-                    | SessionContext.Redeeming token -> Cmd.ofMsg (SessionContextMsg(SessionContextMsg.Redeem token))
-                    | _ -> Cmd.none
-                ]
+            Cmd.ofMsg (pat |> UpdatePatient)
 
         | LoadLocalization Started ->
             { state with Localization = InProgress }, Cmd.fromAsync (GoogleDocs.loadLocalization LoadLocalization)
@@ -1129,64 +1086,6 @@ module private Elmish =
                 }
                 |> Cmd.fromAsync
 
-        | SessionContextMsg(SessionContextMsg.Launch token) ->
-            // launch token received, set session context to being launched
-            let state = { state with SessionContext = SessionContext.Content InProgress }
-
-            let launch =
-                async {
-                    try
-                        do! Async.Sleep 3000 // simulate some delay for the launch
-
-                        match! serverApi.launchSession token with
-                        // a launched session still has to be handed over to its redeem url
-                        | Ok redeemToken -> return SessionContextMsg(SessionContextMsg.Launched redeemToken)
-                        | Error err -> return SessionContextMsg(SessionContextMsg.Error err)
-                    with ex ->
-                        return SessionContextMsg(SessionContextMsg.Error ex.Message)
-                }
-
-            state, Cmd.fromAsync launch
-
-        | SessionContextMsg(SessionContextMsg.Launched(SessionRedeemToken token)) ->
-            state, Cmd.navigate ("session", [ "redeem", token ])
-
-        | SessionContextMsg(SessionContextMsg.Redeem token) ->
-            // session is being redeemed
-            let state = { state with SessionContext = SessionContext.Content InProgress }
-
-            let redeem =
-                async {
-                    try
-                        do! Async.Sleep 2000
-
-                        match! serverApi.redeemSession token with
-                        | Ok session -> return SessionContextMsg(SessionContextMsg.Redeemed session)
-                        | Error err -> return SessionContextMsg(SessionContextMsg.Error err)
-                    with ex ->
-                        return SessionContextMsg(SessionContextMsg.Error ex.Message)
-                }
-
-            state, Cmd.fromAsync redeem
-
-        | SessionContextMsg(SessionContextMsg.Error err) ->
-            // launch token received, but error occurred, set session context to Anonymous
-            Logging.error "launch token error" err
-            let state = { state with SessionContext = SessionContext.Error err }
-            state, Cmd.none
-
-        | SessionContextMsg(SessionContextMsg.Redeemed content) ->
-            // the url already carries the redeem token (see Launched), so a redeemed session
-            // must not navigate again, or it would re-enter Redeem indefinitely.
-            // update the state with the redeemed session content and patient data
-            let state =
-                { state with
-                    SessionContext = SessionContext.Content(Resolved content)
-                    Patient = Some content.Patient
-                }
-
-            state, Cmd.none
-
 
     let calculateInterventions calc meds pat =
         meds
@@ -1387,7 +1286,6 @@ let View () =
             acceptDisclaimer = fun _ -> AcceptDisclaimer |> dispatch
             updatePage = UpdatePage >> dispatch
             page = state.Page
-            session = state.SessionContext
             languages = Localization.languages
             hospitals = state.Hospitals
             switchLang = UpdateLanguage >> dispatch

--- a/src/Informedica.GenPRES.Client/Components/TitleBar.fs
+++ b/src/Informedica.GenPRES.Client/Components/TitleBar.fs
@@ -20,7 +20,6 @@ module TitleBar =
                 switchLang: Shared.Localization.Locales -> unit
                 switchHosp: string -> unit
                 isAuthenticated: bool
-                session: Global.SessionContext
                 onLogin: string -> unit
                 onLogout: unit -> unit
             |})
@@ -156,40 +155,6 @@ module TitleBar =
                 horizontal = "right"
             |}
 
-        let sessionInfo =
-            match props.session with
-            | Global.SessionContext.Anonymous ->
-                JSX.jsx
-                    $"""
-                <Box sx={ {| marginLeft = 2 |} }>
-                    <Typography variant="body1" component="div">
-                        {"Anonymous"}
-                    </Typography>
-                </Box>
-                """
-            | Global.SessionContext.Content deferredContent ->
-                match deferredContent with
-                | Deferred.InProgress ->
-                    JSX.jsx
-                        $"""
-                    <Box sx={ {| marginLeft = 2 |} }>
-                        <Typography variant="body1" component="div">
-                            {"Loading..."}
-                        </Typography>
-                    </Box>
-                    """
-                | Deferred.Resolved content ->
-                    JSX.jsx
-                        $"""
-                    <Box sx={ {| marginLeft = 2 |} }>
-                        <Typography variant="body1" component="div">
-                            {content.UserName}
-                        </Typography>
-                    </Box>
-                    """
-                | _ -> null
-            | _ -> null
-
         JSX.jsx
             $"""
         import AppBar from '@mui/material/AppBar';
@@ -244,7 +209,6 @@ module TitleBar =
                     <Typography variant="body1" component="div" >
                         {$"{context.Hospital}"}
                     </Typography>
-                    {sessionInfo}
 
                     <Box sx={sxLangBox}>
                         <IconButton color="inherit" onClick={handleOpenLangMenu}>

--- a/src/Informedica.GenPRES.Client/Global.fs
+++ b/src/Informedica.GenPRES.Client/Global.fs
@@ -2,7 +2,7 @@ module Global
 
 open Feliz
 open Shared
-open Shared.Types
+
 
 type Pages =
     | LifeSupport
@@ -15,13 +15,6 @@ type Pages =
     | Interactions
     | Settings
 
-[<RequireQualifiedAccess>]
-type SessionContext =
-    | Anonymous
-    | Launching of SessionLaunchToken
-    | Redeeming of SessionRedeemToken
-    | Error of string
-    | Content of Deferred<SessionContent>
 
 let getLocalizedTerm (localizationTerms: Deferred<string[][]>) (lang: Localization.Locales) defVal term =
     localizationTerms

--- a/src/Informedica.GenPRES.Client/Pages/GenPres.fs
+++ b/src/Informedica.GenPRES.Client/Pages/GenPres.fs
@@ -113,7 +113,6 @@ module GenPres =
                 acceptDisclaimer: bool -> unit
                 updatePage: Global.Pages -> unit
                 page: Global.Pages
-                session: Global.SessionContext
                 languages: Localization.Locales[]
                 hospitals: Deferred<string[]>
                 switchLang: Localization.Locales -> unit
@@ -215,7 +214,6 @@ module GenPres =
                     hospitals = props.hospitals
                     switchLang = props.switchLang
                     switchHosp = props.switchHosp
-                    session = props.session
                     isAuthenticated = auth.IsAuthenticated
                     onLogin = auth.Login
                     onLogout = auth.Logout

--- a/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
@@ -134,17 +134,6 @@ module Adapters =
                     NutritionPlanService.navigateNutritionOrderContext totals orderCtxPort (plan, label, ctxCmd, ctx)
         }
 
-    let private makePatientPort (provider: Resources.IResourceProvider) : PatientPort =
-        {
-            loadPatientData =
-                fun (PatientId patientId) ->
-                    async {
-                        if patientId = "test-patient-id" then
-                            return Ok Shared.Types.Patient.Empty
-                        else
-                            return Error "TOOD: Not implemented yet"
-                    }
-        }
 
     let makeAppEnv (provider: Resources.IResourceProvider) : AppEnv =
         let agent, logger = resolveLogger ()
@@ -152,7 +141,6 @@ module Adapters =
 
         {
             formulary = makeFormularyPort provider
-            patient = makePatientPort provider
             orderContext = orderCtxPort
             orderPlan = makeOrderPlanPort agent provider orderCtxPort
             nutritionPlan = makeNutritionPlanPort orderCtxPort logger provider

--- a/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
@@ -5,54 +5,12 @@ module CompositionRoot =
 
     open Informedica.Utils.Lib.ConsoleWriter.NewLineNoTime
     open Shared.Api
-    open Shared.Types
-
-    let launchSession (env: AppEnv) (token: SessionLaunchToken) : Async<Result<SessionRedeemToken, string>> =
-        // TODO: implement proper session launch logic,
-        // which checks the validity of the token and returns a redeem token if valid, or an error if invalid.
-        let (SessionLaunchToken token) = token
-        async { return Ok(SessionRedeemToken "test-redeem-token") }
-
-    let redeemSession (env: AppEnv) (token: SessionRedeemToken) : Async<Result<SessionContent, string>> =
-        async {
-            let (SessionRedeemToken token) = token
-
-            if token = "demo-error" then
-                return Error "error: invalid launch token"
-            else
-                try
-                    let patientId = "test-patient-id"
-
-                    match! env.patient.loadPatientData (PatientId patientId) with
-                    | Error error ->
-                        let errorMessage =
-                            $"Error loading patient data for patientId: {patientId}. Error: {error}"
-
-                        return Error errorMessage
-                    | Ok patient ->
-                        let testSessionContent =
-                            {
-                                RedeemToken = "test-redeem-token"
-                                UserName = "John Doe"
-                                UserEmail = "john@doe.com"
-                                PatientId = "test-patient-id"
-                                SessionId = "test-session-id"
-                                Patient = patient
-                            }
-
-                        return Ok testSessionContent
-                with ex ->
-                    writeErrorMessage $"Error launching session with token: {token}\n{ex}"
-                    return Error ex.Message
-        }
 
 
     let compose (provider: Informedica.GenForm.Lib.Resources.IResourceProvider) : IServerApi =
         let env = Adapters.makeAppEnv provider
 
         {
-            launchSession = launchSession env
-            redeemSession = redeemSession env
             processCommand =
                 fun cmd ->
                     async {

--- a/src/Informedica.GenPRES.Server/ServerApi.Ports.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Ports.fs
@@ -46,10 +46,6 @@ type LogAnalyzerPort =
         analyzeLogFile: string -> Async<Result<string, string[]>>
     }
 
-type PatientId = PatientId of string
-
-type PatientPort = { loadPatientData: PatientId -> Async<Result<Patient, string>> }
-
 
 type AppEnv =
     {
@@ -60,5 +56,4 @@ type AppEnv =
         interaction: InteractionPort
         logAnalyzer: LogAnalyzerPort
         requireLoaded: unit -> string[] option
-        patient: PatientPort
     }

--- a/src/Informedica.GenPRES.Shared/Api.fs
+++ b/src/Informedica.GenPRES.Shared/Api.fs
@@ -156,12 +156,11 @@ module Api =
     /// Defines how routes are generated on server and mapped from the client
     let routerPaths typeName method = $"/api/%s{typeName}/%s{method}"
 
+
     /// A type that specifies the communication protocol between client and server
     /// to learn more read the docs at https://zaid-ajaj.github.io/Fable.Remoting/src/basics.html
     type IServerApi =
         {
             processCommand: Command -> Async<Result<Response, string[]>>
             testApi: unit -> Async<string>
-            launchSession: SessionLaunchToken -> Async<Result<SessionRedeemToken, string>>
-            redeemSession: SessionRedeemToken -> Async<Result<SessionContent, string>>
         }

--- a/src/Informedica.GenPRES.Shared/Types.fs
+++ b/src/Informedica.GenPRES.Shared/Types.fs
@@ -103,31 +103,6 @@ module Types =
             Department: string option
         }
 
-        static member Empty =
-            {
-                Age = None
-                GestationalAge = None
-                Weight =
-                    {
-                        EstimatedP3 = None
-                        Estimated = None
-                        EstimatedP97 = None
-                        Measured = None
-                    }
-                Height =
-                    {
-                        EstimatedP3 = None
-                        Estimated = None
-                        EstimatedP97 = None
-                        Measured = None
-                    }
-                Gender = UnknownGender
-                Access = []
-                RenalFunction = None
-                Location = None
-                Department = None
-            }
-
     /// Weight in gram!!
     and Weight =
         {
@@ -598,23 +573,4 @@ module Types =
             FileName: string
             SizeBytes: int64
             LastModifiedAt: string
-        }
-
-    /// The token used to launch a session in GenPRES,
-    /// which is typically provided by the hospital's authentication system.
-    /// The token is used to verify the user's identity and permissions before allowing access to the GenPRES system.
-    /// It can be used to acquire a redeem token, which is then used to
-    /// redeem the session and obtain the session content, including patient data.
-    type SessionLaunchToken = SessionLaunchToken of string
-
-    type SessionRedeemToken = SessionRedeemToken of string
-
-    type SessionContent =
-        {
-            RedeemToken: string
-            UserName: string
-            UserEmail: string
-            PatientId: string
-            Patient: Patient
-            SessionId: string
         }

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -55,8 +55,6 @@ module StubAdapters =
             navigateNutritionOrderContext = fun _ -> async { return Ok returnPlan }
         }
 
-    let patientAlwaysOk (returnPatient: Patient) : PatientPort =
-        { loadPatientData = fun _ -> async { return Ok returnPatient } }
 
     let makeEnv
         (formulary: FormularyPort)
@@ -67,7 +65,6 @@ module StubAdapters =
         =
         {
             formulary = formulary
-            patient = patientAlwaysOk Patient.Empty
             orderContext = orderContext
             orderPlan = orderPlan
             nutritionPlan = nutritionPlan
@@ -85,13 +82,9 @@ module StubAdapters =
         }
 
 
-    let patientAlwaysFails (msg: string) : PatientPort =
-        { loadPatientData = fun _ -> async { return Error msg } }
-
     let makeEnvNotLoaded (msgs: string[]) : AppEnv =
         {
             formulary = formularyAlwaysFails [| "not loaded" |]
-            patient = patientAlwaysFails "not loaded"
             orderContext = orderContextAlwaysFails [| "not loaded" |]
             orderPlan =
                 {


### PR DESCRIPTION
## Overview

Step 1 of [plan 409](https://github.com/informedica/GenPRES/blob/master/docs/implementation-plans/409-client-launch-sequence.md): corrects the merged #574 down to the router fix and URL hygiene. Three commits, each reviewable alone:

1. **revert(api)** — Shared, Server and tests back to their pre-#574 state (`44eb0182`): the `SessionLaunchToken`/`SessionRedeemToken`/`SessionContent` types, `Patient.Empty`, `launchSession`/`redeemSession`, `PatientPort` and the test stubs go. The redeem hop has no counterpart in [uc-01](https://github.com/informedica/GenPRES/blob/master/docs/scenarios/integration/uc-01-launch.md) and puts a second secret in the URL. The contract comes back as `presentLaunch`/`getSession`/`closeSession` plus a session cookie, drafted in a script, in the next PRs.
2. **refactor(client)** — `SessionContext` state, the launch/redeem message handlers with their `Async.Sleep` delays, the redeem navigation and the `session` prop through `GenPres`/`TitleBar` go. Kept from #574: the `FelizRouter` latest-callback fix and the `calculateInterventions` rename.
3. **feat(client)** — launch sequence step 2: `#/session?launch={token}` becomes `#/session` via `history.replaceState` in `init` and on an in-app `UrlChanged`, before any server call. `parseUrl` → `parsePatient` (strict `[ "patient"; Query ]` shape, a `session` URL yields the defaults silently) plus `parseLaunch`. Both "could not parse url" warnings stop logging the raw URL (parameter names / route segment only).

No session state yet: a launch URL simply becomes `#/session` and the app runs anonymously.

## Further information

Review remarks on #574 and where they land:

| Remark | Here |
|---|---|
| unused `b` in `fun (a, b)` (7sharp9) | gone with the `List.pairwise` parser |
| `SessionContext` does two jobs (7sharp9) | type removed; plan 409 splits it into `Session` state and `LaunchOutcome` payload |
| anonymous route keeps showing the user (halcwb, greptile) | no session context left; PR for step 3 encodes `Closed`/`OpenAnonymous → Anonymous` in `Session.transition` |
| stale requests win, stale results beside a redeemed patient (greptile) | redeem flow removed; step 3's `transition` guards `Outcome` by Launch + public key and sets the patient via `UpdatePatient` |
| tokens unvalidated (greptile) | endpoints removed; the stub returns behind `presentLaunch` in step 2 and is gated on #580 |
| `UrlChanged` wipes the redeemed patient (7sharp9) | moot until step 3, where the session supplies the patient |

Follow-up PRs, each under ~150 lines: 2a shared contract + `SessionPort` + in-memory stub + tests (script), 2b `Remoting.fromContext` + cookie, 3a `Session.fs` state machine + tests, 3b `Keys.fs`, 3c `App.fs` wiring, 4a title bar, 4b `SessionGate` modal, 5 docs.

## Divergence from plan

`parsePatient` keeps master's strict `[ "patient"; Route.Query ]` shape instead of #574's `List.pairwise` search. Same behaviour for every URL the app produces, no re-indented 120-line hunk, and it is what makes a session URL ignore patient parameters for free. The plan's "roadmap 2.1.2" file does not exist in this repo; the docs step will correct the reference.

## Verification

- `dotnet run Build` green; `dotnet fantomas --check` clean on the client; Fable output inspected (`Elmish_parseLaunch`, `Elmish_eraseLaunch` → `history.replaceState(null, "", "#/session")`).
- `dotnet run`, then in Chrome:
  - `http://localhost:5173/#/session?launch=demo` → address bar reads `#/session` on load, `history.length` unchanged (no extra entry, back leaves the site), no `warn`/`error` in the console, app anonymous.
  - `location.hash = '#/session?launch=inapp'` in the running app → erased to `#/session` (the `UrlChanged` path).
  - `#/patient?by=2020&wt=12000&dc=n` → patient 6 y 8 m, 12 kg loaded as before.
- Server tests unaffected: Shared/Server/tests are byte-identical to `44eb0182`.

Reviewer: `dotnet run`, open the three URLs above.

## Author checklist

I confirm that these changes:

- [x] Follow the process described in [CONTRIBUTING.md](../../CONTRIBUTING.md#pull-request-process).
- [x] Make the changes proposed in the linked issue (if applicable): #409
- [x] Follow the approach documented in the linked implementation plan (if applicable): `docs/implementation-plans/409-client-launch-sequence.md`, step 1
- [x] Are no more than 200 lines of changed code, ideally 25-100. (161 insertions, mostly the revert; the client-side addition is ~40 lines.)
- [x] Are not more complex than necessary.
- [x] Cannot easily be split in a way that would make reviewing them significantly easier. (Three commits, reviewable one at a time.)
- [x] Follow the guidelines specified in [DEVELOPMENT.md](../../DEVELOPMENT.md).
- [x] Have been thoroughly tested.
- [x] Don't introduce new security vulnerabilities.
- [x] Follow the [AI/LLM Usage Policy](../../AGENTS.md#aillm-usage-policy) — LLMs were not given direct write access to `.fs` source files (except client-side UI code).

### AI/Vibe Coding Disclosure

- [x] Some or all code in this PR is **vibe coded** (substantially AI-generated). If checked, describe below which parts were AI-generated, which tool was used, and how the code was verified.

Commit 3 (`parsePatient`/`parseLaunch`/`eraseLaunch` and the `init`/`UrlChanged` guards, ~40 lines in `App.fs`) was written by Claude Code (Claude Fable 5.1) following plan 409; commits 1 and 2 are `git checkout` reverts to `44eb0182`. Verified by build, Fantomas, Fable output inspection and the manual browser checks above. Non-UI files were only reverted, never edited.

I confirm that I have:

- [ ] Added appropriate automated tests. (None: client-only URL handling; the client has no test project. Step 3a adds tests for the session state machine.)
- [x] Updated documentation appropriately. (Comments in `App.fs`; plan 409 already describes this step.)
- [x] Added comments that highlight important changes and add justification, where necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NnCcKoWNhFZMh1PLqXPU8j
