### PR TITLE
feat(ui): show the session user in the title bar with a close action

### DIFF
--- a/src/Informedica.GenPRES.Client/Components/TitleBar.fs
+++ b/src/Informedica.GenPRES.Client/Components/TitleBar.fs
@@ -178,11 +178,20 @@ module TitleBar =
                 marginLeft = 2
             |}
 
+        // one button, like Login: keyboard-focusable, named by its text; the name is capped
+        // and clipped so a long display name cannot push the language and login controls out
+        let sxSessionButton =
+            {|
+                marginLeft = 1
+                textTransform = "none"
+                maxWidth = 260
+            |}
+
         let sxSessionLabel =
             {|
-                cursor = "pointer"
-                color = "inherit"
-                userSelect = "none"
+                overflow = "hidden"
+                textOverflow = "ellipsis"
+                whiteSpace = "nowrap"
             |}
 
         let roleName role =
@@ -201,12 +210,16 @@ module TitleBar =
                     JSX.jsx
                         $"""
                     <Box sx={sxSessionBox}>
-                        <IconButton color="inherit" onClick={handleOpenSessionMenu}>
-                            {Mui.Icons.Person}
-                        </IconButton>
-                        <Typography variant="body1" component="div" sx={sxSessionLabel} onClick={handleOpenSessionMenu}>
-                            {label}
-                        </Typography>
+                        <Button
+                            color="inherit"
+                            startIcon={Mui.Icons.Person}
+                            onClick={handleOpenSessionMenu}
+                            aria-haspopup="menu"
+                            aria-expanded={anchorElSession.IsSome}
+                            title={label}
+                            sx={sxSessionButton}>
+                            <Box component="span" sx={sxSessionLabel}>{label}</Box>
+                        </Button>
                         <Menu
                             sx={menuSx}
                             anchorEl={anchorElSession}

--- a/src/Informedica.GenPRES.Client/Components/TitleBar.fs
+++ b/src/Informedica.GenPRES.Client/Components/TitleBar.fs
@@ -7,6 +7,8 @@ module TitleBar =
     open Fable.Core
     open Feliz
     open Fable.Core.JsInterop
+    open Shared.Types
+    open SessionMachine
 
 
     [<JSX.Component>]
@@ -22,10 +24,24 @@ module TitleBar =
                 isAuthenticated: bool
                 onLogin: string -> unit
                 onLogout: unit -> unit
+                // the launch Session (plan 409) is read through the env, not threaded as props
+                appEnv: obj
             |})
         =
 
         let context: Global.Context = React.useContext Global.context
+
+        let session = AppEnv.asEnv<AppEnv.ISession> props.appEnv
+
+        let anchorElSession, setAnchorElSession = React.useState None
+
+        let handleOpenSessionMenu = fun ev -> ev?currentTarget |> setAnchorElSession
+        let handleCloseSessionMenu = fun _ -> setAnchorElSession None
+
+        let handleCloseSession =
+            fun _ ->
+                setAnchorElSession None
+                session.Close()
 
         let anchorElHosp, setAnchorElHosp = React.useState None
 
@@ -155,6 +171,69 @@ module TitleBar =
                 horizontal = "right"
             |}
 
+        let sxSessionBox =
+            {|
+                display = "flex"
+                alignItems = "center"
+                marginLeft = 2
+            |}
+
+        let sxSessionLabel =
+            {|
+                cursor = "pointer"
+                color = "inherit"
+                userSelect = "none"
+            |}
+
+        let roleName role =
+            match role with
+            | UserRole.Prescriber -> "Prescriber"
+            | UserRole.Reader -> "Reader"
+
+        // who is in this Session, next to the hospital: only for an open Session with a user;
+        // nothing for anonymous use (plan 409, UI)
+        let sessionView =
+            let userOf (opened: SessionOpened) closing =
+                opened.User
+                |> Option.map (fun user ->
+                    let label = $"{user.DisplayName} ({roleName user.Role})"
+
+                    JSX.jsx
+                        $"""
+                    <Box sx={sxSessionBox}>
+                        <IconButton color="inherit" onClick={handleOpenSessionMenu}>
+                            {Mui.Icons.Person}
+                        </IconButton>
+                        <Typography variant="body1" component="div" sx={sxSessionLabel} onClick={handleOpenSessionMenu}>
+                            {label}
+                        </Typography>
+                        <Menu
+                            sx={menuSx}
+                            anchorEl={anchorElSession}
+                            anchorOrigin={topRightOrigin}
+                            keepMounted
+                            transformOrigin={topRightOrigin}
+                            open={anchorElSession.IsSome}
+                            onClose={handleCloseSessionMenu}
+                        >
+                            <MenuItem onClick={handleCloseSession} disabled={closing}>
+                                <Typography>{"Close session"}</Typography>
+                            </MenuItem>
+                        </Menu>
+                    </Box>
+                    """
+                )
+
+            match session.Session with
+            | Session.Open opened -> userOf opened false
+            | Session.Closing opened -> userOf opened true
+            | Session.Anonymous
+            | Session.Launching _
+            | Session.Resuming
+            | Session.Refused _
+            | Session.Unreachable _ -> None
+            |> Option.defaultValue null
+
         JSX.jsx
             $"""
         import AppBar from '@mui/material/AppBar';
