### PR TITLE
feat(server): seal the Launch and serve a stub LaunchScript page

### DIFF
--- a/src/Informedica.GenPRES.Client/vite.config.js
+++ b/src/Informedica.GenPRES.Client/vite.config.js
@@ -19,6 +19,11 @@ export default defineConfig({
         "/api": {
             target: proxyTarget,
             changeOrigin: true,
+        },
+        // the stub LaunchScript page (plan 605): served by the server in full scope only
+        "/stub": {
+            target: proxyTarget,
+            changeOrigin: true,
         }
     }
   },

--- a/src/Informedica.GenPRES.Server/Scripts/Launch.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/Launch.fsx
@@ -1,0 +1,467 @@
+// The sealed Launch and the stub LaunchScript page (plan 605, PR 1).
+//
+// Script-first draft (script-only policy) of:
+//   - `LaunchSeal`: the Launch of uc-01 step 1 as MainEHR's LaunchScript will mint it — PatientId,
+//     a fresh nonce and an expiry sealed under a key shared with the Server (Concept 3, Rules 3,
+//     29). Here the key is made once per host start, so a token from an earlier run is "not
+//     sealed under the key". → `ServerApi.Adapters.fs`, module `LaunchSeal`.
+//   - `SessionStub.present` verifying the seal instead of matching words: `expired`, `invalid`
+//     and `spent` become behaviour; records are keyed by the nonce (Rule 2). Until the identity
+//     hop (PR 2) any valid token opens with the stub prescriber. → `ServerApi.Adapters.fs`.
+//   - `StubLaunch`: the page and the redirect of the stub LaunchScript, pure; the Giraffe routes
+//     go into `Server.fs` at migration, behind `not IsProd`.
+//
+// Run: `dotnet fsi Launch.fsx` from this directory (build the solution first).
+
+#I __SOURCE_DIRECTORY__
+#r "nuget: Expecto, 10.2.3"
+
+#load "load.fsx"
+
+open System
+open Shared.Types
+open Shared.Models
+open ServerApi
+
+
+module LaunchSeal =
+
+    /// The key the Launch is sealed under. 32 bytes from a CSPRNG (`newKey`); shared with the
+    /// LaunchScript in the real integration, made per host start for the stub.
+    type Key = Key of byte[]
+
+
+    /// What a Launch says once the seal is verified.
+    type Claims =
+        {
+            PatientId: string
+            Nonce: string
+            Expiry: DateTime
+        }
+
+
+    /// The sealed payload on the wire. Field names are the contract; keep them short.
+    type Payload =
+        {
+            pid: string
+            nonce: string
+            // unix seconds, UTC
+            exp: int64
+        }
+
+
+    let keyLength = 32
+
+
+    let newKey (random: int -> byte[]) = Key(random keyLength)
+
+
+    let toBase64Url (bytes: byte[]) =
+        Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')
+
+
+    let fromBase64Url (s: string) =
+        try
+            let padded = s.Replace('-', '+').Replace('_', '/')
+
+            let padded =
+                match padded.Length % 4 with
+                | 2 -> padded + "=="
+                | 3 -> padded + "="
+                | 0 -> padded
+                | _ -> raise (FormatException "bad length")
+
+            Some(Convert.FromBase64String padded)
+        with _ ->
+            None
+
+
+    let mac (Key key) (data: byte[]) =
+        System.Security.Cryptography.HMACSHA256.HashData(key, data)
+
+
+    let private json = System.Text.Json.JsonSerializerOptions()
+
+
+    /// Seals the claims: `base64url(json) + "." + base64url(HMAC-SHA256(key, json))`.
+    let mint (key: Key) (claims: Claims) : Launch =
+        let payload =
+            {
+                pid = claims.PatientId
+                nonce = claims.Nonce
+                exp = DateTimeOffset(claims.Expiry, TimeSpan.Zero).ToUnixTimeSeconds()
+            }
+
+        let bytes = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(payload, json)
+        Launch $"{toBase64Url bytes}.{toBase64Url (mac key bytes)}"
+
+
+    /// Verifies the seal (constant-time), then the lifetime (Rule 3). Anything that is not a
+    /// Launch sealed under the key is `LaunchInvalid`; a Launch past its expiry is
+    /// `LaunchExpired`.
+    let verify (now: DateTime) (key: Key) (Launch text) : Result<Claims, LaunchRefusal> =
+        let parts = if isNull text then [||] else text.Split('.')
+
+        match parts with
+        | [| payload; signature |] ->
+            match fromBase64Url payload, fromBase64Url signature with
+            | Some bytes, Some given when
+                System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(mac key bytes, given)
+                ->
+                try
+                    let p = System.Text.Json.JsonSerializer.Deserialize<Payload>(bytes, json)
+
+                    if isNull p.pid || isNull p.nonce || p.pid = "" || p.nonce = "" then
+                        Error LaunchRefusal.LaunchInvalid
+                    else
+                        let expiry = DateTimeOffset.FromUnixTimeSeconds(p.exp).UtcDateTime
+
+                        if now > expiry then
+                            Error LaunchRefusal.LaunchExpired
+                        else
+                            Ok
+                                {
+                                    PatientId = p.pid
+                                    Nonce = p.nonce
+                                    Expiry = expiry
+                                }
+                with _ ->
+                    Error LaunchRefusal.LaunchInvalid
+            | _ -> Error LaunchRefusal.LaunchInvalid
+        | _ -> Error LaunchRefusal.LaunchInvalid
+
+
+/// The stub for launch steps 4 and 5 over a sealed Launch (replaces the word-matching stub).
+module SessionStub =
+
+    open SessionStub
+
+    /// Answers a presentation and returns the state after it. Pure: the clock, the id source,
+    /// the verifier and the patient are parameters.
+    ///
+    /// - not sealed under the key, or past its expiry: refused, nothing recorded (Rules 3, 29);
+    /// - a record under the nonce: the same public key gets the recorded answer (Rule 2, same
+    ///   browser); another key is LaunchSpent (it cannot be told from another browser);
+    /// - a new nonce opens a Session for the Launch's PatientId and writes the record in the
+    ///   same act (Rule 40). The record lives as long as the Launch does.
+    let present
+        (now: DateTime)
+        (newId: unit -> string)
+        (verify: Launch -> Result<LaunchSeal.Claims, LaunchRefusal>)
+        (patient: Patient)
+        (state: State)
+        (launch, key)
+        : State * LaunchResult
+        =
+        match verify launch with
+        | Error refusal ->
+            // nothing is recorded for a refused Launch; records past their expiry go with it (Rule 29)
+            { state with Launches = state.Launches |> Map.filter (fun _ r -> now <= r.Expiry) },
+            LaunchResult.Refused refusal
+        | Ok claims ->
+            match state.Launches |> Map.tryFind claims.Nonce with
+            | Some record when record.PublicKey = key -> state, record.Result
+            | Some _ -> state, LaunchResult.Refused LaunchRefusal.LaunchSpent
+            | None ->
+                let id = newId ()
+
+                let session =
+                    {
+                        User = Some stubUser
+                        PatientContext =
+                            Some
+                                {
+                                    PatientId = claims.PatientId
+                                    Patient = patient
+                                }
+                        OpenedToken = Some(OpenedToken $"opened-{id}")
+                        KeyThumbprint = Some(PublicKey.thumbprint key)
+                    }
+
+                let result = LaunchResult.Opened(id, session)
+
+                {
+                    Launches =
+                        state.Launches
+                        |> Map.filter (fun _ r -> now <= r.Expiry)
+                        |> Map.add
+                            claims.Nonce
+                            {
+                                PublicKey = key
+                                Result = result
+                                Expiry = claims.Expiry
+                            }
+                    Sessions = state.Sessions |> Map.add id session
+                },
+                result
+
+
+    /// The port over a single mutable state guarded by a lock; `verify` is the seal check
+    /// bound to the host's key.
+    let makeSessionPort
+        (now: unit -> DateTime)
+        (newId: unit -> string)
+        (verify: Launch -> Result<LaunchSeal.Claims, LaunchRefusal>)
+        (patient: Patient)
+        =
+        let gate = obj ()
+        let mutable state = emptyState
+
+        let update f =
+            lock
+                gate
+                (fun () ->
+                    let next, result = f state
+                    state <- next
+                    result
+                )
+
+        {
+            present = fun launch -> async { return update (fun s -> present (now ()) newId verify patient s launch) }
+            find = fun id -> async { return lock gate (fun () -> state.Sessions |> Map.tryFind id) }
+            close = fun id -> async { return update (fun s -> { s with Sessions = s.Sessions |> Map.remove id }, ()) }
+        }
+
+
+/// The stub LaunchScript (uc-01 step 1) as a page the server serves in full scope: it mints a
+/// sealed Launch for a chosen PatientId and opens the client on it. Pure here; `Server.fs`
+/// mounts `GET /stub/launch` (the page) and `POST /stub/launch` (mint + redirect).
+module StubLaunch =
+
+    let path = "/stub/launch"
+
+
+    /// The Launch lifetime (Rule 29): a page load, the identity round trip, a retry or two.
+    let lifetime = TimeSpan.FromMinutes 2.0
+
+
+    /// The form. No inline script or style, so the CSP (`default-src 'self'`) holds.
+    let page =
+        $"""<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>GenPRES stub launch</title></head>
+<body>
+<h1>Stub LaunchScript</h1>
+<p>Stands in for the MainEHR LaunchScript (uc-01 step 1): mints a sealed Launch for the patient
+below and opens GenPRES on it. Development and test servers only.</p>
+<form method="post" action="{path}">
+  <label>PatientId <input name="pid" value="stub-patient" required></label>
+  <button type="submit">Launch</button>
+</form>
+</body>
+</html>"""
+
+
+    /// Where the browser goes after minting: the hash form of decision D1.
+    let launchUrl (launch: Launch) =
+        match launch with
+        | Launch text -> $"/#/session?launch={Uri.EscapeDataString text}"
+
+
+    /// Mints the Launch for a posted PatientId; blank falls back to the stub patient.
+    let mint (now: DateTime) (newNonce: unit -> string) (key: LaunchSeal.Key) (pid: string) =
+        let pid = if String.IsNullOrWhiteSpace pid then "stub-patient" else pid.Trim()
+
+        LaunchSeal.mint
+            key
+            {
+                PatientId = pid
+                Nonce = newNonce ()
+                Expiry = now + lifetime
+            }
+
+
+open Expecto
+open Expecto.Flip
+
+
+let key = LaunchSeal.Key(Array.init 32 byte)
+let otherKey = LaunchSeal.Key(Array.init 32 (fun i -> byte (i + 1)))
+let t0 = DateTime(2026, 9, 10, 12, 0, 0, DateTimeKind.Utc)
+
+let claims =
+    {
+        LaunchSeal.PatientId = "p-1"
+        LaunchSeal.Nonce = "n-1"
+        LaunchSeal.Expiry = t0.AddMinutes 2.0
+    }
+
+
+let sealTests =
+    testList
+        "LaunchSeal"
+        [
+            test "a minted Launch verifies to its claims" {
+                LaunchSeal.mint key claims
+                |> LaunchSeal.verify t0 key
+                |> Expect.equal "claims" (Ok claims)
+            }
+
+            test "the token has two base64url parts and no padding" {
+                let (Launch text) = LaunchSeal.mint key claims
+                let parts = text.Split('.')
+                parts.Length |> Expect.equal "two parts" 2
+
+                for p in parts do
+                    (p.Contains "=" || p.Contains "+" || p.Contains "/")
+                    |> Expect.isFalse "no padding, no + or /"
+            }
+
+            test "another key does not verify" {
+                LaunchSeal.mint key claims
+                |> LaunchSeal.verify t0 otherKey
+                |> Expect.equal "invalid" (Error LaunchRefusal.LaunchInvalid)
+            }
+
+            test "a tampered payload does not verify" {
+                let (Launch text) = LaunchSeal.mint key claims
+                let parts = text.Split('.')
+
+                let tampered =
+                    { claims with PatientId = "p-2" }
+                    |> LaunchSeal.mint key
+                    |> fun (Launch t) -> t.Split('.')[0]
+
+                Launch $"{tampered}.{parts[1]}"
+                |> LaunchSeal.verify t0 key
+                |> Expect.equal "invalid" (Error LaunchRefusal.LaunchInvalid)
+            }
+
+            test "garbage, empty, null and one-part texts are invalid" {
+                for text in [ "garbage"; ""; null; "a.b.c"; "!!.??"; "eyJ9.abc" ] do
+                    Launch text
+                    |> LaunchSeal.verify t0 key
+                    |> Expect.equal $"'{text}'" (Error LaunchRefusal.LaunchInvalid)
+            }
+
+            test "past the expiry the Launch is expired, not invalid" {
+                LaunchSeal.mint key claims
+                |> LaunchSeal.verify (t0.AddMinutes 3.0) key
+                |> Expect.equal "expired" (Error LaunchRefusal.LaunchExpired)
+            }
+
+            test "empty claims are invalid even under the right seal" {
+                LaunchSeal.mint key { claims with PatientId = "" }
+                |> LaunchSeal.verify t0 key
+                |> Expect.equal "invalid" (Error LaunchRefusal.LaunchInvalid)
+            }
+        ]
+
+
+let ids = ref 0
+let newId () = ids.Value <- ids.Value + 1; $"id-{ids.Value}"
+let verify = LaunchSeal.verify t0 key
+let keyA = PublicKey "key-a"
+let keyB = PublicKey "key-b"
+let launch1 = LaunchSeal.mint key claims
+let launch2 = LaunchSeal.mint key { claims with Nonce = "n-2"; PatientId = "p-2" }
+
+let presentWith st launch k =
+    SessionStub.present t0 newId verify Patient.empty st (launch, k)
+
+
+let stubTests =
+    testList
+        "SessionStub.present over a sealed Launch"
+        [
+            test "a valid Launch opens a Session for its PatientId and records the nonce" {
+                let st, result = presentWith SessionStub.emptyState launch1 keyA
+
+                match result with
+                | LaunchResult.Opened(_, session) ->
+                    session.PatientContext |> Option.map _.PatientId |> Expect.equal "patient" (Some "p-1")
+                    session.KeyThumbprint |> Expect.equal "thumbprint" (Some(PublicKey.thumbprint keyA))
+                | other -> failtest $"expected Opened, got {other}"
+
+                st.Launches |> Map.containsKey "n-1" |> Expect.isTrue "record under the nonce"
+                st.Sessions |> Map.count |> Expect.equal "one session" 1
+            }
+
+            test "the same key within the lifetime is answered as the first time (Rule 2)" {
+                let st, first = presentWith SessionStub.emptyState launch1 keyA
+                let st2, again = presentWith st launch1 keyA
+                again |> Expect.equal "same answer" first
+                st2 |> Expect.equal "same state" st
+            }
+
+            test "another key is spent and opens nothing" {
+                let st, _ = presentWith SessionStub.emptyState launch1 keyA
+                let st2, result = presentWith st launch1 keyB
+                result |> Expect.equal "spent" (LaunchResult.Refused LaunchRefusal.LaunchSpent)
+                st2.Sessions |> Map.count |> Expect.equal "still one" 1
+            }
+
+            test "a second Launch with another nonce opens a second Session" {
+                let st, _ = presentWith SessionStub.emptyState launch1 keyA
+                let st2, result = presentWith st launch2 keyB
+
+                match result with
+                | LaunchResult.Opened(_, session) ->
+                    session.PatientContext |> Option.map _.PatientId |> Expect.equal "patient" (Some "p-2")
+                | other -> failtest $"expected Opened, got {other}"
+
+                st2.Sessions |> Map.count |> Expect.equal "two" 2
+            }
+
+            test "not sealed under the key: invalid, nothing recorded" {
+                let st, result =
+                    presentWith SessionStub.emptyState (LaunchSeal.mint otherKey claims) keyA
+
+                result |> Expect.equal "invalid" (LaunchResult.Refused LaunchRefusal.LaunchInvalid)
+                st |> Expect.equal "unchanged" SessionStub.emptyState
+            }
+
+            test "past its expiry: expired, even for the same key, and the record is gone" {
+                let st, _ = presentWith SessionStub.emptyState launch1 keyA
+                let later = t0.AddMinutes 3.0
+
+                let st2, result =
+                    SessionStub.present later newId (LaunchSeal.verify later key) Patient.empty st (launch1, keyA)
+
+                result |> Expect.equal "expired" (LaunchResult.Refused LaunchRefusal.LaunchExpired)
+                st2.Launches |> Map.containsKey "n-1" |> Expect.isFalse "record dropped"
+            }
+        ]
+
+
+let stubLaunchTests =
+    testList
+        "StubLaunch"
+        [
+            test "mint gives a Launch that verifies to the posted PatientId, two minutes long" {
+                StubLaunch.mint t0 (fun () -> "nonce-x") key "p-9"
+                |> LaunchSeal.verify t0 key
+                |> Expect.equal
+                    "claims"
+                    (Ok
+                        {
+                            LaunchSeal.PatientId = "p-9"
+                            LaunchSeal.Nonce = "nonce-x"
+                            LaunchSeal.Expiry = t0 + StubLaunch.lifetime
+                        })
+            }
+
+            test "a blank PatientId falls back to the stub patient" {
+                StubLaunch.mint t0 (fun () -> "n") key "  "
+                |> LaunchSeal.verify t0 key
+                |> Result.map _.PatientId
+                |> Expect.equal "stub-patient" (Ok "stub-patient")
+            }
+
+            test "the launch url is the hash form with the token escaped" {
+                StubLaunch.launchUrl (Launch "a.b")
+                |> Expect.equal "url" "/#/session?launch=a.b"
+
+                StubLaunch.launchUrl (Launch "a+b/c=")
+                |> Expect.equal "escaped" "/#/session?launch=a%2Bb%2Fc%3D"
+            }
+
+            test "the page has no inline script and posts to its own path" {
+                StubLaunch.page.Contains "<script" |> Expect.isFalse "no script"
+                StubLaunch.page.Contains $"action=\"{StubLaunch.path}\"" |> Expect.isTrue "posts to itself"
+                StubLaunch.page.Contains "name=\"pid\"" |> Expect.isTrue "pid field"
+            }
+        ]
+
+
+runTestsWithCLIArgs [] [||] (testList "Launch.fsx" [ sealTests; stubTests; stubLaunchTests ]) |> ignore

