### PR TITLE
feat(client): wire the launch session into the app

### DIFF
--- a/src/Informedica.GenPRES.Client/App.fs
+++ b/src/Informedica.GenPRES.Client/App.fs
@@ -560,8 +560,8 @@ module private Elmish =
 
 
     /// One command per session effect (plan 409, "Wiring in App.fs"). A transport failure
-    /// is an Error outcome, never an exception; Closed is dispatched whether or not the close
-    /// call succeeded, because the server deletes the cookie either way.
+    /// is a message, never an exception: an Error outcome for a presentation, CloseFailed for
+    /// a close that did not reach the server.
     let interpretSessionEffect (effect: SessionEffect) : Cmd<Msg> =
         match effect with
         | SessionEffect.CallPresentLaunch(launch, key) ->
@@ -585,11 +585,11 @@ module private Elmish =
             |> Cmd.fromAsync
         | SessionEffect.CallCloseSession ->
             async {
+                // the server deletes the cookie whatever its close returns (finally), so an
+                // answer of any kind means Closed; only a request that never got there fails
                 match! serverApi.processSession Api.SessionCommand.CloseSession |> Async.Catch with
-                | Choice1Of2 _ -> ()
-                | Choice2Of2 ex -> Logging.error "could not close the session on the server" ex.Message
-
-                return SessionMsg SessionMsg.Closed
+                | Choice1Of2 _ -> return SessionMsg SessionMsg.Closed
+                | Choice2Of2 ex -> return SessionMsg(SessionMsg.CloseFailed ex.Message)
             }
             |> Cmd.fromAsync
         | SessionEffect.GoTo url -> Cmd.ofEffect (fun _ -> Browser.Dom.window.location.assign url)
@@ -876,6 +876,18 @@ module private Elmish =
 
         | SessionMsg msg ->
             let session, effects = Session.transition msg state.Session
+
+            let state =
+                match msg with
+                | SessionMsg.CloseFailed reason ->
+                    Logging.error "could not close the session on the server" reason
+
+                    { state with
+                        SnackbarMsg = "De sessie kon niet worden gesloten. Probeer het opnieuw."
+                        SnackbarOpen = true
+                        SnackbarSeverity = "error"
+                    }
+                | _ -> state
 
             { state with Session = session }, effects |> List.map interpretSessionEffect |> Cmd.batch
 

--- a/src/Informedica.GenPRES.Client/App.fs
+++ b/src/Informedica.GenPRES.Client/App.fs
@@ -12,6 +12,7 @@ open Shared
 open Shared.Types
 open Shared.Models
 open Global
+open SessionMachine
 
 
 module private Elmish =
@@ -49,12 +50,15 @@ module private Elmish =
             AuthToken: string
             LogFiles: Deferred<LogFileInfo[]>
             LogAnalysisReport: Deferred<string>
+            // the launch Session (plan 409); Anonymous is the state every URL patient runs in
+            Session: Session
         }
 
 
     type Msg =
         | UrlChanged of string list
         | AcceptDisclaimer
+        | SessionMsg of SessionMsg
 
         | UpdatePage of Global.Pages
         | UpdatePatient of Patient option
@@ -363,11 +367,37 @@ module private Elmish =
             None, None, None, true, None
 
 
-    /// The launch token of a "#/session?launch={token}" url, the form MainEHR
-    /// opens GenPRES with (launch sequence step 1). Opaque to the client.
+    /// What a "#/session?..." url carries: the Launch MainEHR opened GenPRES with (launch
+    /// sequence step 1), or the reason the IdentityProvider return refused it (step 4.5).
+    [<RequireQualifiedAccess>]
+    type LaunchUrl =
+        | Launch of Launch
+        | Refused of LaunchRefusal
+
+
+    /// The fixed vocabulary of "#/session?refused={reason}"; an unknown reason is invalid.
+    let parseRefusal reason =
+        match reason with
+        | "expired" -> LaunchRefusal.LaunchExpired
+        | "spent" -> LaunchRefusal.LaunchSpent
+        | "no-identity" -> LaunchRefusal.NoBrowserIdentity
+        | "no-role" -> LaunchRefusal.NoRole
+        | "wrong-patient" -> LaunchRefusal.WrongActivePatient
+        | "enrolment" -> LaunchRefusal.EnrolmentRequired
+        | _ -> LaunchRefusal.LaunchInvalid
+
+
+    /// The launch token of a "#/session?launch={token}" url, opaque to the client, or the
+    /// refusal of a "#/session?refused={reason}" url. Both are erased the same way.
     let parseLaunch sl =
         match sl with
