### PR TITLE
feat(server): default UI language from GENPRES_LANG

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,11 @@ GENPRES_PROD=0
 # Debug mode: 0=off, 1=on
 GENPRES_DEBUG=1
 
+# Default UI language until the url (`la=`) or the user chooses one.
+# ISO code en, nl, fr, de, es, it (any case); unset means nl. Any other value
+# refuses the start.
+GENPRES_LANG=nl
+
 # Password for admin operations (settings, log analysis, resource reload)
 # Left EMPTY on purpose: empty or unset means admin operations are disabled
 # (fail-closed). `dotnet run` copies this file to .env on a fresh clone, and

--- a/Build.fs
+++ b/Build.fs
@@ -530,6 +530,9 @@ Target.create
                 "GENPRES_URL_ID"
                 "-e"
                 "GENPRES_PASSWORD"
+                // optional: forwarded only when set in the caller's environment
+                "-e"
+                "GENPRES_LANG"
                 dockerImage
             ]
             "."

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1016,8 +1016,21 @@ GENPRES_URL_ID=<your-url-id>   # Google Sheets data URL ID (required; .env.examp
 GENPRES_LOG=i                  # Logging level: 0=off, d=debug, i=info, w=warning, e=error
 GENPRES_PROD=0                 # Production mode: 0=demo (safe default), 1=production data
 GENPRES_DEBUG=1                # Debug mode: 0=off, 1=on