--- a/src/Informedica.GenPRES.Server/Server.fs
+++ b/src/Informedica.GenPRES.Server/Server.fs
@@ -605,14 +605,16 @@ module Host =
                         }
                 ]
 
+        // one request log around the whole route selection: the stub page, the api and the
+        // 404 arm each leave exactly one trail
         let webApp =
-            choose
-                [
-                    // the stub page is logged like the api, so a minted Launch leaves the same trail
-                    Http.logClientIP >=> choose stubLaunch
-                    Http.logClientIP >=> Http.safeWebApi webApi
-                    setStatusCode 404 >=> text "Not Found"
-                ]
+            Http.logClientIP
+            >=> choose
+                    [
+                        yield! stubLaunch
+                        Http.safeWebApi webApi
+                        setStatusCode 404 >=> text "Not Found"
+                    ]
 
         application {
             url ("http://*:" + settings.Port.ToString() + "/")

--- a/src/Informedica.GenPRES.Server/Server.fs
+++ b/src/Informedica.GenPRES.Server/Server.fs
@@ -553,8 +553,13 @@ module Host =
     let build (settings: Config.Settings) (provider: Informedica.GenForm.Lib.Resources.IResourceProvider) =
         // Built once per host: the session stub's state lives in it. Remoting.fromContext
         // runs its function per request, so the env must not be built in there.
+        // the key the stub LaunchScript seals Launches under (plan 605): per host start, so a
+        // token from an earlier run is "not sealed under the key"
+        let launchKey =
+            LaunchSeal.newKey System.Security.Cryptography.RandomNumberGenerator.GetBytes
+
         let env =
-            let env = Adapters.makeAppEnv provider
+            let env = Adapters.makeAppEnvWith launchKey provider
 
             // Stop-gap until the scope switch (#580): a production server never opens a
             // stub Session. Drop this swap when #580 decides what production exposes.
@@ -576,9 +581,34 @@ module Host =
         // below), so this stays handler-only. The 404 arm replaces a legacy
         // "GenInteractions App. Use localhost: 8080 for the GUI" string that
         // leaked an old app name and hinted at port 8080 (L2 / B5).
+        // the stub LaunchScript page (uc-01 step 1 stand-in, plan 605): full scope only, so a
+        // production server never mints a Launch. GET shows the form, POST mints and redirects.
+        let stubLaunch =
+            if settings.IsProd then
+                []
+            else
+                [
+                    GET >=> route StubLaunch.path >=> htmlString StubLaunch.page
+                    POST
+                    >=> route StubLaunch.path
+                    >=> fun next ctx ->
+                        task {
+                            let! form = ctx.Request.ReadFormAsync()
+
+                            let pid =
+                                match form.TryGetValue "pid" with
+                                | true, values -> values.ToString()
+                                | _ -> ""
+
+                            let launch = StubLaunch.mint System.DateTime.UtcNow PublicKey.randomId launchKey pid
+                            return! redirectTo false (StubLaunch.launchUrl launch) next ctx
+                        }
+                ]
+
         let webApp =
             choose
                 [
+                    yield! stubLaunch
                     Http.logClientIP >=> Http.safeWebApi webApi
                     setStatusCode 404 >=> text "Not Found"
                 ]

--- a/src/Informedica.GenPRES.Server/Server.fs
+++ b/src/Informedica.GenPRES.Server/Server.fs
@@ -608,7 +608,8 @@ module Host =
         let webApp =
             choose
                 [
-                    yield! stubLaunch
+                    // the stub page is logged like the api, so a minted Launch leaves the same trail
+                    Http.logClientIP >=> choose stubLaunch
                     Http.logClientIP >=> Http.safeWebApi webApi
                     setStatusCode 404 >=> text "Not Found"
                 ]

--- a/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
@@ -78,6 +78,113 @@ module PublicKey =
         RandomNumberGenerator.GetBytes 32 |> base64Url
 
 
+module LaunchSeal =
+
+    /// The key the Launch is sealed under. 32 bytes from a CSPRNG (`newKey`); shared with the
+    /// LaunchScript in the real integration, made per host start for the stub.
+    type Key = Key of byte[]
+
+
+    /// What a Launch says once the seal is verified.
+    type Claims =
+        {
+            PatientId: string
+            Nonce: string
+            Expiry: DateTime
+        }
+
+
+    /// The sealed payload on the wire. Field names are the contract; keep them short.
+    type Payload =
+        {
+            pid: string
+            nonce: string
+            // unix seconds, UTC
+            exp: int64
+        }
+
+
+    let keyLength = 32
+
+
+    let newKey (random: int -> byte[]) = Key(random keyLength)
+
+
+    let toBase64Url (bytes: byte[]) =
+        Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')
+
+
+    let fromBase64Url (s: string) =
+        try
+            let padded = s.Replace('-', '+').Replace('_', '/')
+
+            let padded =
+                match padded.Length % 4 with
+                | 2 -> padded + "=="
+                | 3 -> padded + "="
+                | 0 -> padded
+                | _ -> raise (FormatException "bad length")
+
+            Some(Convert.FromBase64String padded)
+        with _ ->
+            None
+
+
+    let mac (Key key) (data: byte[]) =
+        System.Security.Cryptography.HMACSHA256.HashData(key, data)
+
+
+    let private json = System.Text.Json.JsonSerializerOptions()
+
+
+    /// Seals the claims: `base64url(json) + "." + base64url(HMAC-SHA256(key, json))`.
+    let mint (key: Key) (claims: Claims) : Launch =
+        let payload =
+            {
+                pid = claims.PatientId
+                nonce = claims.Nonce
+                exp = DateTimeOffset(claims.Expiry, TimeSpan.Zero).ToUnixTimeSeconds()
+            }
+
+        let bytes = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(payload, json)
+        Launch $"{toBase64Url bytes}.{toBase64Url (mac key bytes)}"
+
+
+    /// Verifies the seal (constant-time), then the lifetime (Rule 3). Anything that is not a
+    /// Launch sealed under the key is `LaunchInvalid`; a Launch past its expiry is
+    /// `LaunchExpired`.
+    let verify (now: DateTime) (key: Key) (Launch text) : Result<Claims, LaunchRefusal> =
+        let parts = if isNull text then [||] else text.Split('.')
+
+        match parts with
+        | [| payload; signature |] ->
+            match fromBase64Url payload, fromBase64Url signature with
+            | Some bytes, Some given when
+                System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(mac key bytes, given)
+                ->
+                try
+                    let p = System.Text.Json.JsonSerializer.Deserialize<Payload>(bytes, json)
+
+                    if isNull p.pid || isNull p.nonce || p.pid = "" || p.nonce = "" then
+                        Error LaunchRefusal.LaunchInvalid
+                    else
+                        let expiry = DateTimeOffset.FromUnixTimeSeconds(p.exp).UtcDateTime
+
+                        if now > expiry then
+                            Error LaunchRefusal.LaunchExpired
+                        else
+                            Ok
+                                {
+                                    PatientId = p.pid
+                                    Nonce = p.nonce
+                                    Expiry = expiry
+                                }
+                with _ ->
+                    Error LaunchRefusal.LaunchInvalid
+            | _ -> Error LaunchRefusal.LaunchInvalid
+        | _ -> Error LaunchRefusal.LaunchInvalid
+
+
 /// In-memory stand-in for launch steps 4 and 5 (plan 409 step 2). It never redirects: the
 /// answer comes from the Launch text. The record it keeps per Launch is the LaunchRecord the
 /// real server appends at step 4.2, with the Launch text standing in for the nonce.
@@ -107,19 +214,6 @@ module SessionStub =
         }
 
 