@@ -209,6 +288,7 @@ module TitleBar =
                     <Typography variant="body1" component="div" >
                         {$"{context.Hospital}"}
                     </Typography>
+                    {sessionView}
 
                     <Box sx={sxLangBox}>
                         <IconButton color="inherit" onClick={handleOpenLangMenu}>

--- a/src/Informedica.GenPRES.Client/Pages/GenPres.fs
+++ b/src/Informedica.GenPRES.Client/Pages/GenPres.fs
@@ -217,6 +217,7 @@ module GenPres =
                     isAuthenticated = auth.IsAuthenticated
                     onLogin = auth.Login
                     onLogout = auth.Logout
+                    appEnv = props.appEnv
                 |}
 
         let interactions = (AppEnv.asEnv<AppEnv.IInteractions> props.appEnv).Interactions


### PR DESCRIPTION
## Overview

Step 4a of [plan 409](https://github.com/informedica/GenPRES/blob/master/docs/implementation-plans/409-client-launch-sequence.md), on top of #593: the title bar shows who is in the Session and offers to close it.

- **`Components/TitleBar.fs`**: while the Session is `Open` or `Closing`, a person icon and "display name (role)" appear right after the hospital; clicking either opens a menu with one item, "Close session", disabled while the close is in flight. Nothing is shown for `Anonymous`, `Launching`, `Resuming`, `Refused` or `Unreachable`.
- The bar reads `AppEnv.ISession` through the env; the only new prop is `appEnv`, as the plan asked instead of threading session props through `GenPres` and `TitleBar`.
- **`Pages/GenPres.fs`**: passes `appEnv` to the bar.

## Further information

The two strings ("Close session", the role names) are hard-coded English like the bar's existing "Login"/"Logout". Localisation terms live in the sheet; they get added together with the `SessionGate` texts in step 4b.

## Divergence from plan

None.

## Verification

Client project builds; Fable output nests the new block correctly; Fantomas clean. In Chrome against `GENPRES_PROD=0 dotnet run`, isolated context:

- `#/session?launch=titlebar-3` → bar reads `GenPRES Noodlijst | UMCU | Stub Prescriber (Prescriber) | NL | LOGIN`, no disclaimer.
- Click the name → menu with "Close session" → click → the name leaves the bar, `processSession GetSession` afterwards answers `SessionResp null` (cookie deleted server-side), and the anonymous disclaimer returns.

Reviewer: the same launch URL, then the menu on the name.

## Author checklist

I confirm that these changes:

- [x] Follow the process described in [CONTRIBUTING.md](../../CONTRIBUTING.md#pull-request-process).
- [x] Make the changes proposed in the linked issue (if applicable): #409
- [x] Follow the approach documented in the linked implementation plan (if applicable): `docs/implementation-plans/409-client-launch-sequence.md`, step 4 (title bar)
- [x] Are no more than 200 lines of changed code, ideally 25-100. (81 insertions.)
- [x] Are not more complex than necessary.
- [x] Cannot easily be split in a way that would make reviewing them significantly easier.
- [x] Follow the guidelines specified in [DEVELOPMENT.md](../../DEVELOPMENT.md).
- [x] Have been thoroughly tested.
- [x] Don't introduce new security vulnerabilities.
- [x] Follow the [AI/LLM Usage Policy](../../AGENTS.md#aillm-usage-policy) — LLMs were not given direct write access to `.fs` source files (except client-side UI code).

### AI/Vibe Coding Disclosure

- [x] Some or all code in this PR is **vibe coded** (substantially AI-generated). If checked, describe below which parts were AI-generated, which tool was used, and how the code was verified.

Written by Claude Code (Claude Fable 5.1) from plan 409 as direct client UI edits, reviewed locally by the maintainer before the push. Verified by the build, the Fable output and the Chrome sequence above.

I confirm that I have:

- [ ] Added appropriate automated tests. (UI only; the machine behind it is tested in #591.)
- [x] Updated documentation appropriately. (Comments; plan 409 already describes the step.)
- [x] Added comments that highlight important changes and add justification, where necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NnCcKoWNhFZMh1PLqXPU8j
