### PR TITLE
feat(client): localise the session gate and session menu

### DIFF
--- a/docs/implementation-plans/409-client-launch-sequence.md
+++ b/docs/implementation-plans/409-client-launch-sequence.md
@@ -417,6 +417,7 @@ are listed per step with the reason.
 | 3c | [#593](https://github.com/informedica/GenPRES/pull/593) | `App.fs` wiring: `State.Session`, effect interpreter, `Resume` on load, `ISession` on `ConcreteAppEnv` |
 | 4a | [#595](https://github.com/informedica/GenPRES/pull/595) | title bar: user and role behind a person button, "Close session" |
 | 4b | [#596](https://github.com/informedica/GenPRES/pull/596) | `SessionGatePolicy.fs` (pure, tested) and `Views/SessionGate.fs` |
+| follow-up | [#600](https://github.com/informedica/GenPRES/pull/600) | localisation: 22 `Terms` cases for the gate and the session menu, `gateFor` takes a translator, English and Dutch sheet rows |
 
 ### Deviations from the text above
 
@@ -459,9 +460,10 @@ are listed per step with the reason.
 - **Disclaimer.** Gated at the view, `ShowDisclaimer && Session is Anonymous`, not in state, for
   the same reason (`Resuming` is transient) and so that an anonymous open after a refusal still
   sees it.
-- **Gate texts.** The title bar and gate strings are English, in one place each. Turning them into
-  `Terms` cases means editing `Shared/Localization.fs` (non-UI source) plus sheet rows; that is a
-  script-first follow-up, not part of these PRs.
+- **Gate texts.** The title bar and gate strings landed as English literals, in one place each,
+  because turning them into `Terms` cases means editing `Shared/Localization.fs` (non-UI source)
+  plus sheet rows. The script-first follow-up (#600) did that: the policy takes a translator
+  (`Terms -> string`), every sentence is one term, numbers are filled through `{0}`/`{1}`.
 
 ### Still open
 
@@ -470,4 +472,5 @@ are listed per step with the reason.
 - Step 7, the signed request (`Keys.sign`, the DPoP proof, the OpenedToken inside it).
 - Session endings and the Rule 11 notice; UC-2 enrolment; WorkPlan carry-over (#518); decision D1.
 - The scope switch (#580), which retires the `IsProd` stop-gap.
-- Localisation terms for the title bar and the gate.
+- On a launch URL the language ends up English (`UrlChanged` defaults to English without `la=`)
+  and the gate hides the language switcher; the gate itself is localised (#600).

--- a/src/Informedica.GenPRES.Client/Components/TitleBar.fs
+++ b/src/Informedica.GenPRES.Client/Components/TitleBar.fs
@@ -7,6 +7,7 @@ module TitleBar =
     open Fable.Core
     open Feliz
     open Fable.Core.JsInterop
+    open Shared
     open Shared.Types
     open SessionMachine
 
@@ -194,10 +195,16 @@ module TitleBar =
                 whiteSpace = "nowrap"
             |}
 
+        // the session terms in the User's language, else the policy's English
+        let terms = (AppEnv.asEnv<AppEnv.ILocalization> props.appEnv).LocalizationTerms
+
+        let tr term =
+            Global.getLocalizedTerm terms context.Localization (SessionGatePolicy.english term) term
+
         let roleName role =
             match role with
-            | UserRole.Prescriber -> "Prescriber"
-            | UserRole.Reader -> "Reader"
+            | UserRole.Prescriber -> tr Terms.``Session Role Prescriber``
+            | UserRole.Reader -> tr Terms.``Session Role Reader``
 
         // who is in this Session, next to the hospital: only for an open Session with a user;
         // nothing for anonymous use (plan 409, UI)
@@ -230,7 +237,7 @@ module TitleBar =
                             onClose={handleCloseSessionMenu}
                         >
                             <MenuItem onClick={handleCloseSession} disabled={closing}>
-                                <Typography>{"Close session"}</Typography>
+                                <Typography>{tr Terms.``Session Close``}</Typography>
                             </MenuItem>
                         </Menu>
                     </Box>

--- a/src/Informedica.GenPRES.Client/Pages/GenPres.fs
+++ b/src/Informedica.GenPRES.Client/Pages/GenPres.fs
@@ -334,8 +334,7 @@ module GenPres =
         // and after a refusal; it cannot be dismissed, the machine decides when it goes
         let sessionGateOpen =
             (AppEnv.asEnv<AppEnv.ISession> props.appEnv).Session
-            |> SessionGatePolicy.gateFor
-            |> Option.isSome
+            |> SessionGatePolicy.isGated
 
         let sessionGateView = Views.SessionGate.View {| appEnv = props.appEnv |}
 

--- a/src/Informedica.GenPRES.Client/SessionGatePolicy.fs
+++ b/src/Informedica.GenPRES.Client/SessionGatePolicy.fs
@@ -1,10 +1,12 @@
 /// <summary>
 /// The session gate's policy (plan 409, uc-01 Refusals): for every session phase, what the gate
 /// says and what it offers. Pure F#, no React, so it runs under Expecto next to the machine;
-/// Views/SessionGate.fs renders it.
+/// Views/SessionGate.fs renders it. The texts are `Terms`, translated by the caller: the view
+/// passes the sheet lookup, the tests pass `english`.
 /// </summary>
 module SessionGatePolicy
 
+open Shared
 open Shared.Types
 open SessionMachine
 
@@ -26,62 +28,135 @@ type Gate =
     }
 
 
-// English for now. These become Shared.Localization.Terms cases plus sheet rows once the
-// terms are agreed; the keys below are the intended term names.
-let relaunch = "Open GenPRES again from MainEHR."
-
-let relaunchAfter = "open GenPRES again from MainEHR."
-
-let refusalBody refusal =
-    match refusal with
-    | LaunchRefusal.LaunchExpired -> $"The launch has expired. {relaunch}"
-    | LaunchRefusal.LaunchSpent -> $"This launch has already been used. {relaunch}"
-    | LaunchRefusal.LaunchInvalid -> $"The launch is not valid. {relaunch}"
-    | LaunchRefusal.NoBrowserIdentity -> "Your browser could not be identified."
-    | LaunchRefusal.NoRole ->
+/// The English of the session terms: what the gate and the session menu show when the sheet has
+/// no row for a term, or the terms have not loaded. Any other term falls back to its name, as
+/// `Global.pageToString` does.
+let english (term: Terms) =
+    match term with
+    | Terms.``Session Gate Opening`` -> "Opening your session"
+    | Terms.``Session Gate Opening Text`` -> "Presenting the launch, attempt {0} of {1}."
+    | Terms.``Session Gate Resuming`` -> "Resuming your session"
+    | Terms.``Session Gate Resuming Text`` -> "Checking for an open session."
+    | Terms.``Session Gate Unreachable`` -> "GenPRES could not be reached"
+    | Terms.``Session Gate Unreachable Text`` -> "The server did not answer after {0} attempts."
+    | Terms.``Session Gate Refused`` -> "GenPRES could not open your session"
+    | Terms.``Session Gate Try Again Or Relaunch`` -> "Try again, or open GenPRES again from MainEHR."
+    | Terms.``Session Relaunch`` -> "Open GenPRES again from MainEHR."
+    | Terms.``Session Retry`` -> "Try again."
+    | Terms.``Session Refusal Expired`` -> "The launch has expired."
+    | Terms.``Session Refusal Spent`` -> "This launch has already been used."
+    | Terms.``Session Refusal Invalid`` -> "The launch is not valid."
+    | Terms.``Session Refusal No Browser Identity`` -> "Your browser could not be identified."
+    | Terms.``Session Refusal No Role`` ->
         "You have no role in GenPRES. You can continue without a launch: no patient is carried over."
-    | LaunchRefusal.WrongActivePatient ->
-        $"The patient active in MainEHR is not the patient of this launch. Activate the right patient and {relaunchAfter}"
-    | LaunchRefusal.EnrolmentRequired ->
-        $"A PIN has to be set before prescribing. Enrolment is not available yet. {relaunch}"
+    | Terms.``Session Refusal Wrong Patient`` ->
+        "The patient active in MainEHR is not the patient of this launch. Activate the right patient and open GenPRES again from MainEHR."
+    | Terms.``Session Refusal Enrolment`` ->
+        "A PIN has to be set before prescribing. Enrolment is not available yet. Open GenPRES again from MainEHR."
+    | Terms.``Session Try Again`` -> "Try again"
+    | Terms.``Session Continue Without Launch`` -> "Continue without launch"
+    | Terms.``Session Close`` -> "Close session"
+    | Terms.``Session Role Prescriber`` -> "Prescriber"
+    | Terms.``Session Role Reader`` -> "Reader"
+    | _ -> $"{term}"
+
+
+/// Fills `{0}`, `{1}`, ... in a translated sentence with the given values, in order.
+let fill (args: string list) (s: string) =
+    args
+    |> List.indexed
+    |> List.fold (fun s (i, a) -> s |> String.replace $"{{{i}}}" a) s
+
+
+/// Joins translated sentences into one body; an empty translation adds no sentence.
+let sentences (xs: string list) =
+    xs |> List.filter (String.isNullOrWhiteSpace >> not) |> String.concat " "
+
+
+/// The sentences of a refusal: what happened, then what the User can do. Every sentence is one
+/// term, so no translation is ever embedded in another.
+let refusalBody (tr: Terms -> string) refusal =
+    match refusal with
+    | LaunchRefusal.LaunchExpired ->
+        [
+            tr Terms.``Session Refusal Expired``
+            tr Terms.``Session Relaunch``
+        ]
+    | LaunchRefusal.LaunchSpent ->
+        [
+            tr Terms.``Session Refusal Spent``
+            tr Terms.``Session Relaunch``
+        ]
+    | LaunchRefusal.LaunchInvalid ->
+        [
+            tr Terms.``Session Refusal Invalid``
+            tr Terms.``Session Relaunch``
+        ]
+    | LaunchRefusal.NoBrowserIdentity -> [ tr Terms.``Session Refusal No Browser Identity`` ]
+    | LaunchRefusal.NoRole -> [ tr Terms.``Session Refusal No Role`` ]
+    | LaunchRefusal.WrongActivePatient -> [ tr Terms.``Session Refusal Wrong Patient`` ]
+    | LaunchRefusal.EnrolmentRequired -> [ tr Terms.``Session Refusal Enrolment`` ]
+
+
+/// Whether the gate is over the app: false while the app is usable (anonymous, open, closing).
+let isGated (session: Session) =
+    match session with
+    | Session.Anonymous
+    | Session.Open _
+    | Session.Closing _ -> false
+    | Session.Launching _
+    | Session.Resuming
+    | Session.Unreachable _
+    | Session.Refused _ -> true
 
 
 /// The gate for a session phase, or None when the app is usable (anonymous, open, closing).
-let gateFor (session: Session) : Gate option =
+let gateFor (tr: Terms -> string) (session: Session) : Gate option =
     match session with
     | Session.Launching(_, _, attempt) ->
         Some
             {
-                Title = "Opening your session"
-                Body = $"Presenting the launch, attempt %i{attempt} of %i{Session.maxAttempts}."
+                Title = tr Terms.``Session Gate Opening``
+                Body =
+                    tr Terms.``Session Gate Opening Text``
+                    |> fill [ $"%i{attempt}"; $"%i{Session.maxAttempts}" ]
                 Busy = true
                 Actions = []
             }
     | Session.Resuming ->
         Some
             {
-                Title = "Resuming your session"
-                Body = "Checking for an open session."
+                Title = tr Terms.``Session Gate Resuming``
+                Body = tr Terms.``Session Gate Resuming Text``
                 Busy = true
                 Actions = []
             }
     | Session.Unreachable(_, _, attempts) ->
         Some
             {
-                Title = "GenPRES could not be reached"
-                Body = $"The server did not answer after %i{attempts} attempts. Try again, or {relaunchAfter}"
+                Title = tr Terms.``Session Gate Unreachable``
+                Body =
+                    sentences
+                        [
+                            tr Terms.``Session Gate Unreachable Text`` |> fill [ $"%i{attempts}" ]
+                            tr Terms.``Session Gate Try Again Or Relaunch``
+                        ]
                 Busy = false
                 Actions = [ Action.Retry ]
             }
     | Session.Refused(refusal, retry) ->
         Some
             {
-                Title = "GenPRES could not open your session"
+                Title = tr Terms.``Session Gate Refused``
                 Body =
-                    match refusal, retry with
-                    | LaunchRefusal.NoBrowserIdentity, Some _ -> $"{refusalBody refusal} Try again."
-                    | LaunchRefusal.NoBrowserIdentity, None -> $"{refusalBody refusal} {relaunch}"
-                    | _ -> refusalBody refusal
+                    sentences
+                        [
+                            yield! refusalBody tr refusal
+                            match refusal, retry with
+                            | LaunchRefusal.NoBrowserIdentity, Some _ -> tr Terms.``Session Retry``
+                            | LaunchRefusal.NoBrowserIdentity, None -> tr Terms.``Session Relaunch``
+                            | _ -> ()
+                        ]
                 Busy = false
                 Actions =
                     [

--- a/src/Informedica.GenPRES.Client/Views/SessionGate.fs
+++ b/src/Informedica.GenPRES.Client/Views/SessionGate.fs
@@ -14,15 +14,22 @@ module SessionGate =
 
     open Fable.Core
     open Feliz
+    open Shared
     open SessionGatePolicy
 
 
     [<JSX.Component>]
     let View (props: {| appEnv: obj |}) =
         let session = AppEnv.asEnv<AppEnv.ISession> props.appEnv
+        let terms = (AppEnv.asEnv<AppEnv.ILocalization> props.appEnv).LocalizationTerms
+        let context: Global.Context = React.useContext Global.context
+
+        // the sheet's translation in the User's language, else the policy's English
+        let tr term =
+            Global.getLocalizedTerm terms context.Localization (english term) term
 
         let gate =
-            gateFor session.Session
+            gateFor tr session.Session
             |> Option.defaultValue
                 {
                     Title = ""
@@ -53,14 +60,14 @@ module SessionGate =
                     JSX.jsx
                         $"""
                     <Button key="retry" variant="contained" color="primary" onClick={onRetry}>
-                        {"Try again"}
+                        {tr Terms.``Session Try Again``}
                     </Button>
                     """
                 | Action.ContinueWithoutLaunch ->
                     JSX.jsx
                         $"""
                     <Button key="continue" variant="contained" color="primary" onClick={onContinue}>
-                        {"Continue without launch"}
+                        {tr Terms.``Session Continue Without Launch``}
                     </Button>
                     """
             )

--- a/src/Informedica.GenPRES.Shared/Localization.fs
+++ b/src/Informedica.GenPRES.Shared/Localization.fs
@@ -5,8 +5,8 @@
 // indices that map to each language are hardcoded in `getTerm`, which means
 // **reordering columns in the spreadsheet silently breaks all translations**.
 //
-// An improved, more idiomatic approach is demonstrated in
-// `Scripts/Localization.fsx`.  Key improvements proposed there:
+// An improved, more idiomatic approach is the `TranslationMap` API further down in this file
+// (`parseCSV`, `getTermFromMap`, `mergeTranslations`), not yet used by the client:
 //   - Parse the CSV by column *headers* (language display names) so the
 //     implementation is robust to spreadsheet column reordering.
 //   - Store translations as `TranslationMap` (`Map<string, Map<Locales, string>>`)
@@ -21,7 +21,8 @@ namespace Shared
 
 /// Compile-time-safe enumeration of all localizable UI strings.
 /// Add a new case here whenever a new UI label is introduced, and update the
-/// Localization sheet (and `Scripts/Localization.fsx` static fallback) accordingly.
+/// Localization sheet accordingly. New cases are drafted script-first in
+/// `Scripts/Localization.fsx` (the script-only policy), which also prints the sheet rows.
 type Terms =
     | ``Patient enter patient data``
     | ``Patient Age``
@@ -134,15 +135,37 @@ type Terms =
     | ``Nutrition Remove Enteral Text``
     // Interactions
     | ``Interactions Medication``
+    // Session (plan 409): the gate and the session menu
+    | ``Session Gate Opening``
+    | ``Session Gate Opening Text``
+    | ``Session Gate Resuming``
+    | ``Session Gate Resuming Text``
+    | ``Session Gate Unreachable``
+    | ``Session Gate Unreachable Text``
+    | ``Session Gate Refused``
+    | ``Session Gate Try Again Or Relaunch``
+    | ``Session Relaunch``
+    | ``Session Retry``
+    | ``Session Refusal Expired``
+    | ``Session Refusal Spent``
+    | ``Session Refusal Invalid``
+    | ``Session Refusal No Browser Identity``
+    | ``Session Refusal No Role``
+    | ``Session Refusal Wrong Patient``
+    | ``Session Refusal Enrolment``
+    | ``Session Try Again``
+    | ``Session Continue Without Launch``
+    | ``Session Close``
+    | ``Session Role Prescriber``
+    | ``Session Role Reader``
 
 
 module Localization =
 
 
     /// Supported UI languages.  Add a case here when a new language is
-    /// introduced, then update `toString`, `fromString`, `languages`, the
-    /// Localization spreadsheet, and the static fallback in
-    /// `Scripts/Localization.fsx`.
+    /// introduced, then update `toString`, `fromString`, `languages`, `getTerm`
+    /// and the Localization spreadsheet.
     type Locales =
         | English
         | Dutch
@@ -191,9 +214,8 @@ module Localization =
 
     /// Converts a display name string to a `Locales` value.
     ///
-    /// ⚠️  This function **throws** for unknown input.  Consider using the
-    /// `tryLocaleFromString` function from `Scripts/Localization.fsx` which
-    /// returns `Option<Locales>` instead.
+    /// ⚠️  This function **throws** for unknown input.  Consider using
+    /// `tryFromString` below, which returns `Option<Locales>` instead.
     let fromString (s: string) =
         let s = s.Trim().ToLower()
 
@@ -216,9 +238,9 @@ module Localization =
     ///
     /// ⚠️  Column positions are **hardcoded** (English = 1, Dutch = 2, …).
     /// Reordering columns in the spreadsheet will silently return wrong
-    /// translations.  See `Scripts/Localization.fsx` for a header-based parser
-    /// (`parseLocalizationCSV`) that is robust to column reordering and uses a
-    /// typed `TranslationMap` instead of `string[][]`.
+    /// translations.  See `parseCSV` below for a header-based parser that is
+    /// robust to column reordering and uses a typed `TranslationMap` instead of
+    /// `string[][]`.
     let getTerm (terms: string[][]) locale term =
         let term = $"{term}".Trim()
 

--- a/src/Informedica.GenPRES.Shared/Scripts/Localization.fsx
+++ b/src/Informedica.GenPRES.Shared/Scripts/Localization.fsx
@@ -1,0 +1,206 @@
+// Session terms for the gate and the title bar (plan 409 follow-up, uc-01 Refusals).
+//
+// Script-first draft of the new `Terms` cases: `Shared/Localization.fs` is non-UI source, so the
+// cases are proposed here as `SessionTerms` (a DU cannot be extended in a script), with their
+// English defaults and Dutch translations, and checked against `Localization.getTerm` over rows
+// shaped like the "Localization" sheet. After review, `printCases ()` gives the lines to paste
+// into `Terms`, and `printTsv ()` the rows for the sheet and `data/localization/*.tsv`.
+//
+// Run: `dotnet fsi Localization.fsx` from this directory, or via the FSI MCP after
+// `#I "<this directory>"`.
+
+#I __SOURCE_DIRECTORY__
+#r "nuget: Expecto, 10.2.3"
+
+#load "../Types.fs"
+#load "../Utils.fs"
+#load "../Localization.fs"
+
+open Shared
+open Shared.Localization
+
+
+/// The proposed cases. Same naming as the sheet: an area prefix, then the term. Every sentence is
+/// its own term (no sentence is interpolated into another), so a translation never has to agree
+/// in case or word order with a sentence it is embedded in. Numbers are filled by the caller
+/// through `{0}` and `{1}`.
+type SessionTerms =
+    // gate titles and bodies per phase
+    | ``Session Gate Opening``
+    | ``Session Gate Opening Text``
+    | ``Session Gate Resuming``
+    | ``Session Gate Resuming Text``
+    | ``Session Gate Unreachable``
+    | ``Session Gate Unreachable Text``
+    | ``Session Gate Refused``
+    | ``Session Gate Try Again Or Relaunch``
+    // sentences the gate appends to a refusal
+    | ``Session Relaunch``
+    | ``Session Retry``
+    // one sentence per refusal (uc-01 Refusals)
+    | ``Session Refusal Expired``
+    | ``Session Refusal Spent``
+    | ``Session Refusal Invalid``
+    | ``Session Refusal No Browser Identity``
+    | ``Session Refusal No Role``
+    | ``Session Refusal Wrong Patient``
+    | ``Session Refusal Enrolment``
+    // buttons and the title bar
+    | ``Session Try Again``
+    | ``Session Continue Without Launch``
+    | ``Session Close``
+    | ``Session Role Prescriber``
+    | ``Session Role Reader``
+
+
+/// The English defaults: the strings the client shows today, verbatim.
+let english term =
+    match term with
+    | ``Session Gate Opening`` -> "Opening your session"
+    | ``Session Gate Opening Text`` -> "Presenting the launch, attempt {0} of {1}."
+    | ``Session Gate Resuming`` -> "Resuming your session"
+    | ``Session Gate Resuming Text`` -> "Checking for an open session."
+    | ``Session Gate Unreachable`` -> "GenPRES could not be reached"
+    | ``Session Gate Unreachable Text`` -> "The server did not answer after {0} attempts."
+    | ``Session Gate Refused`` -> "GenPRES could not open your session"
+    | ``Session Gate Try Again Or Relaunch`` -> "Try again, or open GenPRES again from MainEHR."
+    | ``Session Relaunch`` -> "Open GenPRES again from MainEHR."
+    | ``Session Retry`` -> "Try again."
+    | ``Session Refusal Expired`` -> "The launch has expired."
+    | ``Session Refusal Spent`` -> "This launch has already been used."
+    | ``Session Refusal Invalid`` -> "The launch is not valid."
+    | ``Session Refusal No Browser Identity`` -> "Your browser could not be identified."
+    | ``Session Refusal No Role`` ->
+        "You have no role in GenPRES. You can continue without a launch: no patient is carried over."
+    | ``Session Refusal Wrong Patient`` ->
+        "The patient active in MainEHR is not the patient of this launch. Activate the right patient and open GenPRES again from MainEHR."
+    | ``Session Refusal Enrolment`` ->
+        "A PIN has to be set before prescribing. Enrolment is not available yet. Open GenPRES again from MainEHR."
+    | ``Session Try Again`` -> "Try again"
+    | ``Session Continue Without Launch`` -> "Continue without launch"
+    | ``Session Close`` -> "Close session"
+    | ``Session Role Prescriber`` -> "Prescriber"
+    | ``Session Role Reader`` -> "Reader"
+
+
+/// Dutch, for the sheet; the other four languages stay empty and fall back to English.
+let dutch term =
+    match term with
+    | ``Session Gate Opening`` -> "Uw sessie wordt geopend"
+    | ``Session Gate Opening Text`` -> "De launch wordt aangeboden, poging {0} van {1}."
+    | ``Session Gate Resuming`` -> "Uw sessie wordt hervat"
+    | ``Session Gate Resuming Text`` -> "Er wordt gecontroleerd op een open sessie."
+    | ``Session Gate Unreachable`` -> "GenPRES is niet bereikbaar"
+    | ``Session Gate Unreachable Text`` -> "De server antwoordde niet na {0} pogingen."
+    | ``Session Gate Refused`` -> "GenPRES kon uw sessie niet openen"
+    | ``Session Gate Try Again Or Relaunch`` -> "Probeer opnieuw, of open GenPRES opnieuw vanuit MainEHR."
+    | ``Session Relaunch`` -> "Open GenPRES opnieuw vanuit MainEHR."
+    | ``Session Retry`` -> "Probeer opnieuw."
+    | ``Session Refusal Expired`` -> "De launch is verlopen."
+    | ``Session Refusal Spent`` -> "Deze launch is al gebruikt."
+    | ``Session Refusal Invalid`` -> "De launch is niet geldig."
+    | ``Session Refusal No Browser Identity`` -> "Uw browser kon niet worden geïdentificeerd."
+    | ``Session Refusal No Role`` ->
+        "U heeft geen rol in GenPRES. U kunt doorgaan zonder launch: er wordt geen patiënt overgenomen."
+    | ``Session Refusal Wrong Patient`` ->
+        "De patiënt die actief is in MainEHR is niet de patiënt van deze launch. Activeer de juiste patiënt en open GenPRES opnieuw vanuit MainEHR."
+    | ``Session Refusal Enrolment`` ->
+        "Er moet een pincode worden ingesteld voordat u kunt voorschrijven. Inschrijven is nog niet beschikbaar. Open GenPRES opnieuw vanuit MainEHR."
+    | ``Session Try Again`` -> "Probeer opnieuw"
+    | ``Session Continue Without Launch`` -> "Doorgaan zonder launch"
+    | ``Session Close`` -> "Sessie sluiten"
+    | ``Session Role Prescriber`` -> "Voorschrijver"
+    | ``Session Role Reader`` -> "Lezer"
+
+
+let all =
+    Reflection.FSharpType.GetUnionCases typeof<SessionTerms>
+    |> Array.map (fun c -> Reflection.FSharpValue.MakeUnion(c, [||]) :?> SessionTerms)
+
+
+/// Rows shaped like the sheet: Term, English, Dutch, French, German, Spanish, Italian.
+let rows = all |> Array.map (fun t -> [| $"{t}"; english t; dutch t; ""; ""; ""; "" |])
+
+
+/// Fills `{0}`, `{1}`, ... in a translated term; the client does the same.
+let fill (args: string list) (s: string) =
+    args |> List.indexed |> List.fold (fun s (i, a) -> s |> String.replace $"{{{i}}}" a) s
+
+
+let printCases () =
+    printfn "    // Session (plan 409): the gate and the session menu"
+    all |> Array.iter (fun t -> printfn $"    | ``{t}``")
+
+
+let printTsv () =
+    rows |> Array.iter (fun r -> r |> String.concat "\t" |> printfn "%s")
+
+
+open Expecto
+open Expecto.Flip
+
+
+let tests =
+    testList
+        "session terms"
+        [
+            test "every case has an English default and a Dutch translation" {
+                for t in all do
+                    english t |> String.isNullOrWhiteSpace |> Expect.isFalse $"English for {t}"
+                    dutch t |> String.isNullOrWhiteSpace |> Expect.isFalse $"Dutch for {t}"
+            }
+
+            test "every case resolves through getTerm in English and Dutch" {
+                for t in all do
+                    getTerm rows English t |> Expect.equal $"English {t}" (Some(english t))
+                    getTerm rows Dutch t |> Expect.equal $"Dutch {t}" (Some(dutch t))
+            }
+
+            test "a language without a translation resolves to None (client falls back to English)" {
+                for t in all do
+                    getTerm rows French t |> Expect.isNone $"French {t}"
+            }
+
+            test "case names are unique and are the row keys" {
+                rows
+                |> Array.map (fun r -> r[0])
+                |> Array.distinct
+                |> Array.length
+                |> Expect.equal "distinct keys" all.Length
+            }
+
+            test "placeholders appear only in the two attempt texts, in both languages" {
+                let withPlaceholders =
+                    all
+                    |> Array.filter (fun t -> (english t).Contains "{0}" || (dutch t).Contains "{0}")
+                    |> Array.sort
+
+                withPlaceholders
+                |> Expect.equal
+                    "placeholders"
+                    ([| ``Session Gate Opening Text``; ``Session Gate Unreachable Text`` |] |> Array.sort)
+
+                (english ``Session Gate Opening Text``).Contains "{1}" |> Expect.isTrue "{1} en"
+                (dutch ``Session Gate Opening Text``).Contains "{1}" |> Expect.isTrue "{1} nl"
+            }
+
+            test "fill replaces the placeholders" {
+                english ``Session Gate Opening Text``
+                |> fill [ "2"; "3" ]
+                |> Expect.equal "filled" "Presenting the launch, attempt 2 of 3."
+
+                dutch ``Session Gate Unreachable Text``
+                |> fill [ "3" ]
+                |> Expect.equal "filled" "De server antwoordde niet na 3 pogingen."
+            }
+
+            test "product names keep their case in every language" {
+                for t in all do
+                    for s in [ english t; dutch t ] do
+                        s.Contains "genpres" |> Expect.isFalse $"lowercased GenPRES in: {s}"
+                        s.Contains "mainehr" |> Expect.isFalse $"lowercased MainEHR in: {s}"
+            }
+        ]
+
+
+runTestsWithCLIArgs [] [||] tests |> ignore

--- a/tests/Informedica.GenPRES.Shared.Tests/SessionGatePolicyTests.fs
+++ b/tests/Informedica.GenPRES.Shared.Tests/SessionGatePolicyTests.fs
@@ -6,6 +6,7 @@ module SessionGatePolicyTests =
 
     open Expecto
     open Expecto.Flip
+    open Shared
     open Shared.Types
     open SessionMachine
     open SessionGatePolicy
@@ -24,7 +25,17 @@ module SessionGatePolicyTests =
 
 
     let gateOf session =
-        match gateFor session with
+        match gateFor english session with
+        | Some gate -> gate
+        | None -> failtest $"expected a gate for {session}"
+
+
+    /// A translator that shows which term was asked for, so a test can assert terms, not prose.
+    let named (term: Terms) = $"<{term}>"
+
+
+    let namedGateOf session =
+        match gateFor named session with
         | Some gate -> gate
         | None -> failtest $"expected a gate for {session}"
 
@@ -53,7 +64,26 @@ module SessionGatePolicyTests =
                                 "Open", Session.Open opened
                                 "Closing", Session.Closing opened
                             ] do
-                            test name { gateFor session |> Expect.isNone "no gate" }
+                            test name {
+                                gateFor english session |> Expect.isNone "no gate"
+                                isGated session |> Expect.isFalse "not gated"
+                            }
+                    ]
+
+                testList
+                    "isGated agrees with gateFor"
+                    [
+                        for name, session in
+                            [
+                                "Launching", Session.Launching(launch, key, 1)
+                                "Resuming", Session.Resuming
+                                "Unreachable", Session.Unreachable(launch, key, 3)
+                                "Refused", Session.Refused(LaunchRefusal.NoRole, None)
+                            ] do
+                            test name {
+                                gateFor english session |> Expect.isSome "gate"
+                                isGated session |> Expect.isTrue "gated"
+                            }
                     ]
 
                 test "Launching is busy, names the attempt, offers nothing" {
@@ -111,6 +141,107 @@ module SessionGatePolicyTests =
                     let gate = gateOf (Session.Refused(LaunchRefusal.NoBrowserIdentity, None))
                     gate.Actions |> Expect.isEmpty "no actions"
                     gate.Body |> Expect.stringContains "relaunch" "Open GenPRES again from MainEHR."
+                }
+
+                testList
+                    "every text is a term, translated by the caller"
+                    [
+                        test "Launching" {
+                            let gate = namedGateOf (Session.Launching(launch, key, 2))
+                            gate.Title |> Expect.equal "title" "<Session Gate Opening>"
+                            gate.Body |> Expect.equal "body" "<Session Gate Opening Text>"
+                        }
+
+                        test "Resuming" {
+                            let gate = namedGateOf Session.Resuming
+                            gate.Title |> Expect.equal "title" "<Session Gate Resuming>"
+                            gate.Body |> Expect.equal "body" "<Session Gate Resuming Text>"
+                        }
+
+                        test "Unreachable" {
+                            let gate = namedGateOf (Session.Unreachable(launch, key, 3))
+                            gate.Title |> Expect.equal "title" "<Session Gate Unreachable>"
+
+                            gate.Body
+                            |> Expect.equal
+                                "body"
+                                "<Session Gate Unreachable Text> <Session Gate Try Again Or Relaunch>"
+                        }
+
+                        for refusal, body in
+                            [
+                                LaunchRefusal.LaunchExpired, "<Session Refusal Expired> <Session Relaunch>"
+                                LaunchRefusal.LaunchSpent, "<Session Refusal Spent> <Session Relaunch>"
+                                LaunchRefusal.LaunchInvalid, "<Session Refusal Invalid> <Session Relaunch>"
+                                LaunchRefusal.NoRole, "<Session Refusal No Role>"
+                                LaunchRefusal.WrongActivePatient, "<Session Refusal Wrong Patient>"
+                                LaunchRefusal.EnrolmentRequired, "<Session Refusal Enrolment>"
+                                LaunchRefusal.NoBrowserIdentity,
+                                "<Session Refusal No Browser Identity> <Session Relaunch>"
+                            ] do
+                            test $"Refused {refusal} without a retry" {
+                                let gate = namedGateOf (Session.Refused(refusal, None))
+                                gate.Title |> Expect.equal "title" "<Session Gate Refused>"
+                                gate.Body |> Expect.equal "body" body
+                            }
+
+                        test "Refused NoBrowserIdentity with a retry" {
+                            let gate =
+                                namedGateOf (Session.Refused(LaunchRefusal.NoBrowserIdentity, Some(launch, key)))
+
+                            gate.Body
+                            |> Expect.equal "body" "<Session Refusal No Browser Identity> <Session Retry>"
+                        }
+                    ]
+
+                test "the numbers are filled into the translated text, in order" {
+                    let template (term: Terms) =
+                        match term with
+                        | Terms.``Session Gate Opening Text`` -> "poging {0} van {1}"
+                        | Terms.``Session Gate Unreachable Text`` -> "{0} pogingen"
+                        | _ -> ""
+
+                    (gateOf (Session.Launching(launch, key, 2))).Body
+                    |> Expect.equal "english" $"Presenting the launch, attempt 2 of {Session.maxAttempts}."
+
+                    match gateFor template (Session.Launching(launch, key, 2)) with
+                    | Some gate -> gate.Body |> Expect.equal "translated" $"poging 2 van {Session.maxAttempts}"
+                    | None -> failtest "expected a gate"
+
+                    match gateFor template (Session.Unreachable(launch, key, 3)) with
+                    | Some gate -> gate.Body |> Expect.equal "translated" "3 pogingen"
+                    | None -> failtest "expected a gate"
+                }
+
+                test "every session term has an English default that is not its name" {
+                    for term in
+                        [
+                            Terms.``Session Gate Opening``
+                            Terms.``Session Gate Opening Text``
+                            Terms.``Session Gate Resuming``
+                            Terms.``Session Gate Resuming Text``
+                            Terms.``Session Gate Unreachable``
+                            Terms.``Session Gate Unreachable Text``
+                            Terms.``Session Gate Refused``
+                            Terms.``Session Gate Try Again Or Relaunch``
+                            Terms.``Session Relaunch``
+                            Terms.``Session Retry``
+                            Terms.``Session Refusal Expired``
+                            Terms.``Session Refusal Spent``
+                            Terms.``Session Refusal Invalid``
+                            Terms.``Session Refusal No Browser Identity``
+                            Terms.``Session Refusal No Role``
+                            Terms.``Session Refusal Wrong Patient``
+                            Terms.``Session Refusal Enrolment``
+                            Terms.``Session Try Again``
+                            Terms.``Session Continue Without Launch``
+                            Terms.``Session Close``
+                            Terms.``Session Role Prescriber``
+                            Terms.``Session Role Reader``
+                        ] do
+                        english term |> Expect.notEqual $"default for {term}" $"{term}"
+
+                    english Terms.Cancel |> Expect.equal "not a session term: its name" "Cancel"
                 }
 
                 test "product names keep their case in every body" {


### PR DESCRIPTION
## Summary

Plan 409 follow-up: the session gate and the session menu were English literals; they are now `Terms` cases resolved through the Localization sheet, English by default when a row is missing. Scope: gate + session title bar (roles, "Close session"); Login/Logout stay as they are.

- `SessionGatePolicy.gateFor (tr: Terms -> string) session` keeps the policy pure; the view passes the sheet lookup, the tests pass `english`, so the rendered English is byte-identical to before. Every sentence is its own term (no translation embedded in another; the earlier lower-case hazard is gone). Numbers are filled through `{0}`/`{1}`. `isGated` replaces `gateFor ... |> Option.isSome` in the page.
- 22 new `Terms` cases, drafted script-first in `Shared/Scripts/Localization.fsx` (7 tests, prints the cases and the sheet rows) and migrated after review.
- `Views/SessionGate.fs` and `Components/TitleBar.fs` read `LocalizationTerms` through the env; no prop changes.
- `Localization.fs`: comment fixes only (references to a `Scripts/Localization.fsx` that no longer existed).
- `SessionGatePolicyTests`: 15 → 32 (term-per-phase table with a naming translator, number filling, English defaults).

## Sheet rows (Term, English, Dutch; other languages empty → English fallback)

Paste into the "Localization" sheet of the demo workbook:

```tsv
Session Gate Opening	Opening your session	Uw sessie wordt geopend				
Session Gate Opening Text	Presenting the launch, attempt {0} of {1}.	De launch wordt aangeboden, poging {0} van {1}.				
Session Gate Resuming	Resuming your session	Uw sessie wordt hervat				
Session Gate Resuming Text	Checking for an open session.	Er wordt gecontroleerd op een open sessie.				
Session Gate Unreachable	GenPRES could not be reached	GenPRES is niet bereikbaar				
Session Gate Unreachable Text	The server did not answer after {0} attempts.	De server antwoordde niet na {0} pogingen.				
Session Gate Refused	GenPRES could not open your session	GenPRES kon uw sessie niet openen				
Session Gate Try Again Or Relaunch	Try again, or open GenPRES again from MainEHR.	Probeer opnieuw, of open GenPRES opnieuw vanuit MainEHR.				
Session Relaunch	Open GenPRES again from MainEHR.	Open GenPRES opnieuw vanuit MainEHR.				
Session Retry	Try again.	Probeer opnieuw.				
Session Refusal Expired	The launch has expired.	De launch is verlopen.				
Session Refusal Spent	This launch has already been used.	Deze launch is al gebruikt.				
Session Refusal Invalid	The launch is not valid.	De launch is niet geldig.				
Session Refusal No Browser Identity	Your browser could not be identified.	Uw browser kon niet worden geïdentificeerd.				
Session Refusal No Role	You have no role in GenPRES. You can continue without a launch: no patient is carried over.	U heeft geen rol in GenPRES. U kunt doorgaan zonder launch: er wordt geen patiënt overgenomen.				
Session Refusal Wrong Patient	The patient active in MainEHR is not the patient of this launch. Activate the right patient and open GenPRES again from MainEHR.	De patiënt die actief is in MainEHR is niet de patiënt van deze launch. Activeer de juiste patiënt en open GenPRES opnieuw vanuit MainEHR.				
Session Refusal Enrolment	A PIN has to be set before prescribing. Enrolment is not available yet. Open GenPRES again from MainEHR.	Er moet een pincode worden ingesteld voordat u kunt voorschrijven. Inschrijven is nog niet beschikbaar. Open GenPRES opnieuw vanuit MainEHR.				
Session Try Again	Try again	Probeer opnieuw				
Session Continue Without Launch	Continue without launch	Doorgaan zonder launch				
Session Close	Close session	Sessie sluiten				
Session Role Prescriber	Prescriber	Voorschrijver				
Session Role Reader	Reader	Lezer				
```

## Verification

- `dotnet run Build`, Fable compile of the client, `dotnet run ServerTests` (Shared.Tests 406, all suites green), Fantomas clean.
- Chrome, demo server, rows injected into the sheet response: `launch=no-role` → gate in English by default, Dutch after switching the language ("GenPRES kon uw sessie niet openen … Doorgaan zonder launch"); successful launch → title bar "Stub Prescriber (Voorschrijver)", menu "Sessie sluiten"; offline launch → "De server antwoordde niet na 3 pogingen. Probeer opnieuw, of open GenPRES opnieuw vanuit MainEHR." → online → "Probeer opnieuw" opens the session.

## Vibe coding disclosure

Drafted with Claude Code (script, policy, view wiring, tests); reviewed and migrated by hand, verified as above.

## Noted, not in scope

- On a launch URL the language ends up English (the `UrlChanged` handler defaults to English without `la=`), and the gate hides the language switcher. Pre-existing; a follow-up.
- Serving the Localization sheet through the server is plan 378 phase 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZWjibQUW8uqCVbfV4vDTf