-    /// The Launch texts that refuse; anything else opens a Session.
-    let refusalOf text =
-        match text with
-        | "expired" -> Some LaunchRefusal.LaunchExpired
-        | "spent" -> Some LaunchRefusal.LaunchSpent
-        | "invalid" -> Some LaunchRefusal.LaunchInvalid
-        | "no-identity" -> Some LaunchRefusal.NoBrowserIdentity
-        | "no-role" -> Some LaunchRefusal.NoRole
-        | "wrong-patient" -> Some LaunchRefusal.WrongActivePatient
-        | "enrolment" -> Some LaunchRefusal.EnrolmentRequired
-        | _ -> None
-
-
     let stubUser =
         {
             UserId = "stub-prescriber"
@@ -129,32 +223,31 @@ module SessionStub =
 
 
     /// Answers a presentation and returns the state after it. Pure: the clock, the id source,
-    /// the lifetime and the patient are parameters.
+    /// the verifier and the patient are parameters.
     ///
-    /// - a Launch with a record: expired -> LaunchExpired and the record is dropped; the same
-    ///   public key -> the recorded answer (Rule 2, same browser); another key -> LaunchSpent
-    ///   (it cannot be told from another browser).
-    /// - a Launch without a record: a refusal word refuses and records nothing, so a retry
-    ///   re-verifies; anything else opens a Session and writes the record in the same act
-    ///   (Rule 40).
+    /// - not sealed under the key, or past its expiry: refused, nothing recorded (Rules 3, 29);
+    /// - a record under the nonce: the same public key gets the recorded answer (Rule 2, same
+    ///   browser); another key is LaunchSpent (it cannot be told from another browser);
+    /// - a new nonce opens a Session for the Launch's PatientId and writes the record in the
+    ///   same act (Rule 40). The record lives as long as the Launch does.
     let present
         (now: DateTime)
         (newId: unit -> string)
-        (lifetime: TimeSpan)
+        (verify: Launch -> Result<LaunchSeal.Claims, LaunchRefusal>)
         (patient: Patient)
         (state: State)
-        (Launch text, key)
+        (launch, key)
         : State * LaunchResult
         =
-        match state.Launches |> Map.tryFind text with
-        | Some record when now > record.Expiry ->
-            { state with Launches = state.Launches |> Map.remove text },
-            LaunchResult.Refused LaunchRefusal.LaunchExpired
-        | Some record when record.PublicKey = key -> state, record.Result
-        | Some _ -> state, LaunchResult.Refused LaunchRefusal.LaunchSpent
-        | None ->
-            match refusalOf text with
-            | Some refusal -> state, LaunchResult.Refused refusal
+        match verify launch with
+        | Error refusal ->
+            // nothing is recorded for a refused Launch; records past their expiry go with it (Rule 29)
+            { state with Launches = state.Launches |> Map.filter (fun _ r -> now <= r.Expiry) },
+            LaunchResult.Refused refusal
+        | Ok claims ->
+            match state.Launches |> Map.tryFind claims.Nonce with
+            | Some record when record.PublicKey = key -> state, record.Result
+            | Some _ -> state, LaunchResult.Refused LaunchRefusal.LaunchSpent
             | None ->
                 let id = newId ()
 
@@ -164,7 +257,7 @@ module SessionStub =
                         PatientContext =
                             Some
                                 {
-                                    PatientId = "stub-patient"
+                                    PatientId = claims.PatientId
                                     Patient = patient
                                 }
                         OpenedToken = Some(OpenedToken $"opened-{id}")
@@ -176,21 +269,27 @@ module SessionStub =
                 {
                     Launches =
                         state.Launches
+                        |> Map.filter (fun _ r -> now <= r.Expiry)
                         |> Map.add
-                            text
+                            claims.Nonce
                             {
                                 PublicKey = key
                                 Result = result
-                                Expiry = now + lifetime
+                                Expiry = claims.Expiry
                             }
                     Sessions = state.Sessions |> Map.add id session
                 },
                 result
 
 
-    /// The port over a single mutable state guarded by a lock. `now` and `newId` are injected
-    /// (ADR-0001, effects as parameters); production passes `DateTime.UtcNow` and a random id.
-    let makeSessionPort (now: unit -> DateTime) (newId: unit -> string) (lifetime: TimeSpan) (patient: Patient) =
+    /// The port over a single mutable state guarded by a lock; `verify` is the seal check
+    /// bound to the host's key.
+    let makeSessionPort
+        (now: unit -> DateTime)
+        (newId: unit -> string)
+        (verify: Launch -> Result<LaunchSeal.Claims, LaunchRefusal>)
+        (patient: Patient)
+        =
         let gate = obj ()
         let mutable state = emptyState
 
@@ -204,10 +303,62 @@ module SessionStub =
                 )
 
         {
-            present = fun launch -> async { return update (fun s -> present (now ()) newId lifetime patient s launch) }
+            present = fun launch -> async { return update (fun s -> present (now ()) newId verify patient s launch) }
             find = fun id -> async { return lock gate (fun () -> state.Sessions |> Map.tryFind id) }
             close = fun id -> async { return update (fun s -> { s with Sessions = s.Sessions |> Map.remove id }, ()) }
         }