-        | [ "session"; Route.Query queryParams ] -> queryParams |> Map.ofList |> Map.tryFind "launch"
+        | [ "session"; Route.Query queryParams ] ->
+            let query = queryParams |> Map.ofList
+
+            match query |> Map.tryFind "launch", query |> Map.tryFind "refused" with
+            | Some token, _ -> Some(LaunchUrl.Launch(Launch token))
+            | None, Some reason -> Some(LaunchUrl.Refused(parseRefusal reason))
+            | None, None -> None
         | _ -> None
 
 
@@ -438,13 +468,37 @@ module private Elmish =
             AuthToken = ""
             LogFiles = HasNotStartedYet
             LogAnalysisReport = HasNotStartedYet
+            Session = Session.Anonymous
         }
+
+
+    /// Launch step 3 then 4: make the key pair, then present the Launch with its public key.
+    /// A browser that cannot make a key cannot launch; that is reported as a missing browser
+    /// identity, the refusal whose text asks for a retry and then a relaunch.
+    let presentLaunch (launch: Launch) : Cmd<Msg> =
+        async {
+            match! Keys.generate () |> Async.Catch with
+            | Choice1Of2 key -> return SessionMsg(SessionMsg.Present(launch, key))
+            | Choice2Of2 ex ->
+                Logging.error "could not make the browser key pair" ex.Message
+                return SessionMsg(SessionMsg.RefusedAtCallback LaunchRefusal.NoBrowserIdentity)
+        }
+        |> Cmd.fromAsync
+
+
+    /// The session command a "#/session?..." url asks for; a plain url asks for nothing.
+    let launchCmd (launchUrl: LaunchUrl option) : Cmd<Msg> =
+        match launchUrl with
+        | Some(LaunchUrl.Launch launch) -> presentLaunch launch
+        | Some(LaunchUrl.Refused refusal) -> Cmd.ofMsg (SessionMsg(SessionMsg.RefusedAtCallback refusal))
+        | None -> Cmd.none
 
 
     let init () : State * Cmd<Msg> =
         let url = Router.currentUrl ()
+        let launchUrl = url |> parseLaunch
 
-        if url |> parseLaunch |> Option.isSome then
+        if launchUrl.IsSome then
             eraseLaunch ()
 
         let pat, page, lang, discl, med = url |> parsePatient
@@ -452,6 +506,10 @@ module private Elmish =
         let cmds =
             Cmd.batch
                 [
+                    // a page load without a Launch resumes on the cookie (reload, IdP return)
+                    match launchUrl with
+                    | None -> Cmd.ofMsg (SessionMsg SessionMsg.Resume)
+                    | Some _ -> launchCmd launchUrl
                     checkServer
                     Cmd.ofMsg (LoadNormalValues Started)
                     Cmd.ofMsg (LoadBolusMedication Started)
@@ -499,6 +557,52 @@ module private Elmish =
                         Cmd.ofMsg (LoadParenteralia Started)
                     ]
             | _ -> base', Cmd.ofMsg (LoadOrderContextResult(cmd, Started))