+GENPRES_LANG=nl                # Default UI language: en, nl, fr, de, es, it — see below
 GENPRES_PASSWORD=<password>    # Admin password — see policy below
 ```
+
+#### Default language
+
+`GENPRES_LANG` is the UI language a browser starts in. The client asks the server for it at
+start-up (`getSettings`); until then, and when the server cannot be reached, the client falls
+back to Dutch, as it always did. Accepted values are the ISO 639-1 codes `en`, `nl`, `fr`, `de`,
+`es`, `it` in any case (the display names such as `Nederlands` work too). Unset or blank means
+`nl`; any other value makes the server refuse to start with a message naming the setting.
+
+The server default is the lowest rung: an `la=` parameter in the url wins over it, and so does a
+language the user picks in the title bar or the disclaimer. Navigating between pages keeps the
+current language; only a new `la=` changes it.
 
 #### Password policy
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -24,6 +24,8 @@ services:
       GENPRES_PROD: ${GENPRES_PROD:-0}
       GENPRES_LOG: ${GENPRES_LOG:-0}
       GENPRES_DEBUG: ${GENPRES_DEBUG:-0}
+      # Default UI language (en, nl, fr, de, es, it); empty = the server default, nl.
+      GENPRES_LANG: ${GENPRES_LANG:-}
     volumes:
       # Production reads *.cache, which the image does not ship. The host data/cache also
       # holds the *.demo files, so the mount is harmless in demo mode.

--- a/src/Informedica.GenPRES.Client/App.fs
+++ b/src/Informedica.GenPRES.Client/App.fs
@@ -52,6 +52,10 @@ module private Elmish =
             LogAnalysisReport: Deferred<string>
             // the launch Session (plan 409); Anonymous is the state every URL patient runs in
             Session: Session
+            // what the server was configured with: the default language, the demo flag
+            Settings: Deferred<Api.ServerSettings>
+            // the url or the User chose the language; the server default no longer applies
+            LanguageChosen: bool
         }
 
 
@@ -99,6 +103,7 @@ module private Elmish =
         | CloseSnackbar
         | CheckServer of AsyncOperationStatus<Result<string, exn>>
         | DismissServerError
+        | LoadSettings of AsyncOperationStatus<Result<Api.ServerSettings, exn>>
 
         | Login of password: string
         | LoadLoginResult of ApiResponse
@@ -126,6 +131,17 @@ module private Elmish =
                 return CheckServer(Finished(Ok result))
             with ex ->
                 return CheckServer(Finished(Error ex))
+        }
+        |> Cmd.fromAsync
+
+
+    let loadSettings =
+        async {
+            try
+                let! settings = serverApi.getSettings ()
+                return LoadSettings(Finished(Ok settings))
+            with ex ->
+                return LoadSettings(Finished(Error ex))
         }
         |> Cmd.fromAsync
 
@@ -332,16 +348,8 @@ module private Elmish =
                 | Some s when s = "pe" -> Some Parenteralia
                 | _ -> None
 
-            let lang =
-                match paramsMap |> Map.tryFind "la" with
-                | Some s when s = "en" -> Some Localization.English
-                | Some s when s = "du" -> Some Localization.Dutch
-                | Some s when s = "fr" -> Some Localization.French
-                | Some s when s = "gr" -> Some Localization.German
-                | Some s when s = "sp" -> Some Localization.Spanish
-                | Some s when s = "it" -> Some Localization.Italian
-                //                | Some s when s = "ch" -> Some Localization.Chinees // refact: to Chinese
-                | _ -> None
+            // ISO code, display name or the legacy codes (du, gr, sp): one parser with the server
+            let lang = paramsMap |> Map.tryFind "la" |> Option.bind Localization.tryParse
 
             let discl =
                 match paramsMap |> Map.tryFind "dc" with
@@ -453,6 +461,7 @@ module private Elmish =
             Hospitals = HasNotStartedYet
             Context =
                 {
+                    // the server default replaces this once LoadSettings resolves, unless the url chose
                     Localization = lang |> Option.defaultValue Localization.Dutch
                     Hospital = "UMCU"
                 }
@@ -469,6 +478,8 @@ module private Elmish =
             LogFiles = HasNotStartedYet
             LogAnalysisReport = HasNotStartedYet
             Session = Session.Anonymous
+            Settings = HasNotStartedYet
+            LanguageChosen = lang.IsSome
         }
 
 
@@ -511,6 +522,7 @@ module private Elmish =
                     | None -> Cmd.ofMsg (SessionMsg SessionMsg.Resume)
                     | Some _ -> launchCmd launchUrl
                     checkServer
+                    Cmd.ofMsg (LoadSettings Started)
                     Cmd.ofMsg (LoadNormalValues Started)
                     Cmd.ofMsg (LoadBolusMedication Started)
                     Cmd.ofMsg (LoadContinuousMedication Started)
@@ -680,6 +692,27 @@ module private Elmish =
 
         | DismissServerError -> { state with ServerError = None }, Cmd.none
 
+        | LoadSettings Started -> { state with Settings = InProgress }, loadSettings
+
+        | LoadSettings(Finished(Ok settings)) ->
+            // the server default counts until the url or the User chooses; a choice made while
+            // the settings were in flight wins
+            { state with
+                Settings = Resolved settings
+                IsDemo = settings.IsDemo
+                State.Context.Localization =
+                    if state.LanguageChosen then
+                        state.Context.Localization
+                    else
+                        settings.Language
+            },
+            Cmd.none
+
+        | LoadSettings(Finished(Error err)) ->
+            // no settings: the client keeps its own defaults, which is what it did before
+            Logging.error "cannot load the server settings" err
+            { state with Settings = HasNotStartedYet }, Cmd.none
+
         | Login password ->
             state,
             Api.LogAnalyzerCmd(Api.ValidatePassword password)
@@ -738,6 +771,7 @@ module private Elmish =
             { state with
                 ShowDisclaimer = true
                 State.Context.Localization = lang
+                LanguageChosen = true
             },
             Cmd.none
 
@@ -864,8 +898,10 @@ module private Elmish =
                             ctx
                             |> OrderContext.setMedication m.indication m.medication m.route m.form m.dosetype
                             |> Resolved
-                // State. prefix needed: disambiguates State.Context field from Global.Context type
-                State.Context.Localization = lang |> Option.defaultValue Localization.English
+                // State. prefix needed: disambiguates State.Context field from Global.Context type.
+                // Only an `la` parameter changes the language; a navigation keeps the current one
+                State.Context.Localization = lang |> Option.defaultValue state.Context.Localization
+                LanguageChosen = state.LanguageChosen || lang.IsSome
             },
             Cmd.batch
                 [

--- a/src/Informedica.GenPRES.Client/App.fs
+++ b/src/Informedica.GenPRES.Client/App.fs
@@ -54,7 +54,8 @@ module private Elmish =
             Session: Session
             // what the server was configured with: the default language, the demo flag
             Settings: Deferred<Api.ServerSettings>
-            // the url or the User chose the language; the server default no longer applies
+            // the url or the User chose the language (LanguagePolicy); the server default no
+            // longer applies. The language itself lives in Context, where the views read it
             LanguageChosen: bool
         }
 
@@ -462,7 +463,7 @@ module private Elmish =
             Context =
                 {
                     // the server default replaces this once LoadSettings resolves, unless the url chose
-                    Localization = lang |> Option.defaultValue Localization.Dutch
+                    Localization = (LanguagePolicy.Language.initial lang).Current
                     Hospital = "UMCU"
                 }
             IsDemo = false
@@ -479,7 +480,22 @@ module private Elmish =
             LogAnalysisReport = HasNotStartedYet
             Session = Session.Anonymous
             Settings = HasNotStartedYet
-            LanguageChosen = lang.IsSome
+            LanguageChosen = (LanguagePolicy.Language.initial lang).Chosen
+        }
+
+
+    /// The language as LanguagePolicy sees it, and the state after the policy answered.
+    let languageOf (state: State) : LanguagePolicy.Language =
+        {
+            Current = state.Context.Localization
+            Chosen = state.LanguageChosen
+        }
+
+
+    let withLanguage (language: LanguagePolicy.Language) (state: State) =
+        { state with
+            State.Context.Localization = language.Current
+            LanguageChosen = language.Chosen
         }
 
 
@@ -696,16 +712,12 @@ module private Elmish =
 
         | LoadSettings(Finished(Ok settings)) ->
             // the server default counts until the url or the User chooses; a choice made while
-            // the settings were in flight wins
+            // the settings were in flight wins (LanguagePolicy.onServerDefault)
             { state with
                 Settings = Resolved settings
                 IsDemo = settings.IsDemo
-                State.Context.Localization =
-                    if state.LanguageChosen then
-                        state.Context.Localization
-                    else
-                        settings.Language
-            },
+            }
+            |> withLanguage (languageOf state |> LanguagePolicy.Language.onServerDefault settings.Language),
             Cmd.none
 
         | LoadSettings(Finished(Error err)) ->
@@ -768,11 +780,8 @@ module private Elmish =
         | AcceptDisclaimer -> { state with ShowDisclaimer = false }, Cmd.none
 
         | UpdateLanguage lang ->
-            { state with
-                ShowDisclaimer = true
-                State.Context.Localization = lang
-                LanguageChosen = true
-            },
+            { state with ShowDisclaimer = true }
+            |> withLanguage (languageOf state |> LanguagePolicy.Language.choose lang),
             Cmd.none
 
         | UpdateHospital hosp ->
@@ -879,6 +888,9 @@ module private Elmish =
 
             let pat = if anonymous then pat else state.Patient
 
+            // only an `la` parameter changes the language; a navigation keeps the current one
+            let language = languageOf state |> LanguagePolicy.Language.onUrl lang
+
             { state with
                 ShowDisclaimer = discl
                 Page = page |> Option.defaultValue LifeSupport
@@ -898,10 +910,9 @@ module private Elmish =
                             ctx
                             |> OrderContext.setMedication m.indication m.medication m.route m.form m.dosetype
                             |> Resolved
-                // State. prefix needed: disambiguates State.Context field from Global.Context type.
-                // Only an `la` parameter changes the language; a navigation keeps the current one
-                State.Context.Localization = lang |> Option.defaultValue state.Context.Localization
-                LanguageChosen = state.LanguageChosen || lang.IsSome
+                // State. prefix needed: disambiguates State.Context field from Global.Context type
+                State.Context.Localization = language.Current
+                LanguageChosen = language.Chosen
             },
             Cmd.batch
                 [

--- a/src/Informedica.GenPRES.Client/Informedica.GenPRES.Client.fsproj
+++ b/src/Informedica.GenPRES.Client/Informedica.GenPRES.Client.fsproj
@@ -8,6 +8,7 @@
     <Compile Include="Extensions.fs" />
     <Compile Include="Utils.fs" />
     <Compile Include="Global.fs" />
+    <Compile Include="LanguagePolicy.fs" />
     <Compile Include="SessionMachine.fs" />
     <Compile Include="SessionGatePolicy.fs" />
     <Compile Include="Keys.fs" />

--- a/src/Informedica.GenPRES.Client/LanguagePolicy.fs
+++ b/src/Informedica.GenPRES.Client/LanguagePolicy.fs
@@ -1,0 +1,59 @@
+/// <summary>
+/// Which UI language the client shows, and why: the url's <c>la</c> parameter and the User's
+/// choice outrank the server default (<c>GENPRES_LANG</c>), which outranks the built-in
+/// fallback. Pure F#, no React, so it runs under Expecto; App.fs applies it.
+/// </summary>
+module LanguagePolicy
+
+open Shared.Localization
+
+
+/// The current language and whether the url or the User chose it. Once chosen, the server
+/// default no longer applies, whichever order the messages arrive in.
+type Language =
+    {
+        Current: Locales
+        Chosen: bool
+    }
+
+
+module Language =
+
+    /// Until the server settings arrive, and when they never do: Dutch, the client's default.
+    let fallback = Dutch
+
+
+    /// At start: the url's language, else the fallback, not yet chosen.
+    let initial (url: Locales option) =
+        {
+            Current = url |> Option.defaultValue fallback
+            Chosen = url.IsSome
+        }
+
+
+    /// A navigation: only an `la` parameter changes the language; without one the current
+    /// language stays, chosen or not.
+    let onUrl (url: Locales option) (language: Language) =
+        match url with
+        | Some l ->
+            {
+                Current = l
+                Chosen = true
+            }
+        | None -> language
+
+
+    /// The User picks a language.
+    let choose (l: Locales) (_: Language) =
+        {
+            Current = l
+            Chosen = true
+        }
+
+
+    /// The server default arrives: it applies unless the url or the User already chose.
+    let onServerDefault (l: Locales) (language: Language) =
+        if language.Chosen then
+            language
+        else
+            { language with Current = l }

--- a/src/Informedica.GenPRES.Server/Scripts/Settings.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/Settings.fsx
@@ -1,0 +1,254 @@
+// Server default language (GENPRES_LANG) and the settings the client learns from the server.
+//
+// Script-first draft (script-only policy) of:
+//   - `Config.Settings.Lang` (raw, `nonBlank`), `Config.language` (derived, `Result`), the
+//     `validateStartup` extension, the banner line — to migrate into `Server.fs`, module `Config`;
+//   - `ServerSettings` and `getSettings` — to migrate into `Shared/Api.fs` next to `IServerApi`
+//     (the record cannot be extended here, so `getSettings` is sketched as a function);
+//   - `Config.toServerSettings` — the DMZ mapping from the env-shaped `Settings` to the contract.
+// `Server.fs` itself is not loaded (Saturn host); `Config` is restated here with only the fields
+// that matter, following the source shape.
+//
+// Run: `dotnet fsi Settings.fsx` from this directory (build the solution first).
+
+#I __SOURCE_DIRECTORY__
+#r "nuget: Expecto, 10.2.3"
+
+#load "load.fsx"
+
+open Shared.Localization
+
+
+/// One parser for env value, url parameter and sheet header (Shared/Scripts/Localization.fsx).
+module Localization =
+
+    let tryParse (s: string) : Locales option =
+        if isNull s then
+            None
+        else
+            match s.Trim().ToLower() with
+            | "en" -> Some English
+            | "nl"
+            | "du" -> Some Dutch
+            | "fr" -> Some French
+            | "de"
+            | "gr" -> Some German
+            | "es"
+            | "sp" -> Some Spanish
+            | "it" -> Some Italian
+            | s -> tryFromString s
+
+
+/// What the client learns from the server at start-up (→ Shared/Api.fs). PR 2 adds `Scope`.
+type ServerSettings =
+    {
+        // GENPRES_LANG: the UI language until the url or the User chooses one
+        Language: Locales
+        // not GENPRES_PROD: demo data, the title suffix
+        IsDemo: bool
+    }
+
+
+module Config =
+
+    /// The GENPRES_* settings as the server uses them (only the fields this draft touches).
+    type Settings =
+        {
+            // GENPRES_PROD = "1"
+            IsProd: bool
+            // GENPRES_URL_ID; None when unset or blank
+            UrlId: string option
+            // GENPRES_PASSWORD; None when unset or blank
+            Password: string option
+            // GENPRES_LANG, raw; None when unset or blank. Parsed by `language`.
+            Lang: string option
+        }
+
+
+    let nonBlank (raw: string option) =
+        raw |> Option.filter (System.String.IsNullOrWhiteSpace >> not)
+
+
+    let minProductionPasswordLength = 16
+
+
+    let validateProductionPassword (isProd: bool) (password: string option) : Result<unit, string> =
+        if not isProd then
+            Ok()
+        else
+            match password |> nonBlank with
+            | None -> Error "GENPRES_PROD=1 but GENPRES_PASSWORD is not set (or is empty)."
+            | Some pwd when pwd.Length < minProductionPasswordLength ->
+                Error $"GENPRES_PROD=1 but GENPRES_PASSWORD is shorter than %i{minProductionPasswordLength} characters."
+            | Some _ -> Ok()
+
+
+    /// The default UI language. Unset means Dutch, the client's default until now; a value
+    /// that is not a language is the message the server refuses to start with.
+    let defaultLanguage = Dutch
+
+
+    /// <summary>
+    /// The UI language from <c>GENPRES_LANG</c>: <c>defaultLanguage</c> when unset, the parsed
+    /// language when it is one (ISO code, display name or legacy url code, any case), otherwise
+    /// the start-up error naming the setting and the value.
+    /// </summary>
+    let language (settings: Settings) : Result<Locales, string> =
+        match settings.Lang with
+        | None -> Ok defaultLanguage
+        | Some raw ->
+            match Localization.tryParse raw with
+            | Some l -> Ok l
+            | None ->
+                let accepted = languages |> Array.map (toShortCode >> _.ToLower()) |> String.concat ", "
+
+                Error
+                    $"GENPRES_LANG=%s{raw} is not a language. Accepted: %s{accepted} \
+                      (or a display name such as Nederlands). Unset it for the default (%s{toShortCode defaultLanguage |> _.ToLower()})."
+
+
+    /// <summary>
+    /// Every start-up guard in one place: the production password policy, the language, then
+    /// the presence of <c>GENPRES_URL_ID</c>. <c>Ok</c> carries the URL ID the host needs.
+    /// </summary>
+    let validateStartup (settings: Settings) : Result<string, string> =
+        validateProductionPassword settings.IsProd settings.Password
+        |> Result.bind (fun () -> language settings |> Result.map ignore)
+        |> Result.bind (fun () ->
+            match settings.UrlId with
+            | Some urlId -> Ok urlId
+            | None -> Error "No GENPRES_URL_ID (or value is empty)"
+        )
+
+
+    let fromEnv (getEnv: string -> string option) : Settings =
+        {
+            IsProd =
+                getEnv "GENPRES_PROD"
+                |> Option.map (fun v -> v = "1")
+                |> Option.defaultValue false
+            UrlId = getEnv "GENPRES_URL_ID" |> nonBlank
+            Password = getEnv "GENPRES_PASSWORD" |> nonBlank
+            Lang = getEnv "GENPRES_LANG" |> nonBlank
+        }
+
+
+    /// Banner display string for the language: the derived value, or the raw one when it is
+    /// not a language (the refusal follows from `validateStartup`).
+    let displayLanguage (settings: Settings) =
+        match language settings with
+        | Ok l -> $"{toShortCode l |> _.ToLower()} ({toString l})"
+        | Error _ ->
+            let raw = settings.Lang |> Option.defaultValue ""
+            $"%s{raw} (NOT A LANGUAGE)"
+
+
+    /// <summary>
+    /// The settings the client learns, mapped in the DMZ from the env-shaped record. Call after
+    /// <c>validateStartup</c>: an invalid language never reaches here, so the fallback is dead.
+    /// </summary>
+    let toServerSettings (settings: Settings) : ServerSettings =
+        {
+            Language = language settings |> Result.defaultValue defaultLanguage
+            IsDemo = not settings.IsProd
+        }
+
+
+/// `IServerApi.getSettings` (→ CompositionRoot.compose settings env cookie): the value the host
+/// computed once, answered per request, logged like the other calls.
+let getSettings (settings: ServerSettings) : unit -> Async<ServerSettings> =
+    fun () ->
+        async {
+            Informedica.Utils.Lib.ConsoleWriter.NewLineNoTime.writeInfoMessage "Processing settings"
+            return settings
+        }
+
+
+open Expecto
+open Expecto.Flip
+
+
+let getEnv (m: Map<string, string>) key = m |> Map.tryFind key
+
+let settingsOf m = Config.fromEnv (getEnv m)
+
+
+let tests =
+    testList
+        "GENPRES_LANG"
+        [
+            test "unset is the default language, Dutch" {
+                Map.empty |> settingsOf |> Config.language |> Expect.equal "default" (Ok Dutch)
+            }
+
+            test "blank is unset" {
+                let s = Map [ "GENPRES_LANG", "  " ] |> settingsOf
+                s.Lang |> Expect.isNone "blank"
+                s |> Config.language |> Expect.equal "default" (Ok Dutch)
+            }
+
+            testList
+                "accepted spellings"
+                [
+                    for raw, l in [ "en", English; "NL", Dutch; " fr ", French; "de", German; "es", Spanish; "it", Italian; "gr", German; "sp", Spanish; "du", Dutch; "Nederlands", Dutch ] do
+                        test $"'{raw}'" {
+                            Map [ "GENPRES_LANG", raw ] |> settingsOf |> Config.language |> Expect.equal raw (Ok l)
+                        }
+                ]
+
+            test "a value that is not a language is a start-up error naming the setting and the value" {
+                match Map [ "GENPRES_LANG", "klingon"; "GENPRES_URL_ID", "id" ] |> settingsOf |> Config.validateStartup with
+                | Error msg ->
+                    msg |> Expect.stringContains "setting" "GENPRES_LANG"
+                    msg |> Expect.stringContains "value" "klingon"
+                    msg |> Expect.stringContains "accepted" "nl"
+                | Ok _ -> failtest "expected Error"
+            }
+
+            test "the language is checked after the password and before the url id" {
+                match Map [ "GENPRES_PROD", "1"; "GENPRES_LANG", "klingon" ] |> settingsOf |> Config.validateStartup with
+                | Error msg -> msg |> Expect.stringContains "password first" "GENPRES_PASSWORD"
+                | Ok _ -> failtest "expected Error"
+
+                match Map [ "GENPRES_LANG", "klingon" ] |> settingsOf |> Config.validateStartup with
+                | Error msg -> msg |> Expect.stringContains "language before url id" "GENPRES_LANG"
+                | Ok _ -> failtest "expected Error"
+            }
+
+            test "a valid language still starts with the url id" {
+                Map [ "GENPRES_LANG", "en"; "GENPRES_URL_ID", "id" ]
+                |> settingsOf
+                |> Config.validateStartup
+                |> Expect.equal "Ok with the url id" (Ok "id")
+            }
+
+            test "toServerSettings carries the language and the demo flag" {
+                Map [ "GENPRES_LANG", "en" ]
+                |> settingsOf
+                |> Config.toServerSettings
+                |> Expect.equal "demo, English" { Language = English; IsDemo = true }
+
+                Map [ "GENPRES_PROD", "1" ]
+                |> settingsOf
+                |> Config.toServerSettings
+                |> Expect.equal "prod, Dutch" { Language = Dutch; IsDemo = false }
+            }
+
+            test "the banner shows the derived language, or flags the raw value" {
+                Map [ "GENPRES_LANG", "EN" ] |> settingsOf |> Config.displayLanguage |> Expect.equal "derived" "en (English)"
+
+                Map [ "GENPRES_LANG", "klingon" ]
+                |> settingsOf
+                |> Config.displayLanguage
+                |> Expect.equal "flagged" "klingon (NOT A LANGUAGE)"
+            }
+
+            testAsync "getSettings answers what the host computed" {
+                let s = { Language = French; IsDemo = false }
+                let! answer = getSettings s ()
+                answer |> Expect.equal "same value" s
+            }
+        ]
+
+
+runTestsWithCLIArgs [] [||] tests |> ignore

--- a/src/Informedica.GenPRES.Server/Server.fs
+++ b/src/Informedica.GenPRES.Server/Server.fs
@@ -46,6 +46,8 @@ module Config =
             Log: string
             // GENPRES_DEBUG, raw, banner only
             Debug: string
+            // GENPRES_LANG, raw; None when unset or blank. Parsed by `language`.
+            Lang: string option
         }
 
 
@@ -141,18 +143,70 @@ module Config =
             | Some _ -> Ok()
 
 
+    /// The default UI language: Dutch, the client's own default until now.
+    let defaultLanguage = Shared.Localization.Dutch
+
+
     /// <summary>
-    /// Every start-up guard in one place: the production password policy,
-    /// then the presence of <c>GENPRES_URL_ID</c>. <c>Ok</c> carries the URL
-    /// ID the host needs; <c>Error</c> is the message the server exits with.
+    /// The UI language from <c>GENPRES_LANG</c>: <c>defaultLanguage</c> when
+    /// unset, the parsed language when the value is one (ISO code, display
+    /// name or legacy url code, any case), otherwise the start-up error naming
+    /// the setting and the value.
+    /// </summary>
+    let language (settings: Settings) : Result<Shared.Localization.Locales, string> =
+        match settings.Lang with
+        | None -> Ok defaultLanguage
+        | Some raw ->
+            match Shared.Localization.tryParse raw with
+            | Some l -> Ok l
+            | None ->
+                let accepted =
+                    Shared.Localization.languages
+                    |> Array.map (Shared.Localization.toShortCode >> _.ToLower())
+                    |> String.concat ", "
+
+                let fallback = defaultLanguage |> Shared.Localization.toShortCode |> _.ToLower()
+
+                Error
+                    $"GENPRES_LANG=%s{raw} is not a language. Accepted: %s{accepted} \
+                      (or a display name such as Nederlands). Unset it for the default (%s{fallback})."
+
+
+    /// Banner display string for the language: the derived value, or the raw
+    /// one flagged when it is not a language (validateStartup then refuses).
+    let displayLanguage (settings: Settings) =
+        match language settings with
+        | Ok l -> $"{l |> Shared.Localization.toShortCode |> _.ToLower()} ({l |> Shared.Localization.toString})"
+        | Error _ ->
+            let raw = settings.Lang |> Option.defaultValue ""
+            $"%s{raw} (NOT A LANGUAGE)"
+
+
+    /// <summary>
+    /// Every start-up guard in one place: the production password policy, the
+    /// language, then the presence of <c>GENPRES_URL_ID</c>. <c>Ok</c> carries
+    /// the URL ID the host needs; <c>Error</c> is the message the server exits with.
     /// </summary>
     let validateStartup (settings: Settings) : Result<string, string> =
         validateProductionPassword settings.IsProd settings.Password
+        |> Result.bind (fun () -> language settings |> Result.map ignore)
         |> Result.bind (fun () ->
             match settings.UrlId with
             | Some urlId -> Ok urlId
             | None -> Error "No GENPRES_URL_ID (or value is empty)"
         )
+
+
+    /// <summary>
+    /// The settings the client learns, mapped here in the DMZ from the
+    /// env-shaped record. Call after <c>validateStartup</c>: an invalid
+    /// language never reaches this point, so the fallback is dead.
+    /// </summary>
+    let toServerSettings (settings: Settings) : Shared.Api.ServerSettings =
+        {
+            Language = language settings |> Result.defaultValue defaultLanguage
+            IsDemo = not settings.IsProd
+        }
 
 
     /// Reads every setting through <c>getEnv</c>. Pure: pass <c>Env.getItem</c>
@@ -169,6 +223,7 @@ module Config =
             TrustedProxies = getEnv "GENPRES_TRUSTED_PROXIES" |> parseTrustedProxies
             Log = getEnv "GENPRES_LOG" |> Option.defaultValue "0"
             Debug = getEnv "GENPRES_DEBUG" |> Option.defaultValue "i"
+            Lang = getEnv "GENPRES_LANG" |> nonBlank
         }
 
 
@@ -182,6 +237,7 @@ GENPRES_URL_ID = {settings.UrlId |> redactUrlId}
 GENPRES_LOG ={settings.Log}
 GENPRES_PROD = {if settings.IsProd then "1" else "0"}
 GENPRES_DEBUG = {settings.Debug}
+GENPRES_LANG = {settings |> displayLanguage}
 GENPRES_PASSWORD = {settings.Password |> displayPassword}
 
 === System Info ===
@@ -483,9 +539,12 @@ module Host =
             else
                 env
 
+        // what the client learns: computed once here, answered per request
+        let serverSettings = Config.toServerSettings settings
+
         let webApi =
             Remoting.createApi ()
-            |> Remoting.fromContext (fun ctx -> createServerApi env (Http.sessionCookie ctx))
+            |> Remoting.fromContext (fun ctx -> createServerApi serverSettings env (Http.sessionCookie ctx))
             |> Remoting.withRouteBuilder routerPaths
             |> Remoting.buildHttpHandler
 

--- a/src/Informedica.GenPRES.Server/ServerApi.ApiImpl.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.ApiImpl.fs
@@ -5,5 +5,10 @@ namespace ServerApi
 module ApiImpl =
 
     /// Creates the IServerApi implementation for one request using the composition root.
-    let createServerApi (env: AppEnv) (cookie: SessionCookie) : Shared.Api.IServerApi =
-        CompositionRoot.compose env cookie
+    let createServerApi
+        (settings: Shared.Api.ServerSettings)
+        (env: AppEnv)
+        (cookie: SessionCookie)
+        : Shared.Api.IServerApi
+        =
+        CompositionRoot.compose settings env cookie

--- a/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
@@ -49,8 +49,9 @@ module CompositionRoot =
         }
 
 
-    /// The api of one request: the env is built once per host, the cookie once per request.
-    let compose (env: AppEnv) (cookie: SessionCookie) : IServerApi =
+    /// The api of one request: the settings and the env are built once per host, the cookie
+    /// once per request.
+    let compose (settings: ServerSettings) (env: AppEnv) (cookie: SessionCookie) : IServerApi =
         {
             processCommand =
                 fun cmd ->
@@ -81,6 +82,13 @@ module CompositionRoot =
                         let! response = processSession env cookie cmd
                         writeInfoMessage $"Finished processing session: {cmd |> SessionCommand.toString}"
                         return response
+                    }
+
+            getSettings =
+                fun () ->
+                    async {
+                        writeInfoMessage "Processing settings"
+                        return settings
                     }
 
             testApi = fun () -> async { return "Hello world!" }

--- a/src/Informedica.GenPRES.Shared/Api.fs
+++ b/src/Informedica.GenPRES.Shared/Api.fs
@@ -198,6 +198,16 @@ module Api =
     let routerPaths typeName method = $"/api/%s{typeName}/%s{method}"
 
 
+    /// What the client learns from the server at start-up: how the server was configured.
+    type ServerSettings =
+        {
+            // GENPRES_LANG: the UI language until the url or the User chooses one
+            Language: Localization.Locales
+            // not GENPRES_PROD: demo data, shown as the title suffix
+            IsDemo: bool
+        }
+
+
     /// A type that specifies the communication protocol between client and server
     /// to learn more read the docs at https://zaid-ajaj.github.io/Fable.Remoting/src/basics.html
     type IServerApi =
@@ -205,5 +215,6 @@ module Api =
             processCommand: Command -> Async<Result<Response, string[]>>
             processLaunch: LaunchCommand -> Async<LaunchOutcome>
             processSession: SessionCommand -> Async<SessionResponse>
+            getSettings: unit -> Async<ServerSettings>
             testApi: unit -> Async<string>
         }

--- a/src/Informedica.GenPRES.Shared/Localization.fs
+++ b/src/Informedica.GenPRES.Shared/Localization.fs
@@ -291,7 +291,8 @@ module Localization =
     /// <c>es</c>, <c>it</c>), a display name (<c>English</c>, <c>Nederlands</c>, ...) or one of
     /// the client's legacy url codes (<c>du</c>, <c>gr</c>, <c>sp</c>). Case and surrounding
     /// whitespace do not matter; anything else, including null, is <c>None</c>. One parser for
-    /// the <c>GENPRES_LANG</c> setting, the <c>la</c> url parameter and the sheet header.
+    /// the <c>GENPRES_LANG</c> setting and the <c>la</c> url parameter. The sheet header keeps
+    /// <c>tryFromString</c>: display names only.
     /// </summary>
     let tryParse (s: string) : Locales option =
         if isNull s then

--- a/src/Informedica.GenPRES.Shared/Localization.fs
+++ b/src/Informedica.GenPRES.Shared/Localization.fs
@@ -286,6 +286,30 @@ module Localization =
         | _ -> None
 
 
+    /// <summary>
+    /// Parses a language given as an ISO 639-1 code (<c>en</c>, <c>nl</c>, <c>fr</c>, <c>de</c>,
+    /// <c>es</c>, <c>it</c>), a display name (<c>English</c>, <c>Nederlands</c>, ...) or one of
+    /// the client's legacy url codes (<c>du</c>, <c>gr</c>, <c>sp</c>). Case and surrounding
+    /// whitespace do not matter; anything else, including null, is <c>None</c>. One parser for
+    /// the <c>GENPRES_LANG</c> setting, the <c>la</c> url parameter and the sheet header.
+    /// </summary>
+    let tryParse (s: string) : Locales option =
+        if isNull s then
+            None
+        else
+            match s.Trim().ToLower() with
+            | "en" -> Some English
+            | "nl"
+            | "du" -> Some Dutch
+            | "fr" -> Some French
+            | "de"
+            | "gr" -> Some German
+            | "es"
+            | "sp" -> Some Spanish
+            | "it" -> Some Italian
+            | s -> tryFromString s
+
+
     /// Parses a `string[][]` from `Csv.parseCSV` into a `TranslationMap`.
     ///
     /// The first row is expected to contain column headers. Any column whose

--- a/src/Informedica.GenPRES.Shared/Scripts/Localization.fsx
+++ b/src/Informedica.GenPRES.Shared/Scripts/Localization.fsx
@@ -136,8 +136,77 @@ let printTsv () =
     rows |> Array.iter (fun r -> r |> String.concat "\t" |> printfn "%s")
 
 
+// ---------------------------------------------------------------------------------------------
+// One language vocabulary (GENPRES_LANG, plan: server default language). Today three spellings
+// of the same six languages exist: the ISO short codes of `toShortCode`, the display names of
+// `tryFromString`, and the url codes of the client's `la` parameter (`en du fr gr sp it`).
+// `tryParse` accepts all of them, so the env value and the url parameter share one parser.
+// ---------------------------------------------------------------------------------------------
+
+module Localization =
+
+    open Shared.Localization
+
+    /// Parses a language given as an ISO 639-1 code (`en`, `nl`, `fr`, `de`, `es`, `it`), a
+    /// display name (`English`, `Nederlands`, ...) or one of the client's legacy url codes
+    /// (`du`, `gr`, `sp`). Case and surrounding whitespace do not matter; anything else is None.
+    let tryParse (s: string) : Locales option =
+        if isNull s then
+            None
+        else
+            match s.Trim().ToLower() with
+            | "en" -> Some English
+            | "nl"
+            | "du" -> Some Dutch
+            | "fr" -> Some French
+            | "de"
+            | "gr" -> Some German
+            | "es"
+            | "sp" -> Some Spanish
+            | "it" -> Some Italian
+            | s -> tryFromString s
+
+
 open Expecto
 open Expecto.Flip
+
+
+let parseTests =
+    testList
+        "Localization.tryParse"
+        [
+            test "every locale round-trips through its short code, upper or lower case" {
+                for l in languages do
+                    l |> toShortCode |> Localization.tryParse |> Expect.equal $"{l} upper" (Some l)
+
+                    l
+                    |> toShortCode
+                    |> _.ToLower()
+                    |> Localization.tryParse
+                    |> Expect.equal $"{l} lower" (Some l)
+            }
+
+            test "every locale round-trips through its display name" {
+                for l in languages do
+                    l |> toString |> Localization.tryParse |> Expect.equal $"{l}" (Some l)
+            }
+
+            testList
+                "the client's legacy url codes"
+                [
+                    for code, l in [ "en", English; "du", Dutch; "fr", French; "gr", German; "sp", Spanish; "it", Italian ] do
+                        test code { code |> Localization.tryParse |> Expect.equal code (Some l) }
+                ]
+
+            test "whitespace is ignored" {
+                "  nl " |> Localization.tryParse |> Expect.equal "padded" (Some Dutch)
+            }
+
+            test "unknown, empty and null are None" {
+                for s in [ "xx"; ""; " "; "dutch"; null ] do
+                    s |> Localization.tryParse |> Expect.isNone $"'{s}'"
+            }
+        ]
 
 
 let tests =
@@ -203,4 +272,4 @@ let tests =
         ]
 
 
-runTestsWithCLIArgs [] [||] tests |> ignore
+runTestsWithCLIArgs [] [||] (testList "Localization.fsx" [ tests; parseTests ]) |> ignore

--- a/src/Informedica.GenPRES.Shared/Scripts/Localization.fsx
+++ b/src/Informedica.GenPRES.Shared/Scripts/Localization.fsx
@@ -140,7 +140,8 @@ let printTsv () =
 // One language vocabulary (GENPRES_LANG, plan: server default language). Today three spellings
 // of the same six languages exist: the ISO short codes of `toShortCode`, the display names of
 // `tryFromString`, and the url codes of the client's `la` parameter (`en du fr gr sp it`).
-// `tryParse` accepts all of them, so the env value and the url parameter share one parser.
+// `tryParse` accepts all of them, so the env value and the url parameter share one parser (the
+// sheet header keeps `tryFromString`: display names only).
 // ---------------------------------------------------------------------------------------------
 
 module Localization =

--- a/tests/Informedica.GenPRES.Server.Tests/ConfigTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/ConfigTests.fs
@@ -160,6 +160,7 @@ let fromEnvTests =
                 s.Password |> Expect.isNone "no password"
                 s.TrustedProxies |> Expect.equal "loopback" loopback
                 s.Log |> Expect.equal "log" "0"
+                s.Lang |> Expect.isNone "no language"
             }
 
             test "reads every setting" {
@@ -173,6 +174,7 @@ let fromEnvTests =
                             "GENPRES_TRUSTED_PROXIES", "10.0.0.5"
                             "GENPRES_LOG", "d"
                             "GENPRES_DEBUG", "1"
+                            "GENPRES_LANG", "en"
                         ]
 
                 let s = Config.fromEnv (getEnv env)
@@ -186,6 +188,7 @@ let fromEnvTests =
 
                 s.Log |> Expect.equal "log" "d"
                 s.Debug |> Expect.equal "debug" "1"
+                s.Lang |> Expect.equal "language" (Some "en")
             }
 
             test "blank secrets are treated as unset" {
@@ -193,6 +196,119 @@ let fromEnvTests =
                 let s = Config.fromEnv (getEnv env)
                 s.UrlId |> Expect.isNone "blank url id"
                 s.Password |> Expect.isNone "blank password"
+            }
+
+            test "a blank language is unset" {
+                let s = Config.fromEnv (getEnv (Map [ "GENPRES_LANG", "  " ]))
+                s.Lang |> Expect.isNone "blank language"
+            }
+        ]
+
+
+let languageTests =
+    let settings (m: Map<string, string>) =
+        Config.fromEnv (fun key -> m |> Map.tryFind key)
+
+    testList
+        "GENPRES_LANG"
+        [
+            test "unset is Dutch, the client's default until now" {
+                Map.empty
+                |> settings
+                |> Config.language
+                |> Expect.equal "default" (Ok Shared.Localization.Dutch)
+            }
+
+            testList
+                "accepted spellings: ISO code, display name, legacy url code, any case"
+                [
+                    for raw, lang in
+                        [
+                            "en", Shared.Localization.English
+                            "NL", Shared.Localization.Dutch
+                            " fr ", Shared.Localization.French
+                            "de", Shared.Localization.German
+                            "es", Shared.Localization.Spanish
+                            "it", Shared.Localization.Italian
+                            "du", Shared.Localization.Dutch
+                            "gr", Shared.Localization.German
+                            "sp", Shared.Localization.Spanish
+                            "Nederlands", Shared.Localization.Dutch
+                        ] do
+                        test $"'{raw}'" {
+                            Map [ "GENPRES_LANG", raw ]
+                            |> settings
+                            |> Config.language
+                            |> Expect.equal raw (Ok lang)
+                        }
+                ]
+
+            test "a value that is not a language refuses the start, naming the setting and the value" {
+                match
+                    Map [ "GENPRES_LANG", "klingon"; "GENPRES_URL_ID", "sheet-id" ]
+                    |> settings
+                    |> Config.validateStartup
+                with
+                | Error msg ->
+                    msg |> Expect.stringContains "setting" "GENPRES_LANG"
+                    msg |> Expect.stringContains "value" "klingon"
+                    msg |> Expect.stringContains "accepted values" "nl"
+                | Ok _ -> failtest "expected Error"
+            }
+
+            test "the language is checked after the password and before the url id" {
+                match
+                    Map [ "GENPRES_PROD", "1"; "GENPRES_LANG", "klingon" ]
+                    |> settings
+                    |> Config.validateStartup
+                with
+                | Error msg -> msg |> Expect.stringContains "password first" "GENPRES_PASSWORD"
+                | Ok _ -> failtest "expected Error"
+
+                match Map [ "GENPRES_LANG", "klingon" ] |> settings |> Config.validateStartup with
+                | Error msg -> msg |> Expect.stringContains "language before the url id" "GENPRES_LANG"
+                | Ok _ -> failtest "expected Error"
+            }
+
+            test "a valid language starts with the url id" {
+                Map [ "GENPRES_LANG", "en"; "GENPRES_URL_ID", "sheet-id" ]
+                |> settings
+                |> Config.validateStartup
+                |> Expect.equal "Ok with the url id" (Ok "sheet-id")
+            }
+
+            test "toServerSettings carries the language and the demo flag" {
+                Map [ "GENPRES_LANG", "en" ]
+                |> settings
+                |> Config.toServerSettings
+                |> Expect.equal
+                    "demo, English"
+                    {
+                        Shared.Api.ServerSettings.Language = Shared.Localization.English
+                        IsDemo = true
+                    }
+
+                Map [ "GENPRES_PROD", "1" ]
+                |> settings
+                |> Config.toServerSettings
+                |> Expect.equal
+                    "production, Dutch"
+                    {
+                        Shared.Api.ServerSettings.Language = Shared.Localization.Dutch
+                        IsDemo = false
+                    }
+            }
+
+            test "the banner shows the derived language, or flags the raw value" {
+                Map [ "GENPRES_LANG", "EN" ]
+                |> settings
+                |> Config.displayLanguage
+                |> Expect.equal "derived" "en (English)"
+
+                Map [ "GENPRES_LANG", "klingon" ]
+                |> settings
+                |> Config.displayLanguage
+                |> Expect.equal "flagged" "klingon (NOT A LANGUAGE)"
             }
         ]
 
@@ -207,4 +323,5 @@ let tests =
             validateStartupTests
             redactionTests
             fromEnvTests
+            languageTests
         ]

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -535,6 +535,19 @@ module SessionStubTests =
         testList
             "processLaunch and processSession"
             [
+                testAsync "getSettings answers the settings the host composed with" {
+                    let settings =
+                        {
+                            ServerSettings.Language = Shared.Localization.French
+                            IsDemo = false
+                        }
+
+                    let cookie, _ = memoryCookie None
+                    let api = CompositionRoot.compose settings (envWithStub ()) cookie
+                    let! answer = api.getSettings ()
+                    answer |> Expect.equal "same value" settings
+                }
+
                 testAsync "PresentLaunch: Opened writes the session id to the cookie and returns the session without it" {
                     let env = envWithStub ()
                     let cookie, held = memoryCookie None

--- a/tests/Informedica.GenPRES.Shared.Tests/Informedica.GenPRES.Shared.Tests.fsproj
+++ b/tests/Informedica.GenPRES.Shared.Tests/Informedica.GenPRES.Shared.Tests.fsproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <Compile Include="AgeTests.fs" />
+    <Compile Include="LocalizationTests.fs" />
     <Compile Include="Tests.fs" />
     <!-- the client session state machine is pure F#; linked in so it runs under Expecto -->
     <Compile Include="..\..\src\Informedica.GenPRES.Client\SessionMachine.fs" />

--- a/tests/Informedica.GenPRES.Shared.Tests/Informedica.GenPRES.Shared.Tests.fsproj
+++ b/tests/Informedica.GenPRES.Shared.Tests/Informedica.GenPRES.Shared.Tests.fsproj
@@ -13,6 +13,8 @@
   <ItemGroup>
     <Compile Include="AgeTests.fs" />
     <Compile Include="LocalizationTests.fs" />
+    <Compile Include="..\..\src\Informedica.GenPRES.Client\LanguagePolicy.fs" />
+    <Compile Include="LanguagePolicyTests.fs" />
     <Compile Include="Tests.fs" />
     <!-- the client session state machine is pure F#; linked in so it runs under Expecto -->
     <Compile Include="..\..\src\Informedica.GenPRES.Client\SessionMachine.fs" />

--- a/tests/Informedica.GenPRES.Shared.Tests/LanguagePolicyTests.fs
+++ b/tests/Informedica.GenPRES.Shared.Tests/LanguagePolicyTests.fs
@@ -1,0 +1,131 @@
+namespace Informedica.GenPRES.Shared.Tests
+
+
+/// The language precedence, linked in from the client project: url `la` and the User's choice
+/// outrank the server default, whichever order the messages arrive in; a navigation without
+/// `la` keeps the language.
+module LanguagePolicyTests =
+
+    open Expecto
+    open Expecto.Flip
+    open Shared.Localization
+    open LanguagePolicy
+
+
+    [<Tests>]
+    let tests =
+        testList
+            "LanguagePolicy"
+            [
+                test "no url language: the fallback, not chosen" {
+                    Language.initial None
+                    |> Expect.equal
+                        "fallback"
+                        {
+                            Current = Language.fallback
+                            Chosen = false
+                        }
+                }
+
+                test "a url language is chosen from the start" {
+                    Language.initial (Some English)
+                    |> Expect.equal
+                        "chosen"
+                        {
+                            Current = English
+                            Chosen = true
+                        }
+                }
+
+                test "the server default applies when nothing was chosen" {
+                    Language.initial None
+                    |> Language.onServerDefault English
+                    |> Expect.equal
+                        "server default"
+                        {
+                            Current = English
+                            Chosen = false
+                        }
+                }
+
+                test "settings arriving after a url language do not override it" {
+                    Language.initial (Some Dutch)
+                    |> Language.onServerDefault English
+                    |> Expect.equal
+                        "url wins"
+                        {
+                            Current = Dutch
+                            Chosen = true
+                        }
+                }
+
+                test "settings arriving after the User's choice do not override it" {
+                    Language.initial None
+                    |> Language.choose French
+                    |> Language.onServerDefault English
+                    |> Expect.equal
+                        "choice wins"
+                        {
+                            Current = French
+                            Chosen = true
+                        }
+                }
+
+                test "the User's choice after the settings overrides the server default" {
+                    Language.initial None
+                    |> Language.onServerDefault English
+                    |> Language.choose French
+                    |> Expect.equal
+                        "choice wins"
+                        {
+                            Current = French
+                            Chosen = true
+                        }
+                }
+
+                test "a navigation without la keeps the current language, chosen or not" {
+                    Language.initial None
+                    |> Language.onServerDefault English
+                    |> Language.onUrl None
+                    |> Expect.equal
+                        "kept, not chosen"
+                        {
+                            Current = English
+                            Chosen = false
+                        }
+
+                    Language.initial None
+                    |> Language.choose French
+                    |> Language.onUrl None
+                    |> Expect.equal
+                        "kept, chosen"
+                        {
+                            Current = French
+                            Chosen = true
+                        }
+                }
+
+                test "a navigation with la changes the language and counts as chosen" {
+                    Language.initial None
+                    |> Language.onServerDefault English
+                    |> Language.onUrl (Some Dutch)
+                    |> Expect.equal
+                        "url"
+                        {
+                            Current = Dutch
+                            Chosen = true
+                        }
+                }
+
+                test "settings arriving after a navigation with la do not override it" {
+                    Language.initial None
+                    |> Language.onUrl (Some Dutch)
+                    |> Language.onServerDefault English
+                    |> Expect.equal
+                        "url wins"
+                        {
+                            Current = Dutch
+                            Chosen = true
+                        }
+                }
+            ]

--- a/tests/Informedica.GenPRES.Shared.Tests/LocalizationTests.fs
+++ b/tests/Informedica.GenPRES.Shared.Tests/LocalizationTests.fs
@@ -1,8 +1,8 @@
 namespace Informedica.GenPRES.Shared.Tests
 
 
-/// One language vocabulary: `Localization.tryParse` serves the `GENPRES_LANG` setting, the
-/// client's `la` url parameter and the sheet header names.
+/// One language vocabulary: `Localization.tryParse` serves the `GENPRES_LANG` setting and the
+/// client's `la` url parameter (the sheet header keeps `tryFromString`, display names only).
 module LocalizationTests =
 
     open Expecto

--- a/tests/Informedica.GenPRES.Shared.Tests/LocalizationTests.fs
+++ b/tests/Informedica.GenPRES.Shared.Tests/LocalizationTests.fs
@@ -1,0 +1,55 @@
+namespace Informedica.GenPRES.Shared.Tests
+
+
+/// One language vocabulary: `Localization.tryParse` serves the `GENPRES_LANG` setting, the
+/// client's `la` url parameter and the sheet header names.
+module LocalizationTests =
+
+    open Expecto
+    open Expecto.Flip
+    open Shared.Localization
+
+
+    [<Tests>]
+    let tests =
+        testList
+            "Localization.tryParse"
+            [
+                test "every locale round-trips through its short code, upper or lower case" {
+                    for l in languages do
+                        l |> toShortCode |> tryParse |> Expect.equal $"{l} upper" (Some l)
+
+                        l
+                        |> toShortCode
+                        |> _.ToLower()
+                        |> tryParse
+                        |> Expect.equal $"{l} lower" (Some l)
+                }
+
+                test "every locale round-trips through its display name" {
+                    for l in languages do
+                        l |> toString |> tryParse |> Expect.equal $"{l}" (Some l)
+                }
+
+                testList
+                    "the client's legacy url codes"
+                    [
+                        for code, l in
+                            [
+                                "en", English
+                                "du", Dutch
+                                "fr", French
+                                "gr", German
+                                "sp", Spanish
+                                "it", Italian
+                            ] do
+                            test code { code |> tryParse |> Expect.equal code (Some l) }
+                    ]
+
+                test "whitespace is ignored" { "  nl " |> tryParse |> Expect.equal "padded" (Some Dutch) }
+
+                test "unknown, empty and null are None" {
+                    for s in [ "xx"; ""; " "; "dutch"; null ] do
+                        s |> tryParse |> Expect.isNone $"'{s}'"
+                }
+            ]


### PR DESCRIPTION
## Summary

First of two PRs (the second adds `GENPRES_SCOPE` per plan #581, with `full` as the development mode).

- **`GENPRES_LANG`** sets the default UI language: `en`, `nl`, `fr`, `de`, `es`, `it` (any case; display names such as `Nederlands` work too). Unset or blank means `nl`; any other value refuses the start with a message naming the setting and the accepted values. Read once in `Server.Config` (DMZ), shown in the banner.
- **`getSettings: unit -> Async<ServerSettings>`** on `IServerApi`, answering `{ Language; IsDemo }`, computed once in `Host.build` and threaded through `compose`. This is the `getSettings` of plan #581, with `Language` added; `Scope` comes in the next PR. `IsDemo` now reaches the client, so the "DEMO VERSION!" title suffix is live again.
- **One language parser.** `Localization.tryParse` serves the setting and the client's `la` url parameter; the three spellings of the same six languages (ISO codes, display names, the legacy `du`/`gr`/`sp`) collapse into it.
- **Client precedence:** url `la=` > the user's choice > server default > Dutch until the settings arrive. A navigation without `la=` keeps the current language; it used to reset to English, which is why a launch landed in English and a chosen language was lost on the first page change.

Drafted script-first in `Shared/Scripts/Localization.fsx` (17 tests) and `Server/Scripts/Settings.fsx` (18 tests), migrated after review.

## Verification

- `dotnet run Build`, `dotnet run ServerTests` (Server.Tests 122, Shared.Tests 416, all green), Fable compile, Fantomas.
- Chrome, demo server with `GENPRES_LANG=en`: bare url opens in English with the English disclaimer and the demo suffix; `#/patient?la=du` switches to Dutch; navigating without `la=` keeps Dutch; switching to English in the title bar and navigating pages keeps English; a hash launch keeps it too. The server log shows one `Processing settings` per load.
- `GENPRES_LANG=bogus`: exit code 1, `GENPRES_LANG=bogus is not a language. Accepted: en, nl, fr, de, es, it …`.

## Config and docs

`.env.example` (`GENPRES_LANG=nl`), `compose.yaml` (`GENPRES_LANG: ${GENPRES_LANG:-}`), `Build.fs` `DockerRun` forwards it with `-e GENPRES_LANG`, `DEVELOPMENT.md` gets a "Default language" section. The `Dockerfile` sets no `ENV` for it: the server default applies.

## Vibe coding disclosure

Drafted with Claude Code (scripts, client wiring, tests, docs); reviewed and migrated by hand, verified as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZWjibQUW8uqCVbfV4vDTf