+
+
+/// The stub LaunchScript (uc-01 step 1) as a page the server serves in full scope: it mints a
+/// sealed Launch for a chosen PatientId and opens the client on it. Pure here; `Server.fs`
+/// mounts `GET /stub/launch` (the page) and `POST /stub/launch` (mint + redirect).
+module StubLaunch =
+
+    let path = "/stub/launch"
+
+
+    /// The Launch lifetime (Rule 29): a page load, the identity round trip, a retry or two.
+    let lifetime = TimeSpan.FromMinutes 2.0
+
+
+    /// The form. No inline script or style, so the CSP (`default-src 'self'`) holds.
+    let page =
+        $"""<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>GenPRES stub launch</title></head>
+<body>
+<h1>Stub LaunchScript</h1>
+<p>Stands in for the MainEHR LaunchScript (uc-01 step 1): mints a sealed Launch for the patient
+below and opens GenPRES on it. Development and test servers only.</p>
+<form method="post" action="{path}">
+  <label>PatientId <input name="pid" value="stub-patient" required></label>
+  <button type="submit">Launch</button>
+</form>
+</body>
+</html>"""
+
+
+    /// Where the browser goes after minting: the hash form of decision D1.
+    let launchUrl (launch: Launch) =
+        match launch with
+        | Launch text -> $"/#/session?launch={Uri.EscapeDataString text}"
+
+
+    /// Mints the Launch for a posted PatientId; blank falls back to the stub patient.
+    let mint (now: DateTime) (newNonce: unit -> string) (key: LaunchSeal.Key) (pid: string) =
+        let pid =
+            if String.IsNullOrWhiteSpace pid then
+                "stub-patient"
+            else
+                pid.Trim()
+
+        LaunchSeal.mint
+            key
+            {
+                PatientId = pid
+                Nonce = newNonce ()
+                Expiry = now + lifetime
+            }
 
 
 module Adapters =