+
+
+    /// One command per session effect (plan 409, "Wiring in App.fs"). A transport failure
+    /// is an Error outcome, never an exception; Closed is dispatched whether or not the close
+    /// call succeeded, because the server deletes the cookie either way.
+    let interpretSessionEffect (effect: SessionEffect) : Cmd<Msg> =
+        match effect with
+        | SessionEffect.CallPresentLaunch(launch, key) ->
+            async {
+                try
+                    let! outcome = serverApi.processLaunch (Api.LaunchCommand.PresentLaunch(launch, key))
+                    return SessionMsg(SessionMsg.Outcome(launch, key, Ok outcome))
+                with ex ->
+                    return SessionMsg(SessionMsg.Outcome(launch, key, Error ex.Message))
+            }
+            |> Cmd.fromAsync
+        | SessionEffect.CallGetSession ->
+            async {
+                try
+                    match! serverApi.processSession Api.SessionCommand.GetSession with
+                    | Api.SessionResponse.SessionResp session -> return SessionMsg(SessionMsg.Resumed(Ok session))
+                    | Api.SessionResponse.SessionClosed -> return SessionMsg(SessionMsg.Resumed(Ok None))
+                with ex ->
+                    return SessionMsg(SessionMsg.Resumed(Error ex.Message))
+            }
+            |> Cmd.fromAsync
+        | SessionEffect.CallCloseSession ->
+            async {
+                match! serverApi.processSession Api.SessionCommand.CloseSession |> Async.Catch with
+                | Choice1Of2 _ -> ()
+                | Choice2Of2 ex -> Logging.error "could not close the session on the server" ex.Message
+
+                return SessionMsg SessionMsg.Closed
+            }
+            |> Cmd.fromAsync
+        | SessionEffect.GoTo url -> Cmd.ofEffect (fun _ -> Browser.Dom.window.location.assign url)
+        | SessionEffect.SetPatient patient -> Cmd.ofMsg (UpdatePatient patient)
+        | SessionEffect.KeepKey thumbprint ->
+            Cmd.ofEffect (fun _ ->
+                async {
+                    match! Keys.keep thumbprint |> Async.Catch with
+                    | Choice1Of2() -> ()
+                    | Choice2Of2 ex -> Logging.error "could not prune the browser keys" ex.Message
+                }
+                |> Async.StartImmediate
+            )
 
 
     let update (msg: Msg) (state: State) =
@@ -722,10 +826,24 @@ module private Elmish =
                 ]
 
         | UrlChanged sl ->
-            if sl |> parseLaunch |> Option.isSome then
+            let launchUrl = sl |> parseLaunch
+
+            if launchUrl.IsSome then
                 eraseLaunch ()
 
             let pat, page, lang, discl, med = sl |> parsePatient
+
+            // an open Session supplies the patient: url patient parameters count only while
+            // no Session holds one (plan 409, "Patient is never assigned directly"). The
+            // router fires UrlChanged on mount too, while a Resume may still be in flight,
+            // so only Open and Closing block the url patient
+            let anonymous =
+                match state.Session with
+                | Session.Open _
+                | Session.Closing _ -> false
+                | _ -> true
+
+            let pat = if anonymous then pat else state.Patient
 
             { state with
                 ShowDisclaimer = discl
@@ -749,7 +867,17 @@ module private Elmish =
                 // State. prefix needed: disambiguates State.Context field from Global.Context type
                 State.Context.Localization = lang |> Option.defaultValue Localization.English
             },
-            Cmd.ofMsg (pat |> UpdatePatient)
+            Cmd.batch
+                [
+                    if anonymous then
+                        Cmd.ofMsg (pat |> UpdatePatient)
+                    launchCmd launchUrl
+                ]
+
+        | SessionMsg msg ->
+            let session, effects = Session.transition msg state.Session
+
+            { state with Session = session }, effects |> List.map interpretSessionEffect |> Cmd.batch
 
         | LoadLocalization Started ->
             { state with Localization = InProgress }, Cmd.fromAsync (GoogleDocs.loadLocalization LoadLocalization)
@@ -1173,6 +1301,14 @@ type private ConcreteAppEnv
         member _.ReloadResources pw =
             OrderContextMsg(Api.ReloadResources pw, OrderContext.empty) |> dispatch
 
+    interface AppEnv.ISession with
+        member _.Session = state.Session
+        member _.Close() = SessionMsg SessionMsg.Close |> dispatch
+        member _.Retry() = SessionMsg SessionMsg.Retry |> dispatch
+
+        member _.OpenAnonymously() =
+            SessionMsg SessionMsg.OpenAnonymous |> dispatch
+
     interface AppEnv.IAuthentication with
         member _.IsAuthenticated = state.IsAuthenticated
         member _.Login password = Login password |> dispatch