@@ -355,7 +506,7 @@ module Adapters =
         }
 
 
-    let makeAppEnv (provider: Resources.IResourceProvider) : AppEnv =
+    let makeAppEnvWith (launchKey: LaunchSeal.Key) (provider: Resources.IResourceProvider) : AppEnv =
         let agent, logger = resolveLogger ()
         let orderCtxPort = makeOrderContextPort agent logger provider
 
@@ -416,6 +567,12 @@ module Adapters =
                 SessionStub.makeSessionPort
                     (fun () -> DateTime.UtcNow)
                     PublicKey.randomId
-                    (TimeSpan.FromMinutes 2.0)
+                    (fun launch -> LaunchSeal.verify DateTime.UtcNow launchKey launch)
                     Shared.Models.Patient.empty
         }
+
+
+    /// An env with its own seal key: what tests and the MCP host build. The server builds
+    /// `makeAppEnvWith` so that its stub LaunchScript page mints under the same key.
+    let makeAppEnv (provider: Informedica.GenForm.Lib.Resources.IResourceProvider) =
+        makeAppEnvWith (LaunchSeal.newKey System.Security.Cryptography.RandomNumberGenerator.GetBytes) provider

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -311,7 +311,28 @@ module SessionStubTests =
     let keyB = PublicKey "key-B"
 
 
-    /// A port with a settable clock and a counting id source.
+    /// The seal key of the tests, and another one.
+    let sealKey = LaunchSeal.Key(Array.init LaunchSeal.keyLength byte)
+
+    let otherSealKey =
+        LaunchSeal.Key(Array.init LaunchSeal.keyLength (fun i -> byte (i + 1)))
+
+
+    /// A Launch sealed under the test key for the stub patient, valid for the lifetime from t0.
+    let mintFor nonce pid =
+        LaunchSeal.mint
+            sealKey
+            {
+                PatientId = pid
+                Nonce = nonce
+                Expiry = t0 + lifetime
+            }
+
+    let launch1 = mintFor "n-1" "stub-patient"
+    let launch2 = mintFor "n-2" "p-2"
+
+
+    /// A port with a settable clock, a counting id source and the seal check bound to the clock.
     let makePort () =
         let clock = ref t0
         let count = ref 0
@@ -323,22 +344,10 @@ module SessionStubTests =
                     count.Value <- count.Value + 1
                     $"session-{count.Value}"
                 )
-                lifetime
+                (fun launch -> LaunchSeal.verify clock.Value sealKey launch)
                 Patient.empty
 
         port, clock
-
-
-    let refusalWords =
-        [
-            "expired", LaunchRefusal.LaunchExpired
-            "spent", LaunchRefusal.LaunchSpent
-            "invalid", LaunchRefusal.LaunchInvalid
-            "no-identity", LaunchRefusal.NoBrowserIdentity
-            "no-role", LaunchRefusal.NoRole
-            "wrong-patient", LaunchRefusal.WrongActivePatient
-            "enrolment", LaunchRefusal.EnrolmentRequired
-        ]
 
 
     let thumbprintTests =