@@ -1313,7 +1449,15 @@ let View () =
     let genPresProps =
         {|
             appEnv = appEnv
-            showDisclaimer = state.ShowDisclaimer
+            // the disclaimer is for anonymous use only (plan 409): a launched, resuming or
+            // refused session never sees it; an anonymous open after a refusal does
+            showDisclaimer =
+                state.ShowDisclaimer
+                && (
+                    match state.Session with
+                    | Session.Anonymous -> true
+                    | _ -> false
+                )
             isDemo = state.IsDemo
             acceptDisclaimer = fun _ -> AcceptDisclaimer |> dispatch
             updatePage = UpdatePage >> dispatch

--- a/src/Informedica.GenPRES.Client/App.fs
+++ b/src/Informedica.GenPRES.Client/App.fs
@@ -877,9 +877,12 @@ module private Elmish =
         | SessionMsg msg ->
             let session, effects = Session.transition msg state.Session
 
+            // a failed close is reported only when it was this session's close: a CloseFailed
+            // that arrives after a newer launch superseded the Closing session is dropped by
+            // the machine and must not put an error over the newer session
             let state =
-                match msg with
-                | SessionMsg.CloseFailed reason ->
+                match msg, state.Session with
+                | SessionMsg.CloseFailed reason, Session.Closing _ ->
                     Logging.error "could not close the session on the server" reason
 
                     { state with

--- a/src/Informedica.GenPRES.Client/AppEnv.fs
+++ b/src/Informedica.GenPRES.Client/AppEnv.fs
@@ -70,6 +70,18 @@ type IResources =
     abstract ReloadResources: string -> unit
 
 
+/// The launch Session (plan 409): its phase, and the actions the UI offers on it
+[<Interface>]
+type ISession =
+    abstract Session: SessionMachine.Session
+    // Rule 10: explicit close, from an open Session
+    abstract Close: unit -> unit
+    // from Unreachable, or a refusal worth retrying
+    abstract Retry: unit -> unit
+    // ext 5a: a fresh anonymous open that carries nothing over
+    abstract OpenAnonymously: unit -> unit
+
+
 /// Authentication state and commands
 [<Interface>]
 type IAuthentication =

--- a/src/Informedica.GenPRES.Client/SessionMachine.fs
+++ b/src/Informedica.GenPRES.Client/SessionMachine.fs
@@ -48,6 +48,8 @@ type SessionMsg =
     | OpenAnonymous
     | Close
     | Closed
+    // the close request did not reach the server: the cookie is still there, so is the Session
+    | CloseFailed of reason: string
 
 
 [<RequireQualifiedAccess>]
@@ -149,3 +151,8 @@ module Session =
         // superseded it must not touch the newer session (the same guard as Outcome)
         | SessionMsg.Closed, Session.Closing _ -> Session.Anonymous, [ SessionEffect.SetPatient None ]
         | SessionMsg.Closed, _ -> state, []
+
+        // a close that never reached the server has closed nothing: the Session stays open,
+        // with its patient, and the UI says so; the same guard as Closed
+        | SessionMsg.CloseFailed _, Session.Closing session -> Session.Open session, []
+        | SessionMsg.CloseFailed _, _ -> state, []

--- a/tests/Informedica.GenPRES.Shared.Tests/SessionMachineTests.fs
+++ b/tests/Informedica.GenPRES.Shared.Tests/SessionMachineTests.fs
@@ -375,6 +375,23 @@ module SessionMachineTests =
                     |> Expect.equal "anonymous" (Session.Anonymous, [ SessionEffect.SetPatient None ])
                 }
 
+                test "CloseFailed from Closing returns to Open with the same session and no effects" {
+                    transition (SessionMsg.CloseFailed "down") (Session.Closing full)
+                    |> Expect.equal "still open" (Session.Open full, [])
+                }
+
+                test "CloseFailed outside Closing is dropped" {
+                    for state in
+                        [
+                            Session.Open full
+                            Session.Anonymous
+                            launching
+                            Session.Resuming
+                        ] do
+                        transition (SessionMsg.CloseFailed "down") state
+                        |> Expect.equal "unchanged" (state, [])
+                }
+
                 test "Closed outside Closing is dropped" {
                     for state in
                         [


### PR DESCRIPTION
## Overview

Step 3c of [plan 409](https://github.com/informedica/GenPRES/blob/master/docs/implementation-plans/409-client-launch-sequence.md), on top of #591 and #592: `SessionMachine` and `Keys` wired into `App.fs`.

- **State and messages**: `State.Session: Session`, `Msg.SessionMsg of SessionMsg`. `update` runs `Session.transition` and turns each `SessionEffect` into a command (`interpretSessionEffect`): `CallPresentLaunch` → `processLaunch`, `CallGetSession`/`CallCloseSession` → `processSession`, a transport failure becomes an `Error` outcome, never an exception; `Closed` is dispatched whether or not the close call succeeded, since the server deletes the cookie in a `finally` (#589); `GoTo` → `location.assign`; `SetPatient` → `UpdatePatient`; `KeepKey` → `Keys.keep`.
- **URL**: `parseLaunch` yields `LaunchUrl.Launch` or `LaunchUrl.Refused` (vocabulary `expired`, `spent`, `invalid`, `no-identity`, `no-role`, `wrong-patient`, `enrolment`; unknown = invalid); both forms are erased as before. `init` without a launch dispatches `Resume`; with one it runs `Keys.generate` then `Present`. A browser that cannot make a key pair is reported as `NoBrowserIdentity`.
- **Patient**: an open Session supplies the patient, so URL patient parameters count only while no Session is `Open` or `Closing`. Not for every non-anonymous phase: the router fires `UrlChanged` on mount while `Resume` is still in flight, and blocking `Resuming` broke anonymous patient URLs (found and fixed during verification).
- **Disclaimer**: gated at the view, `state.ShowDisclaimer && Session is Anonymous`. Gating it in state was wrong for the same reason (`Resuming` is transient) and would also have denied the disclaimer to an anonymous open after a refusal.
- **Capability**: `AppEnv.ISession` with `Session`, `Close`, `Retry`, `OpenAnonymously` on `ConcreteAppEnv`, for the title bar (4a) and the `SessionGate` (4b). No view uses it yet.

## Further information

Client-only, under the UI exception; no script stage. `SessionMachine.transition` and the server side are tested in #591 and #589; this PR is the interpreter between them, verified live.

## Divergence from plan

None in substance. The plan's `parseLaunch` "yields `RefusedAtCallback`"; here it yields a `LaunchUrl` and `launchCmd` maps it to the message, so `init` and `UrlChanged` share one function.

## Verification

Client project builds; Fable compiles; Fantomas clean. In Chrome, each scenario in its own isolated context against `GENPRES_PROD=0 dotnet run`:

| Scenario | Observed |
|---|---|
| `#/session?launch=wire-demo-1` | one `processLaunch` with body `PresentLaunch (Launch, PublicKey JWK)`, response `Opened` with `KeyThumbprint`, `Set-Cookie: genpres_session=…; path=/; samesite=strict; httponly`; address bar `#/session`, history length unchanged; one key in IndexedDB with that thumbprint; no disclaimer; `processCommand` loads follow from `UpdatePatient` |
| reload of that tab | `processSession GetSession` first, no `processLaunch`, no disclaimer |
| `#/session?refused=no-role` (fresh load) | erased to `#/session`, no launch or session call, no disclaimer |
| `#/` | `processSession GetSession` (resume), disclaimer shown |
| `#/patient?by=2020&wt=12000&dc=n` | patient 6 y 8 m, 12 kg loaded as on master |

Reviewer: the same five URLs; DevTools → Network for the API calls, Application → Cookies and IndexedDB for the rest.

## Author checklist

I confirm that these changes:

- [x] Follow the process described in [CONTRIBUTING.md](../../CONTRIBUTING.md#pull-request-process).
- [x] Make the changes proposed in the linked issue (if applicable): #409
- [x] Follow the approach documented in the linked implementation plan (if applicable): `docs/implementation-plans/409-client-launch-sequence.md`, step 3 (wiring)
- [x] Are no more than 200 lines of changed code, ideally 25-100. (163 insertions, 7 deletions.)
- [x] Are not more complex than necessary.
- [x] Cannot easily be split in a way that would make reviewing them significantly easier.
- [x] Follow the guidelines specified in [DEVELOPMENT.md](../../DEVELOPMENT.md).
- [x] Have been thoroughly tested.
- [x] Don't introduce new security vulnerabilities.
- [x] Follow the [AI/LLM Usage Policy](../../AGENTS.md#aillm-usage-policy) — LLMs were not given direct write access to `.fs` source files (except client-side UI code).

### AI/Vibe Coding Disclosure

- [x] Some or all code in this PR is **vibe coded** (substantially AI-generated). If checked, describe below which parts were AI-generated, which tool was used, and how the code was verified.

Written by Claude Code (Claude Fable 5.1) from plan 409 as direct client edits, reviewed locally by the maintainer before the push. Verified by the build, the Fable output, and the five Chrome scenarios above.

I confirm that I have:

- [ ] Added appropriate automated tests. (The machine and the server are unit-tested in #591 and #589; the interpreter is browser code, verified live.)
- [x] Updated documentation appropriately. (Doc comments; plan 409 already describes the step.)
- [x] Added comments that highlight important changes and add justification, where necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NnCcKoWNhFZMh1PLqXPU8j