@@ -385,15 +394,36 @@ module SessionStubTests =
             "Session stub"
             [
                 testList
-                    "refusal mapping"
+                    "a Launch the seal refuses opens nothing and records nothing"
                     [
-                        for word, refusal in refusalWords do
-                            testAsync $"launch={word} refuses with {refusal} and records nothing" {
+                        for name, launch, refusal in
+                            [
+                                "not sealed under the key",
+                                LaunchSeal.mint
+                                    otherSealKey
+                                    {
+                                        PatientId = "p"
+                                        Nonce = "n"
+                                        Expiry = t0 + lifetime
+                                    },
+                                LaunchRefusal.LaunchInvalid
+                                "garbage", Launch "not-a-launch", LaunchRefusal.LaunchInvalid
+                                "already expired",
+                                LaunchSeal.mint
+                                    sealKey
+                                    {
+                                        PatientId = "p"
+                                        Nonce = "n"
+                                        Expiry = t0 - TimeSpan.FromSeconds 1.0
+                                    },
+                                LaunchRefusal.LaunchExpired
+                            ] do
+                            testAsync $"{name} refuses with {refusal}" {
                                 let port, _ = makePort ()
 
-                                let! first = port.present (Launch word, keyA)
+                                let! first = port.present (launch, keyA)
                                 // another key gets the same answer: nothing was recorded
-                                let! second = port.present (Launch word, keyB)
+                                let! second = port.present (launch, keyB)
 
                                 first |> Expect.equal "first" (LaunchResult.Refused refusal)
                                 second |> Expect.equal "second, other key" (LaunchResult.Refused refusal)
@@ -403,10 +433,10 @@ module SessionStubTests =
                             }
                     ]
 
-                testAsync "any other launch opens a session with a stub prescriber and patient" {
+                testAsync "a sealed Launch opens a session with the stub prescriber for its PatientId" {
                     let port, _ = makePort ()
 
-                    match! port.present (Launch "demo", keyA) with
+                    match! port.present (launch1, keyA) with
                     | LaunchResult.Opened(id, session) ->
                         id |> Expect.equal "session id" "session-1"
 
@@ -431,9 +461,9 @@ module SessionStubTests =
                 testAsync "a second presentation with the same key within the lifetime is answered as the first" {
                     let port, clock = makePort ()
 
-                    let! first = port.present (Launch "demo", keyA)
+                    let! first = port.present (launch1, keyA)
                     clock.Value <- t0 + TimeSpan.FromSeconds 90.0
-                    let! second = port.present (Launch "demo", keyA)
+                    let! second = port.present (launch1, keyA)
 
                     second |> Expect.equal "same session, same content" first
 
@@ -444,8 +474,8 @@ module SessionStubTests =
                 testAsync "a second presentation with another key is LaunchSpent and opens nothing" {
                     let port, _ = makePort ()
 
-                    let! _ = port.present (Launch "demo", keyA)
-                    let! other = port.present (Launch "demo", keyB)
+                    let! _ = port.present (launch1, keyA)
+                    let! other = port.present (launch1, keyB)
 
                     other |> Expect.equal "spent" (LaunchResult.Refused LaunchRefusal.LaunchSpent)
 
@@ -459,18 +489,33 @@ module SessionStubTests =
                 testAsync "after the lifetime the launch is LaunchExpired, even for the same key" {
                     let port, clock = makePort ()
 
-                    let! _ = port.present (Launch "demo", keyA)
+                    let! _ = port.present (launch1, keyA)
                     clock.Value <- t0 + lifetime + TimeSpan.FromSeconds 1.0
-                    let! late = port.present (Launch "demo", keyA)
+                    let! late = port.present (launch1, keyA)
 
                     late
                     |> Expect.equal "expired" (LaunchResult.Refused LaunchRefusal.LaunchExpired)
                 }
 
+                testAsync "a second Launch with another nonce opens a second session" {
+                    let port, _ = makePort ()
+
+                    let! _ = port.present (launch1, keyA)
+
+                    match! port.present (launch2, keyB) with
+                    | LaunchResult.Opened(id, session) ->
+                        id |> Expect.equal "second id" "session-2"
+
+                        session.PatientContext
+                        |> Option.map _.PatientId
+                        |> Expect.equal "its own patient" (Some "p-2")
+                    | other -> failtest $"expected Opened, got {other}"
+                }
+
                 testAsync "close removes the session" {
                     let port, _ = makePort ()
 
-                    let! _ = port.present (Launch "demo", keyA)
+                    let! _ = port.present (launch1, keyA)
                     do! port.close "session-1"
 
                     let! found = port.find "session-1"
@@ -490,10 +535,11 @@ module SessionStubTests =
                         ids.Value <- ids.Value + 1
                         $"s{ids.Value}"
 
-                    let state1, r1 =
-                        present t0 newId lifetime Patient.empty emptyState (Launch "demo", keyA)
+                    let verify = LaunchSeal.verify t0 sealKey
 
-                    let _, r2 = present t0 newId lifetime Patient.empty state1 (Launch "demo", keyA)
+                    let state1, r1 = present t0 newId verify Patient.empty emptyState (launch1, keyA)
+
+                    let _, r2 = present t0 newId verify Patient.empty state1 (launch1, keyA)
 
                     r2 |> Expect.equal "recorded answer" r1
                     state1.Launches |> Map.count |> Expect.equal "one record" 1
@@ -527,8 +573,118 @@ module SessionStubTests =
         }
 
 
-    let present launch key =
-        LaunchCommand.PresentLaunch(Launch launch, key)
+    /// A fresh sealed Launch under `nonce` for the stub patient.
+    let present nonce key =
+        LaunchCommand.PresentLaunch(mintFor $"n-{nonce}" "stub-patient", key)
+
+
+    let sealTests =
+        let claims: LaunchSeal.Claims =
+            {
+                PatientId = "p-1"
+                Nonce = "n-1"
+                Expiry = t0 + lifetime
+            }
+
+        testList
+            "LaunchSeal"
+            [
+                test "a minted Launch verifies to its claims" {
+                    LaunchSeal.mint sealKey claims
+                    |> LaunchSeal.verify t0 sealKey
+                    |> Expect.equal "claims" (Ok claims)
+                }
+
+                test "the token has two base64url parts and no padding" {
+                    let (Launch text) = LaunchSeal.mint sealKey claims
+                    let parts = text.Split('.')
+                    parts.Length |> Expect.equal "two parts" 2
+
+                    for p in parts do
+                        (p.Contains "=" || p.Contains "+" || p.Contains "/")
+                        |> Expect.isFalse "no padding, no + or /"
+                }
+
+                test "another key does not verify" {
+                    LaunchSeal.mint sealKey claims
+                    |> LaunchSeal.verify t0 otherSealKey
+                    |> Expect.equal "invalid" (Error LaunchRefusal.LaunchInvalid)
+                }
+
+                test "a payload swapped under a signature does not verify" {
+                    let (Launch text) = LaunchSeal.mint sealKey claims
+                    let signature = text.Split('.')[1]
+
+                    let (Launch other) = LaunchSeal.mint sealKey { claims with PatientId = "p-2" }
+                    let payload = other.Split('.')[0]
+
+                    Launch $"{payload}.{signature}"
+                    |> LaunchSeal.verify t0 sealKey
+                    |> Expect.equal "invalid" (Error LaunchRefusal.LaunchInvalid)
+                }
+
+                test "garbage, empty, null and one-part texts are invalid" {
+                    for text in [ "garbage"; ""; null; "a.b.c"; "!!.??"; "eyJ9.abc" ] do
+                        Launch text
+                        |> LaunchSeal.verify t0 sealKey
+                        |> Expect.equal $"'{text}'" (Error LaunchRefusal.LaunchInvalid)
+                }
+
+                test "past the expiry the Launch is expired, not invalid" {
+                    LaunchSeal.mint sealKey claims
+                    |> LaunchSeal.verify (t0 + lifetime + TimeSpan.FromSeconds 1.0) sealKey
+                    |> Expect.equal "expired" (Error LaunchRefusal.LaunchExpired)
+                }
+
+                test "empty claims are invalid even under the right seal" {
+                    LaunchSeal.mint sealKey { claims with PatientId = "" }
+                    |> LaunchSeal.verify t0 sealKey
+                    |> Expect.equal "invalid" (Error LaunchRefusal.LaunchInvalid)
+                }
+            ]
+
+
+    let stubLaunchTests =
+        testList
+            "StubLaunch"
+            [
+                test "mint gives a Launch that verifies to the posted PatientId, one lifetime long" {
+                    StubLaunch.mint t0 (fun () -> "nonce-x") sealKey "p-9"
+                    |> LaunchSeal.verify t0 sealKey
+                    |> Expect.equal
+                        "claims"
+                        (Ok
+                            {
+                                LaunchSeal.PatientId = "p-9"
+                                LaunchSeal.Nonce = "nonce-x"
+                                LaunchSeal.Expiry = t0 + StubLaunch.lifetime
+                            })
+                }
+
+                test "a blank PatientId falls back to the stub patient" {
+                    StubLaunch.mint t0 (fun () -> "n") sealKey "  "
+                    |> LaunchSeal.verify t0 sealKey
+                    |> Result.map _.PatientId
+                    |> Expect.equal "stub-patient" (Ok "stub-patient")
+                }
+
+                test "the launch url is the hash form with the token escaped" {
+                    StubLaunch.launchUrl (Launch "a.b")
+                    |> Expect.equal "url" "/#/session?launch=a.b"
+
+                    StubLaunch.launchUrl (Launch "a+b/c=")
+                    |> Expect.equal "escaped" "/#/session?launch=a%2Bb%2Fc%3D"
+                }
+
+                test "the page has no inline script and posts to its own path" {
+                    StubLaunch.page.Contains "<script" |> Expect.isFalse "no script"
+
+                    StubLaunch.page.Contains $"action=\"{StubLaunch.path}\""
+                    |> Expect.isTrue "posts to itself"
+
+                    StubLaunch.page.Contains "name=\"pid\"" |> Expect.isTrue "pid field"
+                }
+            ]
 
 
     let compositionTests =
@@ -566,9 +722,14 @@ module SessionStubTests =
                     let env = envWithStub ()
                     let cookie, held = memoryCookie None
 
-                    let! outcome = CompositionRoot.processLaunch env cookie (present "no-role" keyA)
+                    let! outcome =
+                        CompositionRoot.processLaunch
+                            env
+                            cookie
+                            (LaunchCommand.PresentLaunch(Launch "not-a-launch", keyA))
 
-                    outcome |> Expect.equal "refused" (LaunchOutcome.Refused LaunchRefusal.NoRole)
+                    outcome
+                    |> Expect.equal "refused" (LaunchOutcome.Refused LaunchRefusal.LaunchInvalid)
 
                     held.Value |> Expect.isNone "no cookie"
                 }
@@ -679,7 +840,16 @@ module SessionStubTests =
             ]
 
 
-    let tests = testList "Session" [ thumbprintTests; stubTests; compositionTests ]
+    let tests =
+        testList
+            "Session"
+            [
+                thumbprintTests
+                sealTests
+                stubTests
+                stubLaunchTests
+                compositionTests
+            ]
 
 
 [<Tests>]


### PR DESCRIPTION
## Summary

Step 1 of plan #605 (PR #606): the Launch becomes a sealed token and the server serves a stub LaunchScript page that mints it.

- **`LaunchSeal`** (`ServerApi.Adapters.fs`): `{ pid; nonce; exp }` as `base64url(json).base64url(HMAC-SHA256)` under a 32-byte key made once per host start (so a token from an earlier run is "not sealed under the key"); constant-time verify yielding the claims, `LaunchInvalid` or `LaunchExpired`.
- **`SessionStub.present`** takes a verifier instead of matching words; records are keyed by the nonce and live as long as the Launch (Rules 2, 3, 29). Until the identity hop (PR 2), any sealed Launch opens with the stub prescriber for its PatientId.
- **`StubLaunch`**: `GET /stub/launch` is a plain HTML form (no script, CSP holds), `POST /stub/launch` mints and redirects to `/#/session?launch=<token>`. Mounted only when `GENPRES_PROD=0`. The Vite dev proxy forwards `/stub`.
- `makeAppEnvWith launchKey provider` for the host (page and port share the key); `makeAppEnv provider` keeps its signature with its own key, so tests and the MCP host are untouched.

Drafted script-first in `Server/Scripts/Launch.fsx` (17 tests), migrated after review.

## Verification

- `dotnet run Build`, `dotnet run ServerTests` (Server.Tests 132), Fantomas clean.
- Chrome, demo server, isolated contexts: `/stub/launch` → PatientId `patient-42` → `#/session?launch=…` erased → title bar "Stub Prescriber (Voorschrijver)"; reload resumes on the cookie; the same token in another browser context → gate "already used" (spent); `launch=not-a-launch` → "not valid".
- Same-browser replay from a fresh page load is also "spent": the client generates a new key pair per page load, so only in-memory retries share a key. Existing behaviour, unchanged here.
- `GENPRES_PROD=1`: `/stub/launch` answers 404; demo answers 200.

## Vibe coding disclosure

Drafted with Claude Code (script, tests, migration patch); reviewed and migrated by hand, verified as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZWjibQUW8uqCVbfV4vDTf
