### PR TITLE
feat(server): run the identity hop over a stub IdentityProvider

### DIFF
--- a/src/Informedica.GenPRES.Client/vite.config.js
+++ b/src/Informedica.GenPRES.Client/vite.config.js
@@ -24,6 +24,15 @@ export default defineConfig({
         "/stub": {
             target: proxyTarget,
             changeOrigin: true,
+        },
+        // the identity hop (uc-01 step 4): the stub IdentityProvider and the callback
+        "/authorize": {
+            target: proxyTarget,
+            changeOrigin: true,
+        },
+        "/callback": {
+            target: proxyTarget,
+            changeOrigin: true,
         }
     }
   },

--- a/src/Informedica.GenPRES.Server/Scripts/Hop.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/Hop.fsx
@@ -1,0 +1,923 @@
+// The identity hop of uc-01 step 4, and step 5, over server-hosted stubs (plan 605, PR 2).
+//
+// Script-first draft (script-only policy) of:
+//   - the ports of the actors behind the launch: IdentityProvider (Actor 8), UserRegistry,
+//     PatientDataPlatform → `ServerApi.Ports.fs`;
+//   - `LaunchResult.RedirectTo` carrying the `state` the edge puts in the cookie, `SessionPort`
+//     growing `callback`, `LaunchStateCookie` (the request port for the state cookie) → `Ports.fs`;
+//   - `Hop`: the LaunchRecord keyed by nonce (4.2), the pure `present` (→ RedirectTo, Rule 2
+//     replay) and `callback` (4.5 + step 5: the refusal ladder, Rule 45 replay, the Rule 40 single
+//     act with the Rule 8 closes) → `ServerApi.Adapters.fs`, replacing `SessionStub`;
+//   - the stubs: `StubDirectory` (IdP + UserRegistry over one identity choice), `StubPatientData`
+//     → `Adapters.fs`; `makeSessionPort` over them.
+//
+// Review points folded in (#606): the error redirect keeps the state; the PIN check binds
+// Prescribers only (Rule 25, ext 5c); `read = None` opens without imported data (ext 6a).
+//
+// Run: `dotnet fsi Hop.fsx` from this directory (build the solution first).
+
+#I __SOURCE_DIRECTORY__
+#r "nuget: Expecto, 10.2.3"
+
+#load "load.fsx"
+
+open System
+open Shared.Types
+open Shared.Models
+open ServerApi
+
+
+// ---------------------------------------------------------------------------------------------
+// Ports (→ ServerApi.Ports.fs)
+// ---------------------------------------------------------------------------------------------
+
+/// Who the IdentityProvider says is at the browser (Concept 4). The Session's User is derived
+/// from it (Rule 4), never from the Launch.
+type BrowserIdentity =
+    {
+        Login: string
+        DisplayName: string
+    }
+
+
+/// What the UserRegistry says about a login at this launch (Rules 5, 6, 24): the User with the
+/// Role, the Patient active in MainEHR, and whether a PIN is set.
+type UserStanding =
+    {
+        User: UserContext
+        ActivePatientId: string option
+        PinSet: bool
+    }
+
+
+/// Actor 8. `authorizeUrl` is where the browser is sent with the `state` (4.2); `redeem`
+/// exchanges the callback's code for the identity over the server's own connection (4.4, C6).
+type IdentityProviderPort =
+    {
+        authorizeUrl: string -> string
+        redeem: string -> BrowserIdentity option
+    }
+
+
+type UserRegistryPort = { standing: BrowserIdentity -> UserStanding option }
+
+
+/// The PatientDataPlatform, read once at the launch (Concept 2). `None` is not a refusal
+/// (ext 6a): the Session opens without imported data.
+type PatientDataPort = { read: string -> Patient option }
+
+
+/// The session adapter's answer to a presentation. `RedirectTo` carries the `state` the edge
+/// writes to the state cookie next to the url that carries it to the IdentityProvider.
+[<RequireQualifiedAccess>]
+type LaunchResult =
+    | Opened of sessionId: string * SessionOpened
+    | RedirectTo of url: string * state: string
+    | Refused of LaunchRefusal
+
+
+/// What the callback (4.5) brings: the `state` from the url and from the cookie, and either a
+/// code or the IdentityProvider's error.
+type Callback =
+    {
+        State: string
+        StateCookie: string option
+        Code: string option
+        Error: string option
+    }
+
+
+/// The answer to a callback: where the browser goes next, and the session id for the cookie
+/// when a Session opened.
+[<RequireQualifiedAccess>]
+type CallbackResult =
+    | Opened of sessionId: string * redirect: string
+    | Refused of LaunchRefusal * redirect: string
+
+
+type SessionPort =
+    {
+        present: Launch * PublicKey -> Async<LaunchResult>
+        callback: Callback -> Async<CallbackResult>
+        find: string -> Async<SessionOpened option>
+        close: string -> Async<unit>
+    }
+
+
+/// The state cookie of one request (4.2): written with the redirect, read at the callback.
+type LaunchStateCookie =
+    {
+        read: unit -> string option
+        write: string -> unit
+    }
+
+
+// ---------------------------------------------------------------------------------------------
+// The hop (→ ServerApi.Adapters.fs, replacing SessionStub)
+// ---------------------------------------------------------------------------------------------
+
+module Hop =
+
+    /// The refusal words of `#/session?refused=<word>`; the client's `parseRefusal` reads them.
+    let refusalWord refusal =
+        match refusal with
+        | LaunchRefusal.LaunchExpired -> "expired"
+        | LaunchRefusal.LaunchSpent -> "spent"
+        | LaunchRefusal.LaunchInvalid -> "invalid"
+        | LaunchRefusal.NoBrowserIdentity -> "no-identity"
+        | LaunchRefusal.NoRole -> "no-role"
+        | LaunchRefusal.WrongActivePatient -> "wrong-patient"
+        | LaunchRefusal.EnrolmentRequired -> "enrolment"
+
+
+    let openedUrl = "/#/session"
+
+    let refusedUrl refusal = $"/#/session?refused={refusalWord refusal}"
+
+
+    /// One record per Launch (4.2), keyed by the nonce (Rule 2) and found by the `state` at the
+    /// callback. The outcome is appended once (Rule 45); the record is dropped whole at expiry.
+    type LaunchRecord =
+        {
+            Nonce: string
+            State: string
+            PatientId: string
+            PublicKey: PublicKey
+            Expiry: DateTime
+            Outcome: LaunchResult option
+        }
+
+
+    /// A Session as the store holds it: what the client learns, plus the login it belongs to
+    /// (Rule 8: a User has at most one open Session).
+    type SessionRecord =
+        {
+            Session: SessionOpened
+            Login: string option
+        }
+
+
+    /// Why a Session ended other than by the User closing it (Rule 11). One case now.
+    [<RequireQualifiedAccess>]
+    type SessionEnding = SupersededByLaunch
+
+
+    type State =
+        {
+            Launches: Map<string, LaunchRecord>
+            Sessions: Map<string, SessionRecord>
+            // sessions ended by the server, told once at the next GetSession (Rule 11, PR 4)
+            Endings: Map<string, SessionEnding>
+        }
+
+
+    let emptyState =
+        {
+            Launches = Map.empty
+            Sessions = Map.empty
+            Endings = Map.empty
+        }
+
+
+    let private dropExpired (now: DateTime) (state: State) =
+        { state with Launches = state.Launches |> Map.filter (fun _ r -> now <= r.Expiry) }
+
+
+    /// The answer `present` gives for a record: the recorded outcome, else the redirect again.
+    let private answerOf (authorizeUrl: string -> string) (record: LaunchRecord) =
+        match record.Outcome with
+        | Some outcome -> outcome
+        | None -> LaunchResult.RedirectTo(authorizeUrl record.State, record.State)
+
+
+    /// Step 4.1 and 4.2. Pure over the state; the clock, the id source, the verifier and the
+    /// IdentityProvider's url are parameters.
+    ///
+    /// - not sealed under the key, or past its expiry: refused, nothing recorded (Rules 3, 29);
+    /// - a record under the nonce: the same public key gets the recorded answer, or the redirect
+    ///   again while the hop is still open (Rule 2, uc-01 Retries); another key is LaunchSpent;
+    /// - a new nonce appends the record and sends the browser to the IdentityProvider.
+    let present
+        (now: DateTime)
+        (newId: unit -> string)
+        (verify: Launch -> Result<LaunchSeal.Claims, LaunchRefusal>)
+        (authorizeUrl: string -> string)
+        (state: State)
+        (launch, key)
+        : State * LaunchResult
+        =
+        let state = dropExpired now state
+
+        match verify launch with
+        | Error refusal -> state, LaunchResult.Refused refusal
+        | Ok claims ->
+            match state.Launches |> Map.tryFind claims.Nonce with
+            | Some record when record.PublicKey = key -> state, answerOf authorizeUrl record
+            | Some _ -> state, LaunchResult.Refused LaunchRefusal.LaunchSpent
+            | None ->
+                let record =
+                    {
+                        Nonce = claims.Nonce
+                        State = newId ()
+                        PatientId = claims.PatientId
+                        PublicKey = key
+                        Expiry = claims.Expiry
+                        Outcome = None
+                    }
+
+                { state with Launches = state.Launches |> Map.add claims.Nonce record },
+                answerOf authorizeUrl record
+
+
+    /// Step 5.7, one act (Rule 40): the Session is written, the login's other Sessions are
+    /// closed and marked (Rule 8), the outcome is appended to the record.
+    let private openSession
+        (newId: unit -> string)
+        (patientData: string -> Patient option)
+        (record: LaunchRecord)
+        (standing: UserStanding)
+        (state: State)
+        =
+        let id = newId ()
+
+        let session =
+            {
+                User = Some standing.User
+                PatientContext =
+                    Some
+                        {
+                            PatientId = record.PatientId
+                            // ext 6a: no imported data is not a refusal
+                            Patient = patientData record.PatientId |> Option.defaultValue Patient.empty
+                        }
+                OpenedToken = Some(OpenedToken $"opened-{id}")
+                KeyThumbprint = Some(PublicKey.thumbprint record.PublicKey)
+            }
+
+        let login = Some standing.User.UserId
+
+        let superseded =
+            state.Sessions
+            |> Map.filter (fun sid s -> sid <> id && s.Login = login)
+            |> Map.toList
+            |> List.map fst
+
+        let outcome = LaunchResult.Opened(id, session)
+
+        {
+            Launches = state.Launches |> Map.add record.Nonce { record with Outcome = Some outcome }
+            Sessions =
+                superseded
+                |> List.fold (fun m sid -> Map.remove sid m) state.Sessions
+                |> Map.add id { Session = session; Login = login }
+            Endings =
+                superseded
+                |> List.fold (fun m sid -> Map.add sid SessionEnding.SupersededByLaunch m) state.Endings
+        },
+        CallbackResult.Opened(id, openedUrl)
+
+
+    let private refuse (record: LaunchRecord) refusal (state: State) =
+        { state with
+            Launches =
+                state.Launches
+                |> Map.add record.Nonce { record with Outcome = Some(LaunchResult.Refused refusal) }
+        },
+        CallbackResult.Refused(refusal, refusedUrl refusal)
+
+
+    /// Step 4.5 and step 5. The ladder, in order: the state cookie must match (the browser that
+    /// started the hop), the record must exist and be within its lifetime, an outcome already
+    /// recorded is answered again (Rule 45), the IdentityProvider must have said who is there
+    /// (ext 3c), the UserRegistry must know them (5.3, ext 5a) with the Launch's Patient active
+    /// (ext 5b), and a Prescriber must have a PIN (5.4, Rule 25, ext 5d; a Reader needs none,
+    /// ext 5c). Then the Session opens in one act.
+    let callback
+        (now: DateTime)
+        (newId: unit -> string)
+        (redeem: string -> BrowserIdentity option)
+        (standing: BrowserIdentity -> UserStanding option)
+        (patientData: string -> Patient option)
+        (state: State)
+        (cb: Callback)
+        : State * CallbackResult
+        =
+        let state = dropExpired now state
+
+        let byState =
+            state.Launches |> Map.toSeq |> Seq.map snd |> Seq.tryFind (fun r -> r.State = cb.State)
+
+        let invalid = CallbackResult.Refused(LaunchRefusal.LaunchInvalid, refusedUrl LaunchRefusal.LaunchInvalid)
+
+        match cb.StateCookie, byState with
+        | Some cookie, Some record when cookie = cb.State && cb.State <> "" ->
+            match record.Outcome with
+            | Some(LaunchResult.Opened(id, _)) -> state, CallbackResult.Opened(id, openedUrl)
+            | Some(LaunchResult.Refused refusal) -> state, CallbackResult.Refused(refusal, refusedUrl refusal)
+            | Some(LaunchResult.RedirectTo _)
+            | None ->
+                let identity =
+                    match cb.Error, cb.Code with
+                    | None, Some code -> redeem code
+                    | _ -> None
+
+                match identity with
+                | None -> refuse record LaunchRefusal.NoBrowserIdentity state
+                | Some identity ->
+                    match standing identity with
+                    | None -> refuse record LaunchRefusal.NoRole state
+                    | Some standing when standing.ActivePatientId <> Some record.PatientId ->
+                        refuse record LaunchRefusal.WrongActivePatient state
+                    | Some standing when standing.User.Role = UserRole.Prescriber && not standing.PinSet ->
+                        refuse record LaunchRefusal.EnrolmentRequired state
+                    | Some standing -> openSession newId patientData record standing state
+        | _, None ->
+            // no record: expired and dropped (Rule 29), or never presented
+            state, invalid
+        | _ -> state, invalid
+
+
+    /// The port over a single mutable state guarded by a lock, over the three actor ports.
+    let makeSessionPort
+        (now: unit -> DateTime)
+        (newId: unit -> string)
+        (verify: Launch -> Result<LaunchSeal.Claims, LaunchRefusal>)
+        (idp: IdentityProviderPort)
+        (registry: UserRegistryPort)
+        (patientData: PatientDataPort)
+        =
+        let gate = obj ()
+        let mutable state = emptyState
+
+        let update f =
+            lock
+                gate
+                (fun () ->
+                    let next, result = f state
+                    state <- next
+                    result
+                )
+
+        {
+            present =
+                fun launch -> async { return update (fun s -> present (now ()) newId verify idp.authorizeUrl s launch) }
+            callback =
+                fun cb ->
+                    async {
+                        return
+                            update (fun s -> callback (now ()) newId idp.redeem registry.standing patientData.read s cb)
+                    }
+            find =
+                fun id -> async { return lock gate (fun () -> state.Sessions |> Map.tryFind id |> Option.map _.Session) }
+            close = fun id -> async { return update (fun s -> { s with Sessions = s.Sessions |> Map.remove id }, ()) }
+        }
+
+
+// ---------------------------------------------------------------------------------------------
+// The stubs (→ ServerApi.Adapters.fs)
+// ---------------------------------------------------------------------------------------------
+
+/// The IdentityProvider and the UserRegistry as one stub directory over an identity choice made
+/// on the stub launch page: `prescriber`, `reader`, `prescriber-other-patient`, `no-pin`,
+/// `unknown` (a login the registry does not know), `none` (no identity: the stub IdP's
+/// `/authorize` never issues a code for it). The active Patient of a choice is the one the
+/// launch page was given, except for `prescriber-other-patient`.
+module StubDirectory =
+
+    let choices = [ "prescriber"; "reader"; "prescriber-other-patient"; "no-pin"; "unknown"; "none" ]
+
+
+    let identityOf choice =
+        {
+            Login = choice
+            DisplayName =
+                match choice with
+                | "prescriber" -> "Stub Prescriber"
+                | "reader" -> "Stub Reader"
+                | "prescriber-other-patient" -> "Stub Prescriber (other patient)"
+                | "no-pin" -> "Stub Prescriber (no PIN)"
+                | other -> $"Stub {other}"
+        }
+
+
+    /// The registry's answer for a login, given the Patient the launch page made active.
+    let standingOf (activePatientId: string) (identity: BrowserIdentity) : UserStanding option =
+        let user role =
+            {
+                UserId = identity.Login
+                DisplayName = identity.DisplayName
+                Role = role
+            }
+
+        match identity.Login with
+        | "prescriber" ->
+            Some
+                {
+                    User = user UserRole.Prescriber
+                    ActivePatientId = Some activePatientId
+                    PinSet = true
+                }
+        | "reader" ->
+            Some
+                {
+                    User = user UserRole.Reader
+                    ActivePatientId = Some activePatientId
+                    PinSet = false
+                }
+        | "prescriber-other-patient" ->
+            Some
+                {
+                    User = user UserRole.Prescriber
+                    ActivePatientId = Some "other-patient"
+                    PinSet = true
+                }
+        | "no-pin" ->
+            Some
+                {
+                    User = user UserRole.Prescriber
+                    ActivePatientId = Some activePatientId
+                    PinSet = false
+                }
+        | _ -> None
+
+
+    /// The directory: one-time codes (the stub IdP) and the active Patient per login (the stub
+    /// registry), behind a lock. `issue` is what `/authorize` calls once it read the identity
+    /// choice and the active Patient from the stub cookie.
+    type Directory =
+        {
+            idp: IdentityProviderPort
+            registry: UserRegistryPort
+            issue: string -> string -> string
+        }
+
+
+    let make (newCode: unit -> string) : Directory =
+        let gate = obj ()
+        let codes = Collections.Generic.Dictionary<string, BrowserIdentity>()
+        let active = Collections.Generic.Dictionary<string, string>()
+
+        {
+            idp =
+                {
+                    authorizeUrl = fun state -> $"/authorize?state={Uri.EscapeDataString state}"
+                    redeem =
+                        fun code ->
+                            lock
+                                gate
+                                (fun () ->
+                                    match codes.TryGetValue code with
+                                    | true, identity ->
+                                        codes.Remove code |> ignore
+                                        Some identity
+                                    | _ -> None
+                                )
+                }
+            registry =
+                {
+                    standing =
+                        fun identity ->
+                            lock
+                                gate
+                                (fun () ->
+                                    match active.TryGetValue identity.Login with
+                                    | true, pid -> standingOf pid identity
+                                    | _ -> standingOf "" identity
+                                )
+                }
+            issue =
+                fun choice activePatientId ->
+                    lock
+                        gate
+                        (fun () ->
+                            let code = newCode ()
+                            codes[code] <- identityOf choice
+                            active[choice] <- activePatientId
+                            code
+                        )
+        }
+
+
+/// The PatientDataPlatform stub: nothing to import, except that `no-data` has no record at all
+/// (ext 6a).
+module StubPatientData =
+
+    let port: PatientDataPort =
+        {
+            read = fun pid -> if pid = "no-data" then None else Some Patient.empty
+        }
+
+
+/// The stub launch page's identity choice, carried to the stub IdentityProvider in a cookie
+/// (→ `StubLaunch` in ServerApi.Adapters.fs). The value is `choice.pid`, both url-escaped, so
+/// the stub UserRegistry knows which Patient the page made active.
+module StubLaunch =
+
+    open StubLaunch
+
+    let choices = StubDirectory.choices
+
+    let identityCookieName = "genpres_stub_identity"
+
+
+    /// The stub identity cookie value for a choice and the Patient the page made active.
+    let identityCookie (choice: string) (pid: string) =
+        $"{Uri.EscapeDataString choice}.{Uri.EscapeDataString pid}"
+
+
+    /// The choice and the Patient back from the cookie; None for anything else.
+    let parseIdentityCookie (value: string option) : (string * string) option =
+        match value with
+        | Some v when not (String.IsNullOrWhiteSpace v) ->
+            match v.Split('.') with
+            | [| choice; pid |] when choices |> List.contains (Uri.UnescapeDataString choice) ->
+                Some(Uri.UnescapeDataString choice, Uri.UnescapeDataString pid)
+            | _ -> None
+        | _ -> None
+
+
+// ---------------------------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------------------------
+
+open Expecto
+open Expecto.Flip
+
+
+let sealKey = LaunchSeal.Key(Array.init LaunchSeal.keyLength byte)
+let t0 = DateTime(2026, 9, 10, 12, 0, 0, DateTimeKind.Utc)
+let lifetime = TimeSpan.FromMinutes 2.0
+let verifyAt (now: DateTime) = LaunchSeal.verify now sealKey
+let keyA = PublicKey "key-a"
+let keyB = PublicKey "key-b"
+
+let mintFor nonce pid =
+    LaunchSeal.mint
+        sealKey
+        {
+            PatientId = pid
+            Nonce = nonce
+            Expiry = t0 + lifetime
+        }
+
+let launch1 = mintFor "n-1" "patient-1"
+
+let counter prefix =
+    let n = ref 0
+
+    fun () ->
+        n.Value <- n.Value + 1
+        $"{prefix}-{n.Value}"
+
+
+/// A fresh directory and id sources per test.
+let fixture () =
+    let ids = counter "id"
+    let directory = StubDirectory.make (counter "code")
+    ids, directory
+
+
+/// Presents, then plays the stub IdP for `choice`, and returns the callback the browser brings.
+let hop (ids: unit -> string) (directory: StubDirectory.Directory) state launch key choice =
+    let state, result = Hop.present t0 ids (verifyAt t0) directory.idp.authorizeUrl state (launch, key)
+
+    match result with
+    | LaunchResult.RedirectTo(_, st) ->
+        let cb =
+            if choice = "none" then
+                {
+                    State = st
+                    StateCookie = Some st
+                    Code = None
+                    Error = Some "no-identity"
+                }
+            else
+                {
+                    State = st
+                    StateCookie = Some st
+                    Code = Some(directory.issue choice "patient-1")
+                    Error = None
+                }
+
+        state, cb
+    | other -> failtest $"expected RedirectTo, got {other}"
+
+
+let run (ids: unit -> string) (directory: StubDirectory.Directory) state cb =
+    Hop.callback t0 ids directory.idp.redeem directory.registry.standing StubPatientData.port.read state cb
+
+
+let presentTests =
+    testList
+        "Hop.present"
+        [
+            test "a sealed Launch is recorded under its nonce and sent to the IdentityProvider" {
+                let ids, d = fixture ()
+                let state, result = Hop.present t0 ids (verifyAt t0) d.idp.authorizeUrl Hop.emptyState (launch1, keyA)
+
+                match result with
+                | LaunchResult.RedirectTo(url, st) ->
+                    url |> Expect.equal "authorize url carries the state" $"/authorize?state={st}"
+                    let record = state.Launches["n-1"]
+                    record.State |> Expect.equal "same state in the record" st
+                    record.PatientId |> Expect.equal "patient" "patient-1"
+                    record.Outcome |> Expect.isNone "no outcome yet"
+                | other -> failtest $"expected RedirectTo, got {other}"
+            }
+
+            test "the same key while the hop is open gets the same redirect (Rule 2, retry)" {
+                let ids, d = fixture ()
+                let state, first = Hop.present t0 ids (verifyAt t0) d.idp.authorizeUrl Hop.emptyState (launch1, keyA)
+                let state2, again = Hop.present t0 ids (verifyAt t0) d.idp.authorizeUrl state (launch1, keyA)
+                again |> Expect.equal "same redirect" first
+                state2 |> Expect.equal "same state" state
+            }
+
+            test "another key is spent" {
+                let ids, d = fixture ()
+                let state, _ = Hop.present t0 ids (verifyAt t0) d.idp.authorizeUrl Hop.emptyState (launch1, keyA)
+                let _, other = Hop.present t0 ids (verifyAt t0) d.idp.authorizeUrl state (launch1, keyB)
+                other |> Expect.equal "spent" (LaunchResult.Refused LaunchRefusal.LaunchSpent)
+            }
+
+            test "after the hop opened, the same key gets the opened Session (Rule 2)" {
+                let ids, d = fixture ()
+                let state, cb = hop ids d Hop.emptyState launch1 keyA "prescriber"
+                let state, opened = run ids d state cb
+                let _, again = Hop.present t0 ids (verifyAt t0) d.idp.authorizeUrl state (launch1, keyA)
+
+                match opened, again with
+                | CallbackResult.Opened(id, _), LaunchResult.Opened(id', session) ->
+                    id' |> Expect.equal "same session" id
+                    session.User |> Option.map _.DisplayName |> Expect.equal "user" (Some "Stub Prescriber")
+                | other -> failtest $"expected Opened twice, got {other}"
+            }
+
+            test "not sealed, or expired: refused and nothing recorded" {
+                let ids, d = fixture ()
+
+                let _, invalid =
+                    Hop.present t0 ids (verifyAt t0) d.idp.authorizeUrl Hop.emptyState (Launch "junk", keyA)
+
+                invalid |> Expect.equal "invalid" (LaunchResult.Refused LaunchRefusal.LaunchInvalid)
+                let late = t0 + lifetime + TimeSpan.FromSeconds 1.0
+
+                let state, expired =
+                    Hop.present late ids (verifyAt late) d.idp.authorizeUrl Hop.emptyState (launch1, keyA)
+
+                expired |> Expect.equal "expired" (LaunchResult.Refused LaunchRefusal.LaunchExpired)
+                state.Launches |> Map.isEmpty |> Expect.isTrue "nothing recorded"
+            }
+        ]
+
+
+let callbackTests =
+    testList
+        "Hop.callback"
+        [
+            test "prescriber: the Session opens for the Launch's Patient, the outcome is recorded" {
+                let ids, d = fixture ()
+                let state, cb = hop ids d Hop.emptyState launch1 keyA "prescriber"
+                let state, result = run ids d state cb
+
+                match result with
+                | CallbackResult.Opened(id, url) ->
+                    url |> Expect.equal "to the app" "/#/session"
+                    let record = state.Sessions[id]
+                    record.Login |> Expect.equal "login" (Some "prescriber")
+                    record.Session.User |> Option.map _.Role |> Expect.equal "role" (Some UserRole.Prescriber)
+                    record.Session.PatientContext |> Option.map _.PatientId |> Expect.equal "patient" (Some "patient-1")
+                    record.Session.KeyThumbprint |> Expect.equal "thumbprint" (Some(PublicKey.thumbprint keyA))
+                    state.Launches["n-1"].Outcome |> Expect.isSome "outcome appended"
+                | other -> failtest $"expected Opened, got {other}"
+            }
+
+            test "reader: opens without a PIN (ext 5c)" {
+                let ids, d = fixture ()
+                let state, cb = hop ids d Hop.emptyState launch1 keyA "reader"
+                let state, result = run ids d state cb
+
+                match result with
+                | CallbackResult.Opened(id, _) ->
+                    state.Sessions[id].Session.User |> Option.map _.Role |> Expect.equal "role" (Some UserRole.Reader)
+                | other -> failtest $"expected Opened, got {other}"
+            }
+
+            testList
+                "refusals, each recorded and each with its word"
+                [
+                    for choice, refusal in
+                        [
+                            "none", LaunchRefusal.NoBrowserIdentity
+                            "unknown", LaunchRefusal.NoRole
+                            "prescriber-other-patient", LaunchRefusal.WrongActivePatient
+                            "no-pin", LaunchRefusal.EnrolmentRequired
+                        ] do
+                        test choice {
+                            let ids, d = fixture ()
+                            let state, cb = hop ids d Hop.emptyState launch1 keyA choice
+                            let state, result = run ids d state cb
+
+                            result
+                            |> Expect.equal
+                                "refused"
+                                (CallbackResult.Refused(refusal, $"/#/session?refused={Hop.refusalWord refusal}"))
+
+                            state.Sessions |> Map.isEmpty |> Expect.isTrue "no session (Rule 7)"
+
+                            state.Launches["n-1"].Outcome
+                            |> Expect.equal "recorded" (Some(LaunchResult.Refused refusal))
+                        }
+                ]
+
+            test "a callback reload gets the same answer without a second redeem (Rule 45)" {
+                let ids, d = fixture ()
+                let state, cb = hop ids d Hop.emptyState launch1 keyA "prescriber"
+                let state, first = run ids d state cb
+                // the code was consumed by the first redeem; the replay must not need it
+                let state2, again = run ids d state cb
+                again |> Expect.equal "same answer" first
+                state2 |> Expect.equal "same state" state
+            }
+
+            test "a state cookie that does not match is invalid, and nothing is redeemed" {
+                let ids, d = fixture ()
+                let state, cb = hop ids d Hop.emptyState launch1 keyA "prescriber"
+
+                for cookie in [ None; Some "other" ] do
+                    let state2, result = run ids d state { cb with StateCookie = cookie }
+                    result |> Expect.equal $"cookie {cookie}" (CallbackResult.Refused(LaunchRefusal.LaunchInvalid, "/#/session?refused=invalid"))
+                    state2.Launches["n-1"].Outcome |> Expect.isNone "hop still open"
+            }
+
+            test "an unknown state is invalid" {
+                let ids, d = fixture ()
+
+                let _, result =
+                    run ids d Hop.emptyState { State = "nope"; StateCookie = Some "nope"; Code = Some "c"; Error = None }
+
+                result |> Expect.equal "invalid" (CallbackResult.Refused(LaunchRefusal.LaunchInvalid, "/#/session?refused=invalid"))
+            }
+
+            test "a code that does not redeem is no browser identity" {
+                let ids, d = fixture ()
+                let state, cb = hop ids d Hop.emptyState launch1 keyA "prescriber"
+                let _, result = run ids d state { cb with Code = Some "forged" }
+                result |> Expect.equal "no identity" (CallbackResult.Refused(LaunchRefusal.NoBrowserIdentity, "/#/session?refused=no-identity"))
+            }
+
+            test "after the lifetime the callback is invalid: the record is gone (Rule 29)" {
+                let ids, d = fixture ()
+                let state, cb = hop ids d Hop.emptyState launch1 keyA "prescriber"
+                let late = t0 + lifetime + TimeSpan.FromSeconds 1.0
+
+                let state2, result =
+                    Hop.callback late ids d.idp.redeem d.registry.standing StubPatientData.port.read state cb
+
+                result |> Expect.equal "invalid" (CallbackResult.Refused(LaunchRefusal.LaunchInvalid, "/#/session?refused=invalid"))
+                state2.Launches |> Map.isEmpty |> Expect.isTrue "dropped"
+            }
+
+            test "no patient data (ext 6a): the Session opens with the PatientId and an empty Patient" {
+                let ids, d = fixture ()
+                let launch = mintFor "n-nd" "no-data"
+                let state, result = Hop.present t0 ids (verifyAt t0) d.idp.authorizeUrl Hop.emptyState (launch, keyA)
+
+                let st =
+                    match result with
+                    | LaunchResult.RedirectTo(_, st) -> st
+                    | other -> failtest $"{other}"
+
+                let cb =
+                    {
+                        State = st
+                        StateCookie = Some st
+                        Code = Some(d.issue "prescriber" "no-data")
+                        Error = None
+                    }
+
+                let state, result = run ids d state cb
+
+                match result with
+                | CallbackResult.Opened(id, _) ->
+                    let ctx = state.Sessions[id].Session.PatientContext
+                    ctx |> Option.map _.PatientId |> Expect.equal "patient id" (Some "no-data")
+                    ctx |> Option.map _.Patient |> Expect.equal "empty patient" (Some Patient.empty)
+                | other -> failtest $"expected Opened, got {other}"
+            }
+
+            test "a second launch of the same login closes the first Session and marks it (Rule 8)" {
+                let ids, d = fixture ()
+                let state, cb1 = hop ids d Hop.emptyState launch1 keyA "prescriber"
+                let state, first = run ids d state cb1
+                let state, cb2 = hop ids d state (mintFor "n-2" "patient-1") keyB "prescriber"
+                let state, second = run ids d state cb2
+
+                match first, second with
+                | CallbackResult.Opened(id1, _), CallbackResult.Opened(id2, _) ->
+                    state.Sessions |> Map.containsKey id1 |> Expect.isFalse "first closed"
+                    state.Sessions |> Map.containsKey id2 |> Expect.isTrue "second open"
+                    state.Endings |> Map.tryFind id1 |> Expect.equal "marked" (Some Hop.SessionEnding.SupersededByLaunch)
+                | other -> failtest $"expected two Opened, got {other}"
+            }
+
+            test "two logins keep two Sessions" {
+                let ids, d = fixture ()
+                let state, cb1 = hop ids d Hop.emptyState launch1 keyA "prescriber"
+                let state, _ = run ids d state cb1
+                let state, cb2 = hop ids d state (mintFor "n-2" "patient-1") keyB "reader"
+                let state, _ = run ids d state cb2
+                state.Sessions |> Map.count |> Expect.equal "two" 2
+                state.Endings |> Map.isEmpty |> Expect.isTrue "none ended"
+            }
+        ]
+
+
+let portTests =
+    testList
+        "makeSessionPort"
+        [
+            testAsync "present, callback, find, close over the port" {
+                let ids, d = fixture ()
+
+                let port =
+                    Hop.makeSessionPort (fun () -> t0) ids (verifyAt t0) d.idp d.registry StubPatientData.port
+
+                let! redirect = port.present (launch1, keyA)
+
+                let st =
+                    match redirect with
+                    | LaunchResult.RedirectTo(_, st) -> st
+                    | other -> failtest $"{other}"
+
+                let! opened =
+                    port.callback
+                        {
+                            State = st
+                            StateCookie = Some st
+                            Code = Some(d.issue "prescriber" "patient-1")
+                            Error = None
+                        }
+
+                match opened with
+                | CallbackResult.Opened(id, _) ->
+                    let! found = port.find id
+                    found |> Option.bind _.User |> Option.map _.UserId |> Expect.equal "found" (Some "prescriber")
+                    do! port.close id
+                    let! gone = port.find id
+                    gone |> Expect.isNone "closed"
+                | other -> failtest $"expected Opened, got {other}"
+            }
+        ]
+
+
+let identityCookieTests =
+    testList
+        "StubLaunch identity cookie"
+        [
+            test "round trip, with characters the cookie cannot carry" {
+                StubLaunch.identityCookie "prescriber" "p 1;2"
+                |> Some
+                |> StubLaunch.parseIdentityCookie
+                |> Expect.equal "same" (Some("prescriber", "p 1;2"))
+            }
+
+            test "an unknown choice, garbage or nothing is None" {
+                for v in [ Some "hacker.p"; Some "prescriber"; Some ""; None ] do
+                    StubLaunch.parseIdentityCookie v |> Expect.isNone $"{v}"
+            }
+        ]
+
+
+let directoryTests =
+    testList
+        "StubDirectory"
+        [
+            test "a code redeems once" {
+                let d = StubDirectory.make (counter "code")
+                let code = d.issue "prescriber" "p"
+                d.idp.redeem code |> Option.map _.Login |> Expect.equal "first" (Some "prescriber")
+                d.idp.redeem code |> Expect.isNone "second"
+            }
+
+            test "every choice but none has an identity; unknown has no standing" {
+                let d = StubDirectory.make (counter "code")
+
+                for choice in StubDirectory.choices |> List.filter ((<>) "none") do
+                    let identity = d.idp.redeem (d.issue choice "p") |> Option.get
+                    identity.Login |> Expect.equal "login" choice
+
+                    match choice, d.registry.standing identity with
+                    | "unknown", None -> ()
+                    | "unknown", Some _ -> failtest "unknown has standing"
+                    | _, None -> failtest $"{choice} has no standing"
+                    | _, Some _ -> ()
+            }
+        ]
+
+
+runTestsWithCLIArgs
+    []
+    [||]
+    (testList "Hop.fsx" [ presentTests; callbackTests; portTests; directoryTests; identityCookieTests ])
+|> ignore

--- a/src/Informedica.GenPRES.Server/Scripts/Hop.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/Hop.fsx
@@ -93,6 +93,9 @@ type Callback =
 type CallbackResult =
     | Opened of sessionId: string * redirect: string
     | Refused of LaunchRefusal * redirect: string
+    // a reload of a callback whose Session a newer launch has since replaced (Rule 8): the
+    // browser goes to the app on whatever cookie it holds, which is the newer Session's
+    | Superseded of redirect: string
 
 
 type SessionPort =
@@ -107,7 +110,8 @@ type SessionPort =
 /// The state cookie of one request (4.2): written with the redirect, read at the callback.
 type LaunchStateCookie =
     {
-        read: unit -> string option
+        // the cookie of one hop, named by its state, so that two tabs can launch at once
+        read: string -> string option
         write: string -> unit
     }
 
@@ -312,7 +316,11 @@ module Hop =
         match cb.StateCookie, byState with
         | Some cookie, Some record when cookie = cb.State && cb.State <> "" ->
             match record.Outcome with
-            | Some(LaunchResult.Opened(id, _)) -> state, CallbackResult.Opened(id, openedUrl)
+            | Some(LaunchResult.Opened(id, _)) when state.Sessions |> Map.containsKey id ->
+                state, CallbackResult.Opened(id, openedUrl)
+            // the recorded Session was replaced by a newer launch of the same login (Rule 8):
+            // answering its id would put a dead cookie over the live one
+            | Some(LaunchResult.Opened _) -> state, CallbackResult.Superseded openedUrl
             | Some(LaunchResult.Refused refusal) -> state, CallbackResult.Refused(refusal, refusedUrl refusal)
             | Some(LaunchResult.RedirectTo _)
             | None ->
@@ -452,10 +460,22 @@ module StubDirectory =
         }
 
 
-    let make (newCode: unit -> string) : Directory =
+    /// A code lives as long as a Launch (Rule 29); older ones are pruned on the next issue.
+    let codeLifetime = TimeSpan.FromMinutes 2.0
+
+
+    /// One active Patient per login, as MainEHR has: a later launch of the same login for
+    /// another Patient makes an earlier, still open launch wrong-patient (ext 5b).
+    let make (now: unit -> DateTime) (newCode: unit -> string) : Directory =
         let gate = obj ()
-        let codes = Collections.Generic.Dictionary<string, BrowserIdentity>()
+        let codes = Collections.Generic.Dictionary<string, BrowserIdentity * DateTime>()
         let active = Collections.Generic.Dictionary<string, string>()
+
+        let prune () =
+            let cutoff = now () - codeLifetime
+
+            for stale in codes |> Seq.filter (fun kv -> snd kv.Value < cutoff) |> Seq.map _.Key |> Seq.toList do
+                codes.Remove stale |> ignore
 
         {
             idp =
@@ -467,7 +487,7 @@ module StubDirectory =
                                 gate
                                 (fun () ->
                                     match codes.TryGetValue code with
-                                    | true, identity ->
+                                    | true, (identity, issued) when now () - issued <= codeLifetime ->
                                         codes.Remove code |> ignore
                                         Some identity
                                     | _ -> None
@@ -490,8 +510,9 @@ module StubDirectory =
                     lock
                         gate
                         (fun () ->
+                            prune ()
                             let code = newCode ()
-                            codes[code] <- identityOf choice
+                            codes[code] <- identityOf choice, now ()
                             active[choice] <- activePatientId
                             code
                         )
@@ -573,7 +594,7 @@ let counter prefix =
 /// A fresh directory and id sources per test.
 let fixture () =
     let ids = counter "id"
-    let directory = StubDirectory.make (counter "code")
+    let directory = StubDirectory.make (fun () -> t0) (counter "code")
     ids, directory
 
 
@@ -821,6 +842,17 @@ let callbackTests =
                 | other -> failtest $"expected two Opened, got {other}"
             }
 
+            test "a callback reload after a newer launch of the same login does not hand back the dead Session" {
+                let ids, d = fixture ()
+                let state, cb1 = hop ids d Hop.emptyState launch1 keyA "prescriber"
+                let state, _ = run ids d state cb1
+                let state, cb2 = hop ids d state (mintFor "n-2" "patient-1") keyB "prescriber"
+                let state, _ = run ids d state cb2
+                let state2, again = run ids d state cb1
+                again |> Expect.equal "superseded" (CallbackResult.Superseded "/#/session")
+                state2 |> Expect.equal "unchanged" state
+            }
+
             test "two logins keep two Sessions" {
                 let ids, d = fixture ()
                 let state, cb1 = hop ids d Hop.emptyState launch1 keyA "prescriber"
@@ -893,15 +925,25 @@ let directoryTests =
     testList
         "StubDirectory"
         [
+            test "past the lifetime a code does not redeem, and the next issue prunes it" {
+                let clock = ref t0
+                let d = StubDirectory.make (fun () -> clock.Value) (counter "code")
+                let stale = d.issue "prescriber" "p"
+                clock.Value <- t0 + StubDirectory.codeLifetime + TimeSpan.FromSeconds 1.0
+                d.idp.redeem stale |> Expect.isNone "stale"
+                let fresh = d.issue "reader" "p"
+                d.idp.redeem fresh |> Option.map _.Login |> Expect.equal "fresh" (Some "reader")
+            }
+
             test "a code redeems once" {
-                let d = StubDirectory.make (counter "code")
+                let d = StubDirectory.make (fun () -> t0) (counter "code")
                 let code = d.issue "prescriber" "p"
                 d.idp.redeem code |> Option.map _.Login |> Expect.equal "first" (Some "prescriber")
                 d.idp.redeem code |> Expect.isNone "second"
             }
 
             test "every choice but none has an identity; unknown has no standing" {
-                let d = StubDirectory.make (counter "code")
+                let d = StubDirectory.make (fun () -> t0) (counter "code")
 
                 for choice in StubDirectory.choices |> List.filter ((<>) "none") do
                     let identity = d.idp.redeem (d.issue choice "p") |> Option.get

--- a/src/Informedica.GenPRES.Server/Server.fs
+++ b/src/Informedica.GenPRES.Server/Server.fs
@@ -300,7 +300,9 @@ module Http =
         CookieOptions(HttpOnly = true, Secure = isHttps, SameSite = SameSiteMode.Strict, Path = "/")
 
 
-    let launchStateCookieName = "genpres_launch_state"
+    /// One state cookie per hop, named by the state (base64url, so a cookie-name token), so
+    /// that two tabs can launch at once without the second erasing the first's proof.
+    let launchStateCookieName (state: string) = $"genpres_launch_state.{state}"
 
 
     /// The state cookie of the identity hop (uc-01 step 4.2): HttpOnly, SameSite=Lax so that
@@ -333,14 +335,14 @@ module Http =
     let launchStateCookie (ctx: HttpContext) : LaunchStateCookie =
         {
             read =
-                fun () ->
-                    match ctx.Request.Cookies.TryGetValue launchStateCookieName with
+                fun state ->
+                    match ctx.Request.Cookies.TryGetValue(launchStateCookieName state) with
                     | true, value when not (System.String.IsNullOrWhiteSpace value) -> Some value
                     | _ -> None
             write =
                 fun state ->
                     ctx.Response.Cookies.Append(
-                        launchStateCookieName,
+                        launchStateCookieName state,
                         state,
                         launchStateCookieOptions ctx.Request.IsHttps
                     )
@@ -607,7 +609,8 @@ module Host =
 
         // the stub IdentityProvider and UserRegistry (plan 605): one-time codes and the active
         // patient per identity choice, issued by /authorize and redeemed at the callback
-        let directory = StubDirectory.make PublicKey.randomId
+        let directory =
+            StubDirectory.make (fun () -> System.DateTime.UtcNow) PublicKey.randomId
 
         let env =
             let env = Adapters.makeAppEnvWith launchKey directory provider

--- a/src/Informedica.GenPRES.Server/Server.fs
+++ b/src/Informedica.GenPRES.Server/Server.fs
@@ -300,6 +300,53 @@ module Http =
         CookieOptions(HttpOnly = true, Secure = isHttps, SameSite = SameSiteMode.Strict, Path = "/")
 
 
+    let launchStateCookieName = "genpres_launch_state"
+
+
+    /// The state cookie of the identity hop (uc-01 step 4.2): HttpOnly, SameSite=Lax so that
+    /// the redirect back from the IdentityProvider carries it, Path=/callback so that nothing
+    /// else sees it, Max-Age the Launch lifetime (Rule 29), Secure when the request came in
+    /// over HTTPS. Not a bearer for anything: it proves the browser that started the hop.
+    let launchStateCookieOptions (isHttps: bool) =
+        CookieOptions(
+            HttpOnly = true,
+            Secure = isHttps,
+            SameSite = SameSiteMode.Lax,
+            Path = "/callback",
+            MaxAge = StubLaunch.lifetime
+        )
+
+
+    /// The stub page's identity choice for the stub IdentityProvider: readable by /authorize
+    /// only for the Launch lifetime; HttpOnly and Lax, never a credential.
+    let stubIdentityCookieOptions (isHttps: bool) =
+        CookieOptions(
+            HttpOnly = true,
+            Secure = isHttps,
+            SameSite = SameSiteMode.Lax,
+            Path = "/",
+            MaxAge = StubLaunch.lifetime
+        )
+
+
+    /// The state cookie of this request as the port the composition root uses.
+    let launchStateCookie (ctx: HttpContext) : LaunchStateCookie =
+        {
+            read =
+                fun () ->
+                    match ctx.Request.Cookies.TryGetValue launchStateCookieName with
+                    | true, value when not (System.String.IsNullOrWhiteSpace value) -> Some value
+                    | _ -> None
+            write =
+                fun state ->
+                    ctx.Response.Cookies.Append(
+                        launchStateCookieName,
+                        state,
+                        launchStateCookieOptions ctx.Request.IsHttps
+                    )
+        }
+
+
     /// The session cookie of this request as the port the composition root uses.
     let sessionCookie (ctx: HttpContext) : SessionCookie =
         {
@@ -558,8 +605,12 @@ module Host =
         let launchKey =
             LaunchSeal.newKey System.Security.Cryptography.RandomNumberGenerator.GetBytes
 
+        // the stub IdentityProvider and UserRegistry (plan 605): one-time codes and the active
+        // patient per identity choice, issued by /authorize and redeemed at the callback
+        let directory = StubDirectory.make PublicKey.randomId
+
         let env =
-            let env = Adapters.makeAppEnvWith launchKey provider
+            let env = Adapters.makeAppEnvWith launchKey directory provider
 
             // Stop-gap until the scope switch (#580): a production server never opens a
             // stub Session. Drop this swap when #580 decides what production exposes.
@@ -573,7 +624,9 @@ module Host =
 
         let webApi =
             Remoting.createApi ()
-            |> Remoting.fromContext (fun ctx -> createServerApi serverSettings env (Http.sessionCookie ctx))
+            |> Remoting.fromContext (fun ctx ->
+                createServerApi serverSettings env (Http.sessionCookie ctx) (Http.launchStateCookie ctx)
+            )
             |> Remoting.withRouteBuilder routerPaths
             |> Remoting.buildHttpHandler
 
@@ -600,10 +653,71 @@ module Host =
                                 | true, values -> values.ToString()
                                 | _ -> ""
 
+                            let choice =
+                                match form.TryGetValue "identity" with
+                                | true, values when StubLaunch.choices |> List.contains (values.ToString()) ->
+                                    values.ToString()
+                                | _ -> "prescriber"
+
                             let launch = StubLaunch.mint System.DateTime.UtcNow PublicKey.randomId launchKey pid
+
+                            // what the stub IdentityProvider will say at /authorize, and which
+                            // patient the stub UserRegistry has active for it
+                            ctx.Response.Cookies.Append(
+                                StubLaunch.identityCookieName,
+                                StubLaunch.identityCookie choice pid,
+                                Http.stubIdentityCookieOptions ctx.Request.IsHttps
+                            )
+
                             return! redirectTo false (StubLaunch.launchUrl launch) next ctx
                         }
+                    // the stub IdentityProvider (uc-01 step 4.3): signs the browser on from the
+                    // identity chosen on the stub page, or reports no identity, and sends it back
+                    // with the state it received
+                    GET
+                    >=> route "/authorize"
+                    >=> fun next ctx ->
+                        let state = ctx.TryGetQueryStringValue "state" |> Option.defaultValue ""
+
+                        let identity =
+                            match ctx.Request.Cookies.TryGetValue StubLaunch.identityCookieName with
+                            | true, value -> StubLaunch.parseIdentityCookie (Some value)
+                            | _ -> None
+
+                        let url =
+                            match identity with
+                            | None
+                            | Some("none", _) ->
+                                $"/callback?state={System.Uri.EscapeDataString state}&error=no-identity"
+                            | Some(choice, pid) ->
+                                let code = directory.issue choice pid
+                                $"/callback?code={System.Uri.EscapeDataString code}&state={System.Uri.EscapeDataString state}"
+
+                        redirectTo false url next ctx
                 ]
+
+        // uc-01 step 4.5: the browser is back from the IdentityProvider. Mounted always; with the
+        // session port disabled it refuses as invalid.
+        let callback =
+            GET
+            >=> route "/callback"
+            >=> fun next ctx ->
+                task {
+                    let query name = ctx.TryGetQueryStringValue name
+
+                    let cb: Callback =
+                        {
+                            State = query "state" |> Option.defaultValue ""
+                            StateCookie = None
+                            Code = query "code"
+                            Error = query "error"
+                        }
+
+                    let! redirect =
+                        CompositionRoot.processCallback env (Http.sessionCookie ctx) (Http.launchStateCookie ctx) cb
+
+                    return! redirectTo false redirect next ctx
+                }
 
         // one request log around the whole route selection: the stub page, the api and the
         // 404 arm each leave exactly one trail
@@ -612,6 +726,7 @@ module Host =
             >=> choose
                     [
                         yield! stubLaunch
+                        callback
                         Http.safeWebApi webApi
                         setStatusCode 404 >=> text "Not Found"
                     ]

--- a/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
@@ -394,7 +394,11 @@ module Hop =
         match cb.StateCookie, byState with
         | Some cookie, Some record when cookie = cb.State && cb.State <> "" ->
             match record.Outcome with
-            | Some(LaunchResult.Opened(id, _)) -> state, CallbackResult.Opened(id, openedUrl)
+            | Some(LaunchResult.Opened(id, _)) when state.Sessions |> Map.containsKey id ->
+                state, CallbackResult.Opened(id, openedUrl)
+            // the recorded Session was replaced by a newer launch of the same login (Rule 8):
+            // answering its id would put a dead cookie over the live one
+            | Some(LaunchResult.Opened _) -> state, CallbackResult.Superseded openedUrl
             | Some(LaunchResult.Refused refusal) -> state, CallbackResult.Refused(refusal, refusedUrl refusal)
             | Some(LaunchResult.RedirectTo _)
             | None ->
@@ -539,10 +543,26 @@ module StubDirectory =
         }
 
 
-    let make (newCode: unit -> string) : Directory =
+    /// A code lives as long as a Launch (Rule 29); older ones are pruned on the next issue.
+    let codeLifetime = TimeSpan.FromMinutes 2.0
+
+
+    /// One active Patient per login, as MainEHR has: a later launch of the same login for
+    /// another Patient makes an earlier, still open launch wrong-patient (ext 5b).
+    let make (now: unit -> DateTime) (newCode: unit -> string) : Directory =
         let gate = obj ()
-        let codes = Collections.Generic.Dictionary<string, BrowserIdentity>()
+        let codes = Collections.Generic.Dictionary<string, BrowserIdentity * DateTime>()
         let active = Collections.Generic.Dictionary<string, string>()
+
+        let prune () =
+            let cutoff = now () - codeLifetime
+
+            for stale in
+                codes
+                |> Seq.filter (fun kv -> snd kv.Value < cutoff)
+                |> Seq.map _.Key
+                |> Seq.toList do
+                codes.Remove stale |> ignore
 
         {
             idp =
@@ -554,7 +574,7 @@ module StubDirectory =
                                 gate
                                 (fun () ->
                                     match codes.TryGetValue code with
-                                    | true, identity ->
+                                    | true, (identity, issued) when now () - issued <= codeLifetime ->
                                         codes.Remove code |> ignore
                                         Some identity
                                     | _ -> None
@@ -577,8 +597,9 @@ module StubDirectory =
                     lock
                         gate
                         (fun () ->
+                            prune ()
                             let code = newCode ()
-                            codes[code] <- identityOf choice
+                            codes[code] <- identityOf choice, now ()
                             active[choice] <- activePatientId
                             code
                         )
@@ -905,5 +926,5 @@ module Adapters =
     let makeAppEnv (provider: Informedica.GenForm.Lib.Resources.IResourceProvider) =
         makeAppEnvWith
             (LaunchSeal.newKey System.Security.Cryptography.RandomNumberGenerator.GetBytes)
-            (StubDirectory.make PublicKey.randomId)
+            (StubDirectory.make (fun () -> DateTime.UtcNow) PublicKey.randomId)
             provider

--- a/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
@@ -185,25 +185,63 @@ module LaunchSeal =
         | _ -> Error LaunchRefusal.LaunchInvalid
 
 
-/// In-memory stand-in for launch steps 4 and 5 (plan 409 step 2). It never redirects: the
-/// answer comes from the Launch text. The record it keeps per Launch is the LaunchRecord the
-/// real server appends at step 4.2, with the Launch text standing in for the nonce.
-module SessionStub =
+/// Launch steps 4 and 5 over server-hosted stubs (plan 605): the LaunchRecord keyed by the
+/// nonce (4.2), the redirect to the IdentityProvider, the callback (4.5) with the step-5 ladder,
+/// the Rule 45 replay and the Rule 40 single act with the Rule 8 closes. Pure over a state
+/// record; `makeSessionPort` wraps it in a lock over the three actor ports.
+module Hop =
 
-    /// One record per Launch (Rules 2, 40, 45): the public key that presented it, the answer
-    /// it got, and when both are forgotten (Rule 29).
+    /// The refusal words of `#/session?refused=<word>`; the client's `parseRefusal` reads them.
+    let refusalWord refusal =
+        match refusal with
+        | LaunchRefusal.LaunchExpired -> "expired"
+        | LaunchRefusal.LaunchSpent -> "spent"
+        | LaunchRefusal.LaunchInvalid -> "invalid"
+        | LaunchRefusal.NoBrowserIdentity -> "no-identity"
+        | LaunchRefusal.NoRole -> "no-role"
+        | LaunchRefusal.WrongActivePatient -> "wrong-patient"
+        | LaunchRefusal.EnrolmentRequired -> "enrolment"
+
+
+    let openedUrl = "/#/session"
+
+    let refusedUrl refusal =
+        $"/#/session?refused={refusalWord refusal}"
+
+
+    /// One record per Launch (4.2), keyed by the nonce (Rule 2) and found by the `state` at the
+    /// callback. The outcome is appended once (Rule 45); the record is dropped whole at expiry.
     type LaunchRecord =
         {
+            Nonce: string
+            State: string
+            PatientId: string
             PublicKey: PublicKey
-            Result: LaunchResult
             Expiry: DateTime
+            Outcome: LaunchResult option
         }
+
+
+    /// A Session as the store holds it: what the client learns, plus the login it belongs to
+    /// (Rule 8: a User has at most one open Session).
+    type SessionRecord =
+        {
+            Session: SessionOpened
+            Login: string option
+        }
+
+
+    /// Why a Session ended other than by the User closing it (Rule 11). One case now.
+    [<RequireQualifiedAccess>]
+    type SessionEnding = SupersededByLaunch
 
 
     type State =
         {
             Launches: Map<string, LaunchRecord>
-            Sessions: Map<string, SessionOpened>
+            Sessions: Map<string, SessionRecord>
+            // sessions ended by the server, told once at the next GetSession (Rule 11, PR 4)
+            Endings: Map<string, SessionEnding>
         }
 
 
@@ -211,84 +249,184 @@ module SessionStub =
         {
             Launches = Map.empty
             Sessions = Map.empty
+            Endings = Map.empty
         }
 
 
-    let stubUser =
-        {
-            UserId = "stub-prescriber"
-            DisplayName = "Stub Prescriber"
-            Role = UserRole.Prescriber
-        }
+    let private dropExpired (now: DateTime) (state: State) =
+        { state with Launches = state.Launches |> Map.filter (fun _ r -> now <= r.Expiry) }
 
 
-    /// Answers a presentation and returns the state after it. Pure: the clock, the id source,
-    /// the verifier and the patient are parameters.
+    /// The answer `present` gives for a record: the recorded outcome, else the redirect again.
+    let private answerOf (authorizeUrl: string -> string) (record: LaunchRecord) =
+        match record.Outcome with
+        | Some outcome -> outcome
+        | None -> LaunchResult.RedirectTo(authorizeUrl record.State, record.State)
+
+
+    /// Step 4.1 and 4.2. Pure over the state; the clock, the id source, the verifier and the
+    /// IdentityProvider's url are parameters.
     ///
     /// - not sealed under the key, or past its expiry: refused, nothing recorded (Rules 3, 29);
-    /// - a record under the nonce: the same public key gets the recorded answer (Rule 2, same
-    ///   browser); another key is LaunchSpent (it cannot be told from another browser);
-    /// - a new nonce opens a Session for the Launch's PatientId and writes the record in the
-    ///   same act (Rule 40). The record lives as long as the Launch does.
+    /// - a record under the nonce: the same public key gets the recorded answer, or the redirect
+    ///   again while the hop is still open (Rule 2, uc-01 Retries); another key is LaunchSpent;
+    /// - a new nonce appends the record and sends the browser to the IdentityProvider.
     let present
         (now: DateTime)
         (newId: unit -> string)
         (verify: Launch -> Result<LaunchSeal.Claims, LaunchRefusal>)
-        (patient: Patient)
+        (authorizeUrl: string -> string)
         (state: State)
         (launch, key)
         : State * LaunchResult
         =
+        let state = dropExpired now state
+
         match verify launch with
-        | Error refusal ->
-            // nothing is recorded for a refused Launch; records past their expiry go with it (Rule 29)
-            { state with Launches = state.Launches |> Map.filter (fun _ r -> now <= r.Expiry) },
-            LaunchResult.Refused refusal
+        | Error refusal -> state, LaunchResult.Refused refusal
         | Ok claims ->
             match state.Launches |> Map.tryFind claims.Nonce with
-            | Some record when record.PublicKey = key -> state, record.Result
+            | Some record when record.PublicKey = key -> state, answerOf authorizeUrl record
             | Some _ -> state, LaunchResult.Refused LaunchRefusal.LaunchSpent
             | None ->
-                let id = newId ()
-
-                let session =
+                let record =
                     {
-                        User = Some stubUser
-                        PatientContext =
-                            Some
-                                {
-                                    PatientId = claims.PatientId
-                                    Patient = patient
-                                }
-                        OpenedToken = Some(OpenedToken $"opened-{id}")
-                        KeyThumbprint = Some(PublicKey.thumbprint key)
+                        Nonce = claims.Nonce
+                        State = newId ()
+                        PatientId = claims.PatientId
+                        PublicKey = key
+                        Expiry = claims.Expiry
+                        Outcome = None
                     }
 
-                let result = LaunchResult.Opened(id, session)
-
-                {
-                    Launches =
-                        state.Launches
-                        |> Map.filter (fun _ r -> now <= r.Expiry)
-                        |> Map.add
-                            claims.Nonce
-                            {
-                                PublicKey = key
-                                Result = result
-                                Expiry = claims.Expiry
-                            }
-                    Sessions = state.Sessions |> Map.add id session
-                },
-                result
+                { state with Launches = state.Launches |> Map.add claims.Nonce record }, answerOf authorizeUrl record
 
 
-    /// The port over a single mutable state guarded by a lock; `verify` is the seal check
-    /// bound to the host's key.
+    /// Step 5.7, one act (Rule 40): the Session is written, the login's other Sessions are
+    /// closed and marked (Rule 8), the outcome is appended to the record.
+    let private openSession
+        (newId: unit -> string)
+        (patientData: string -> Patient option)
+        (record: LaunchRecord)
+        (standing: UserStanding)
+        (state: State)
+        =
+        let id = newId ()
+
+        let session =
+            {
+                User = Some standing.User
+                PatientContext =
+                    Some
+                        {
+                            PatientId = record.PatientId
+                            // ext 6a: no imported data is not a refusal
+                            Patient = patientData record.PatientId |> Option.defaultValue Shared.Models.Patient.empty
+                        }
+                OpenedToken = Some(OpenedToken $"opened-{id}")
+                KeyThumbprint = Some(PublicKey.thumbprint record.PublicKey)
+            }
+
+        let login = Some standing.User.UserId
+
+        let superseded =
+            state.Sessions
+            |> Map.filter (fun sid s -> sid <> id && s.Login = login)
+            |> Map.toList
+            |> List.map fst
+
+        let outcome = LaunchResult.Opened(id, session)
+
+        {
+            Launches = state.Launches |> Map.add record.Nonce { record with Outcome = Some outcome }
+            Sessions =
+                superseded
+                |> List.fold (fun m sid -> Map.remove sid m) state.Sessions
+                |> Map.add
+                    id
+                    {
+                        Session = session
+                        Login = login
+                    }
+            Endings =
+                superseded
+                |> List.fold (fun m sid -> Map.add sid SessionEnding.SupersededByLaunch m) state.Endings
+        },
+        CallbackResult.Opened(id, openedUrl)
+
+
+    let private refuse (record: LaunchRecord) refusal (state: State) =
+        { state with
+            Launches =
+                state.Launches
+                |> Map.add record.Nonce { record with Outcome = Some(LaunchResult.Refused refusal) }
+        },
+        CallbackResult.Refused(refusal, refusedUrl refusal)
+
+
+    /// Step 4.5 and step 5. The ladder, in order: the state cookie must match (the browser that
+    /// started the hop), the record must exist and be within its lifetime, an outcome already
+    /// recorded is answered again (Rule 45), the IdentityProvider must have said who is there
+    /// (ext 3c), the UserRegistry must know them (5.3, ext 5a) with the Launch's Patient active
+    /// (ext 5b), and a Prescriber must have a PIN (5.4, Rule 25, ext 5d; a Reader needs none,
+    /// ext 5c). Then the Session opens in one act.
+    let callback
+        (now: DateTime)
+        (newId: unit -> string)
+        (redeem: string -> BrowserIdentity option)
+        (standing: BrowserIdentity -> UserStanding option)
+        (patientData: string -> Patient option)
+        (state: State)
+        (cb: Callback)
+        : State * CallbackResult
+        =
+        let state = dropExpired now state
+
+        let byState =
+            state.Launches
+            |> Map.toSeq
+            |> Seq.map snd
+            |> Seq.tryFind (fun r -> r.State = cb.State)
+
+        let invalid =
+            CallbackResult.Refused(LaunchRefusal.LaunchInvalid, refusedUrl LaunchRefusal.LaunchInvalid)
+
+        match cb.StateCookie, byState with
+        | Some cookie, Some record when cookie = cb.State && cb.State <> "" ->
+            match record.Outcome with
+            | Some(LaunchResult.Opened(id, _)) -> state, CallbackResult.Opened(id, openedUrl)
+            | Some(LaunchResult.Refused refusal) -> state, CallbackResult.Refused(refusal, refusedUrl refusal)
+            | Some(LaunchResult.RedirectTo _)
+            | None ->
+                let identity =
+                    match cb.Error, cb.Code with
+                    | None, Some code -> redeem code
+                    | _ -> None
+
+                match identity with
+                | None -> refuse record LaunchRefusal.NoBrowserIdentity state
+                | Some identity ->
+                    match standing identity with
+                    | None -> refuse record LaunchRefusal.NoRole state
+                    | Some standing when standing.ActivePatientId <> Some record.PatientId ->
+                        refuse record LaunchRefusal.WrongActivePatient state
+                    | Some standing when standing.User.Role = UserRole.Prescriber && not standing.PinSet ->
+                        refuse record LaunchRefusal.EnrolmentRequired state
+                    | Some standing -> openSession newId patientData record standing state
+        | _, None ->
+            // no record: expired and dropped (Rule 29), or never presented
+            state, invalid
+        | _ -> state, invalid
+
+
+    /// The port over a single mutable state guarded by a lock, over the three actor ports.
     let makeSessionPort
         (now: unit -> DateTime)
         (newId: unit -> string)
         (verify: Launch -> Result<LaunchSeal.Claims, LaunchRefusal>)
-        (patient: Patient)
+        (idp: IdentityProviderPort)
+        (registry: UserRegistryPort)
+        (patientData: PatientDataPort)
         =
         let gate = obj ()
         let mutable state = emptyState
@@ -303,9 +441,162 @@ module SessionStub =
                 )
 
         {
-            present = fun launch -> async { return update (fun s -> present (now ()) newId verify patient s launch) }
-            find = fun id -> async { return lock gate (fun () -> state.Sessions |> Map.tryFind id) }
+            present =
+                fun launch -> async { return update (fun s -> present (now ()) newId verify idp.authorizeUrl s launch) }
+            callback =
+                fun cb ->
+                    async {
+                        return
+                            update (fun s -> callback (now ()) newId idp.redeem registry.standing patientData.read s cb)
+                    }
+            find =
+                fun id ->
+                    async { return lock gate (fun () -> state.Sessions |> Map.tryFind id |> Option.map _.Session) }
             close = fun id -> async { return update (fun s -> { s with Sessions = s.Sessions |> Map.remove id }, ()) }
+        }
+
+
+/// The IdentityProvider and the UserRegistry as one stub directory over an identity choice made
+/// on the stub launch page: `prescriber`, `reader`, `prescriber-other-patient`, `no-pin`,
+/// `unknown` (a login the registry does not know), `none` (no identity: the stub IdP's
+/// `/authorize` never issues a code for it). The active Patient of a choice is the one the
+/// launch page was given, except for `prescriber-other-patient`.
+module StubDirectory =
+
+    let choices =
+        [
+            "prescriber"
+            "reader"
+            "prescriber-other-patient"
+            "no-pin"
+            "unknown"
+            "none"
+        ]
+
+
+    let identityOf choice =
+        {
+            Login = choice
+            DisplayName =
+                match choice with
+                | "prescriber" -> "Stub Prescriber"
+                | "reader" -> "Stub Reader"
+                | "prescriber-other-patient" -> "Stub Prescriber (other patient)"
+                | "no-pin" -> "Stub Prescriber (no PIN)"
+                | other -> $"Stub {other}"
+        }
+
+
+    /// The registry's answer for a login, given the Patient the launch page made active.
+    let standingOf (activePatientId: string) (identity: BrowserIdentity) : UserStanding option =
+        let user role =
+            {
+                UserId = identity.Login
+                DisplayName = identity.DisplayName
+                Role = role
+            }
+
+        match identity.Login with
+        | "prescriber" ->
+            Some
+                {
+                    User = user UserRole.Prescriber
+                    ActivePatientId = Some activePatientId
+                    PinSet = true
+                }
+        | "reader" ->
+            Some
+                {
+                    User = user UserRole.Reader
+                    ActivePatientId = Some activePatientId
+                    PinSet = false
+                }
+        | "prescriber-other-patient" ->
+            Some
+                {
+                    User = user UserRole.Prescriber
+                    ActivePatientId = Some "other-patient"
+                    PinSet = true
+                }
+        | "no-pin" ->
+            Some
+                {
+                    User = user UserRole.Prescriber
+                    ActivePatientId = Some activePatientId
+                    PinSet = false
+                }
+        | _ -> None
+
+
+    /// The directory: one-time codes (the stub IdP) and the active Patient per login (the stub
+    /// registry), behind a lock. `issue` is what `/authorize` calls once it read the identity
+    /// choice and the active Patient from the stub cookie.
+    type Directory =
+        {
+            idp: IdentityProviderPort
+            registry: UserRegistryPort
+            issue: string -> string -> string
+        }
+
+
+    let make (newCode: unit -> string) : Directory =
+        let gate = obj ()
+        let codes = Collections.Generic.Dictionary<string, BrowserIdentity>()
+        let active = Collections.Generic.Dictionary<string, string>()
+
+        {
+            idp =
+                {
+                    authorizeUrl = fun state -> $"/authorize?state={Uri.EscapeDataString state}"
+                    redeem =
+                        fun code ->
+                            lock
+                                gate
+                                (fun () ->
+                                    match codes.TryGetValue code with
+                                    | true, identity ->
+                                        codes.Remove code |> ignore
+                                        Some identity
+                                    | _ -> None
+                                )
+                }
+            registry =
+                {
+                    standing =
+                        fun identity ->
+                            lock
+                                gate
+                                (fun () ->
+                                    match active.TryGetValue identity.Login with
+                                    | true, pid -> standingOf pid identity
+                                    | _ -> standingOf "" identity
+                                )
+                }
+            issue =
+                fun choice activePatientId ->
+                    lock
+                        gate
+                        (fun () ->
+                            let code = newCode ()
+                            codes[code] <- identityOf choice
+                            active[choice] <- activePatientId
+                            code
+                        )
+        }
+
+
+/// The PatientDataPlatform stub: nothing to import, except that `no-data` has no record at all
+/// (ext 6a).
+module StubPatientData =
+
+    let port: PatientDataPort =
+        {
+            read =
+                fun pid ->
+                    if pid = "no-data" then
+                        None
+                    else
+                        Some Shared.Models.Patient.empty
         }
 
 
@@ -359,6 +650,27 @@ below and opens GenPRES on it. Development and test servers only.</p>
                 Nonce = newNonce ()
                 Expiry = now + lifetime
             }
+
+
+    let choices = StubDirectory.choices
+
+    let identityCookieName = "genpres_stub_identity"
+
+
+    /// The stub identity cookie value for a choice and the Patient the page made active.
+    let identityCookie (choice: string) (pid: string) =
+        $"{Uri.EscapeDataString choice}.{Uri.EscapeDataString pid}"
+
+
+    /// The choice and the Patient back from the cookie; None for anything else.
+    let parseIdentityCookie (value: string option) : (string * string) option =
+        match value with
+        | Some v when not (String.IsNullOrWhiteSpace v) ->
+            match v.Split('.') with
+            | [| choice; pid |] when choices |> List.contains (Uri.UnescapeDataString choice) ->
+                Some(Uri.UnescapeDataString choice, Uri.UnescapeDataString pid)
+            | _ -> None
+        | _ -> None
 
 
 module Adapters =
@@ -501,12 +813,26 @@ module Adapters =
     let sessionDisabled: SessionPort =
         {
             present = fun _ -> async { return LaunchResult.Refused LaunchRefusal.LaunchInvalid }
+            callback =
+                fun _ ->
+                    async {
+                        return
+                            CallbackResult.Refused(
+                                LaunchRefusal.LaunchInvalid,
+                                Hop.refusedUrl LaunchRefusal.LaunchInvalid
+                            )
+                    }
             find = fun _ -> async { return None }
             close = fun _ -> async { return () }
         }
 
 
-    let makeAppEnvWith (launchKey: LaunchSeal.Key) (provider: Resources.IResourceProvider) : AppEnv =
+    let makeAppEnvWith
+        (launchKey: LaunchSeal.Key)
+        (directory: StubDirectory.Directory)
+        (provider: Resources.IResourceProvider)
+        : AppEnv
+        =
         let agent, logger = resolveLogger ()
         let orderCtxPort = makeOrderContextPort agent logger provider
 
@@ -564,15 +890,20 @@ module Adapters =
             // plan 409 step 2: an in-memory stub with a two-minute Launch lifetime (Rule 29);
             // its sessions live as long as this AppEnv
             session =
-                SessionStub.makeSessionPort
+                Hop.makeSessionPort
                     (fun () -> DateTime.UtcNow)
                     PublicKey.randomId
                     (fun launch -> LaunchSeal.verify DateTime.UtcNow launchKey launch)
-                    Shared.Models.Patient.empty
+                    directory.idp
+                    directory.registry
+                    StubPatientData.port
         }
 
 
-    /// An env with its own seal key: what tests and the MCP host build. The server builds
-    /// `makeAppEnvWith` so that its stub LaunchScript page mints under the same key.
+    /// An env with its own seal key and stub directory: what tests and the MCP host build. The
+    /// server builds `makeAppEnvWith` so that its stub pages share the key and the directory.
     let makeAppEnv (provider: Informedica.GenForm.Lib.Resources.IResourceProvider) =
-        makeAppEnvWith (LaunchSeal.newKey System.Security.Cryptography.RandomNumberGenerator.GetBytes) provider
+        makeAppEnvWith
+            (LaunchSeal.newKey System.Security.Cryptography.RandomNumberGenerator.GetBytes)
+            (StubDirectory.make PublicKey.randomId)
+            provider

--- a/src/Informedica.GenPRES.Server/ServerApi.ApiImpl.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.ApiImpl.fs
@@ -9,6 +9,7 @@ module ApiImpl =
         (settings: Shared.Api.ServerSettings)
         (env: AppEnv)
         (cookie: SessionCookie)
+        (stateCookie: LaunchStateCookie)
         : Shared.Api.IServerApi
         =
-        CompositionRoot.compose settings env cookie
+        CompositionRoot.compose settings env cookie stateCookie

--- a/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
@@ -11,7 +11,7 @@ module CompositionRoot =
     /// Launch step 4 over the session port. The session id goes into the cookie and nowhere
     /// else (Rule 12); a refusal is a value. A server exception is not a refusal: it propagates,
     /// Fable.Remoting answers 500 and the client's transport-error path retries.
-    let processLaunch (env: AppEnv) (cookie: SessionCookie) (cmd: LaunchCommand) =
+    let processLaunch (env: AppEnv) (cookie: SessionCookie) (stateCookie: LaunchStateCookie) (cmd: LaunchCommand) =
         async {
             match cmd with
             | LaunchCommand.PresentLaunch(launch, key) ->
@@ -19,8 +19,24 @@ module CompositionRoot =
                 | LaunchResult.Opened(id, session) ->
                     cookie.write id
                     return LaunchOutcome.Opened session
-                | LaunchResult.RedirectTo url -> return LaunchOutcome.RedirectTo url
+                | LaunchResult.RedirectTo(url, state) ->
+                    // step 4.2: the state cookie is what proves, at the callback, that the same
+                    // browser started the hop
+                    stateCookie.write state
+                    return LaunchOutcome.RedirectTo url
                 | LaunchResult.Refused refusal -> return LaunchOutcome.Refused refusal
+        }
+
+
+    /// Launch step 4.5 over the session port: the browser is back from the IdentityProvider.
+    /// Answers where it goes next; the session cookie is set when a Session opened.
+    let processCallback (env: AppEnv) (cookie: SessionCookie) (stateCookie: LaunchStateCookie) (cb: Callback) =
+        async {
+            match! env.session.callback { cb with StateCookie = stateCookie.read () } with
+            | CallbackResult.Opened(id, redirect) ->
+                cookie.write id
+                return redirect
+            | CallbackResult.Refused(_, redirect) -> return redirect
         }
 
 
@@ -51,7 +67,13 @@ module CompositionRoot =
 
     /// The api of one request: the settings and the env are built once per host, the cookie
     /// once per request.
-    let compose (settings: ServerSettings) (env: AppEnv) (cookie: SessionCookie) : IServerApi =
+    let compose
+        (settings: ServerSettings)
+        (env: AppEnv)
+        (cookie: SessionCookie)
+        (stateCookie: LaunchStateCookie)
+        : IServerApi
+        =
         {
             processCommand =
                 fun cmd ->
@@ -70,7 +92,7 @@ module CompositionRoot =
                 fun cmd ->
                     async {
                         writeInfoMessage $"Processing launch: {cmd |> LaunchCommand.toString}"
-                        let! outcome = processLaunch env cookie cmd
+                        let! outcome = processLaunch env cookie stateCookie cmd
                         writeInfoMessage $"Finished processing launch: {cmd |> LaunchCommand.toString}"
                         return outcome
                     }

--- a/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
@@ -32,11 +32,12 @@ module CompositionRoot =
     /// Answers where it goes next; the session cookie is set when a Session opened.
     let processCallback (env: AppEnv) (cookie: SessionCookie) (stateCookie: LaunchStateCookie) (cb: Callback) =
         async {
-            match! env.session.callback { cb with StateCookie = stateCookie.read () } with
+            match! env.session.callback { cb with StateCookie = stateCookie.read cb.State } with
             | CallbackResult.Opened(id, redirect) ->
                 cookie.write id
                 return redirect
-            | CallbackResult.Refused(_, redirect) -> return redirect
+            | CallbackResult.Refused(_, redirect)
+            | CallbackResult.Superseded redirect -> return redirect
         }
 
 

--- a/src/Informedica.GenPRES.Server/ServerApi.Ports.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Ports.fs
@@ -111,6 +111,9 @@ type Callback =
 type CallbackResult =
     | Opened of sessionId: string * redirect: string
     | Refused of LaunchRefusal * redirect: string
+    // a reload of a callback whose Session a newer launch has since replaced (Rule 8): the
+    // browser goes to the app on whatever cookie it holds, which is the newer Session's
+    | Superseded of redirect: string
 
 
 type SessionPort =
@@ -139,7 +142,8 @@ type SessionCookie =
 /// The state cookie of one request (4.2): written with the redirect, read at the callback.
 type LaunchStateCookie =
     {
-        read: unit -> string option
+        // the cookie of one hop, named by its state, so that two tabs can launch at once
+        read: string -> string option
         write: string -> unit
     }
 

--- a/src/Informedica.GenPRES.Server/ServerApi.Ports.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Ports.fs
@@ -47,19 +47,78 @@ type LogAnalyzerPort =
     }
 
 
+/// Who the IdentityProvider says is at the browser (Concept 4). The Session's User is derived
+/// from it (Rule 4), never from the Launch.
+type BrowserIdentity =
+    {
+        Login: string
+        DisplayName: string
+    }
+
+
+/// What the UserRegistry says about a login at this launch (Rules 5, 6, 24): the User with the
+/// Role, the Patient active in MainEHR, and whether a PIN is set.
+type UserStanding =
+    {
+        User: UserContext
+        ActivePatientId: string option
+        PinSet: bool
+    }
+
+
+/// Actor 8. `authorizeUrl` is where the browser is sent with the `state` (4.2); `redeem`
+/// exchanges the callback's code for the identity over the server's own connection (4.4, C6).
+type IdentityProviderPort =
+    {
+        authorizeUrl: string -> string
+        redeem: string -> BrowserIdentity option
+    }
+
+
+type UserRegistryPort = { standing: BrowserIdentity -> UserStanding option }
+
+
+/// The PatientDataPlatform, read once at the launch (Concept 2). `None` is not a refusal
+/// (ext 6a): the Session opens without imported data.
+type PatientDataPort = { read: string -> Patient option }
+
+
 /// The session adapter's answer to a presentation. The session id is the server's to put in
 /// the cookie; the composition root maps this to the client's `LaunchOutcome` without it.
+/// `RedirectTo` carries the `state` the edge writes to the state cookie (uc-01 step 4.2) next
+/// to the url that carries it to the IdentityProvider.
 [<RequireQualifiedAccess>]
 type LaunchResult =
     | Opened of sessionId: string * SessionOpened
-    | RedirectTo of url: string
+    | RedirectTo of url: string * state: string
     | Refused of LaunchRefusal
+
+
+/// What the callback (4.5) brings: the `state` from the url and from the cookie, and either a
+/// code or the IdentityProvider's error.
+type Callback =
+    {
+        State: string
+        StateCookie: string option
+        Code: string option
+        Error: string option
+    }
+
+
+/// The answer to a callback: where the browser goes next, and the session id for the cookie
+/// when a Session opened.
+[<RequireQualifiedAccess>]
+type CallbackResult =
+    | Opened of sessionId: string * redirect: string
+    | Refused of LaunchRefusal * redirect: string
 
 
 type SessionPort =
     {
         // idempotent per public key within the Launch lifetime (Rule 2, uc-01 Retries)
         present: Launch * PublicKey -> Async<LaunchResult>
+        // uc-01 step 4.5: the browser is back from the IdentityProvider
+        callback: Callback -> Async<CallbackResult>
         // by session id from the cookie
         find: string -> Async<SessionOpened option>
         // Rule 10: explicit close
@@ -74,6 +133,14 @@ type SessionCookie =
         read: unit -> string option
         write: string -> unit
         delete: unit -> unit
+    }
+
+
+/// The state cookie of one request (4.2): written with the redirect, read at the callback.
+type LaunchStateCookie =
+    {
+        read: unit -> string option
+        write: string -> unit
     }
 
 

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -339,7 +339,9 @@ module SessionStubTests =
     let makePort () =
         let clock = ref t0
         let count = ref 0
-        let directory = StubDirectory.make (fun () -> $"code-{Guid.NewGuid()}")
+
+        let directory =
+            StubDirectory.make (fun () -> clock.Value) (fun () -> $"code-{Guid.NewGuid()}")
 
         let port =
             Hop.makeSessionPort
@@ -413,7 +415,7 @@ module SessionStubTests =
         /// A fresh directory and id sources per test.
         let fixture () =
             let ids = counter "id"
-            let directory = StubDirectory.make (counter "code")
+            let directory = StubDirectory.make (fun () -> t0) (counter "code")
             ids, directory
 
 
@@ -805,7 +807,7 @@ module SessionStubTests =
                 "StubDirectory"
                 [
                     test "a code redeems once" {
-                        let d = StubDirectory.make (counter "code")
+                        let d = StubDirectory.make (fun () -> t0) (counter "code")
                         let code = d.issue "prescriber" "p"
 
                         d.idp.redeem code
@@ -815,8 +817,18 @@ module SessionStubTests =
                         d.idp.redeem code |> Expect.isNone "second"
                     }
 
+                    test "past the lifetime a code does not redeem, and the next issue prunes it" {
+                        let clock = ref t0
+                        let d = StubDirectory.make (fun () -> clock.Value) (counter "code")
+                        let stale = d.issue "prescriber" "p"
+                        clock.Value <- t0 + StubDirectory.codeLifetime + TimeSpan.FromSeconds 1.0
+                        d.idp.redeem stale |> Expect.isNone "stale"
+                        let fresh = d.issue "reader" "p"
+                        d.idp.redeem fresh |> Option.map _.Login |> Expect.equal "fresh" (Some "reader")
+                    }
+
                     test "every choice but none has an identity; unknown has no standing" {
-                        let d = StubDirectory.make (counter "code")
+                        let d = StubDirectory.make (fun () -> t0) (counter "code")
 
                         for choice in StubDirectory.choices |> List.filter ((<>) "none") do
                             let identity = d.idp.redeem (d.issue choice "p") |> Option.get
@@ -860,7 +872,7 @@ module SessionStubTests =
         let value = ref initial
 
         {
-            LaunchStateCookie.read = fun () -> value.Value
+            LaunchStateCookie.read = fun state -> value.Value |> Option.filter ((=) state)
             write = fun state -> value.Value <- Some state
         },
         value
@@ -1148,6 +1160,47 @@ module SessionStubTests =
                     redirect |> Expect.equal "invalid" "/#/session?refused=invalid"
                     held.Value |> Expect.isNone "no cookie"
                     heldState.Value |> Expect.isSome "the first browser's state cookie is untouched"
+                }
+
+                testAsync
+                    "processCallback: a reload after a newer launch of the same login keeps the newer session's cookie" {
+                    let directory, env = envWithStub ()
+                    let cookie, held = memoryCookie None
+                    let stateCookie, _ = memoryStateCookie None
+
+                    let! outcome =
+                        CompositionRoot.processLaunch
+                            env
+                            cookie
+                            stateCookie
+                            (LaunchCommand.PresentLaunch(mintFor "n-1" "stub-patient", keyA))
+
+                    let state1 =
+                        match outcome with
+                        | LaunchOutcome.RedirectTo url -> url.Substring(url.IndexOf "state=" + 6)
+                        | other -> failtest $"{other}"
+
+                    let cb1: Callback =
+                        {
+                            State = state1
+                            StateCookie = None
+                            Code = Some(directory.issue "prescriber" "stub-patient")
+                            Error = None
+                        }
+
+                    let! _ = CompositionRoot.processCallback env cookie stateCookie cb1
+                    let first = held.Value.Value
+
+                    // the same login launches again in another tab: the first Session is replaced
+                    let stateCookie2, _ = memoryStateCookie None
+                    let! _ = openVia directory env cookie stateCookie2 (mintFor "n-2" "stub-patient") keyB "prescriber"
+                    let second = held.Value.Value
+                    second |> Expect.notEqual "a newer session" first
+
+                    // the first tab reloads its callback
+                    let! redirect = CompositionRoot.processCallback env cookie stateCookie cb1
+                    redirect |> Expect.equal "to the app" "/#/session"
+                    held.Value |> Expect.equal "the newer cookie stays" (Some second)
                 }
 
                 testAsync "GetSession: no cookie is None" {

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -61,6 +61,9 @@ module StubAdapters =
     let sessionNone: SessionPort =
         {
             present = fun _ -> async { return LaunchResult.Refused LaunchRefusal.LaunchInvalid }
+            callback =
+                fun _ ->
+                    async { return CallbackResult.Refused(LaunchRefusal.LaunchInvalid, "/#/session?refused=invalid") }
             find = fun _ -> async { return None }
             close = fun _ -> async { return () }
         }
@@ -300,7 +303,6 @@ let requireLoadedTests =
 module SessionStubTests =
 
     open Shared.Api
-    open SessionStub
 
 
     let lifetime = TimeSpan.FromMinutes 2.0
@@ -332,22 +334,26 @@ module SessionStubTests =
     let launch2 = mintFor "n-2" "p-2"
 
 
-    /// A port with a settable clock, a counting id source and the seal check bound to the clock.
+    /// A port with a settable clock, a counting id source, the seal check bound to the clock and
+    /// a stub directory of its own.
     let makePort () =
         let clock = ref t0
         let count = ref 0
+        let directory = StubDirectory.make (fun () -> $"code-{Guid.NewGuid()}")
 
         let port =
-            makeSessionPort
+            Hop.makeSessionPort
                 (fun () -> clock.Value)
                 (fun () ->
                     count.Value <- count.Value + 1
                     $"session-{count.Value}"
                 )
                 (fun launch -> LaunchSeal.verify clock.Value sealKey launch)
-                Patient.empty
+                directory.idp
+                directory.registry
+                StubPatientData.port
 
-        port, clock
+        port, clock, directory
 
 
     let thumbprintTests =
@@ -389,163 +395,452 @@ module SessionStubTests =
             ]
 
 
-    let stubTests =
-        testList
-            "Session stub"
-            [
-                testList
-                    "a Launch the seal refuses opens nothing and records nothing"
-                    [
-                        for name, launch, refusal in
-                            [
-                                "not sealed under the key",
-                                LaunchSeal.mint
-                                    otherSealKey
-                                    {
-                                        PatientId = "p"
-                                        Nonce = "n"
-                                        Expiry = t0 + lifetime
-                                    },
-                                LaunchRefusal.LaunchInvalid
-                                "garbage", Launch "not-a-launch", LaunchRefusal.LaunchInvalid
-                                "already expired",
-                                LaunchSeal.mint
-                                    sealKey
-                                    {
-                                        PatientId = "p"
-                                        Nonce = "n"
-                                        Expiry = t0 - TimeSpan.FromSeconds 1.0
-                                    },
-                                LaunchRefusal.LaunchExpired
-                            ] do
-                            testAsync $"{name} refuses with {refusal}" {
-                                let port, _ = makePort ()
+    /// The hop over the stubs: the script tests of Server/Scripts/Hop.fsx, unchanged.
+    module HopTests =
 
-                                let! first = port.present (launch, keyA)
-                                // another key gets the same answer: nothing was recorded
-                                let! second = port.present (launch, keyB)
+        let verifyAt (now: DateTime) = LaunchSeal.verify now sealKey
+        let launch1 = mintFor "n-1" "patient-1"
 
-                                first |> Expect.equal "first" (LaunchResult.Refused refusal)
-                                second |> Expect.equal "second, other key" (LaunchResult.Refused refusal)
 
-                                let! found = port.find "session-1"
-                                found |> Expect.isNone "no session opened"
+        let counter prefix =
+            let n = ref 0
+
+            fun () ->
+                n.Value <- n.Value + 1
+                $"{prefix}-{n.Value}"
+
+
+        /// A fresh directory and id sources per test.
+        let fixture () =
+            let ids = counter "id"
+            let directory = StubDirectory.make (counter "code")
+            ids, directory
+
+
+        /// Presents, then plays the stub IdP for `choice`, and returns the callback the browser brings.
+        let hop (ids: unit -> string) (directory: StubDirectory.Directory) state launch key choice =
+            let state, result =
+                Hop.present t0 ids (verifyAt t0) directory.idp.authorizeUrl state (launch, key)
+
+            match result with
+            | LaunchResult.RedirectTo(_, st) ->
+                let cb =
+                    if choice = "none" then
+                        {
+                            State = st
+                            StateCookie = Some st
+                            Code = None
+                            Error = Some "no-identity"
+                        }
+                    else
+                        {
+                            State = st
+                            StateCookie = Some st
+                            Code = Some(directory.issue choice "patient-1")
+                            Error = None
+                        }
+
+                state, cb
+            | other -> failtest $"expected RedirectTo, got {other}"
+
+
+        let run (ids: unit -> string) (directory: StubDirectory.Directory) state cb =
+            Hop.callback t0 ids directory.idp.redeem directory.registry.standing StubPatientData.port.read state cb
+
+
+        let presentTests =
+            testList
+                "Hop.present"
+                [
+                    test "a sealed Launch is recorded under its nonce and sent to the IdentityProvider" {
+                        let ids, d = fixture ()
+
+                        let state, result =
+                            Hop.present t0 ids (verifyAt t0) d.idp.authorizeUrl Hop.emptyState (launch1, keyA)
+
+                        match result with
+                        | LaunchResult.RedirectTo(url, st) ->
+                            url |> Expect.equal "authorize url carries the state" $"/authorize?state={st}"
+                            let record = state.Launches["n-1"]
+                            record.State |> Expect.equal "same state in the record" st
+                            record.PatientId |> Expect.equal "patient" "patient-1"
+                            record.Outcome |> Expect.isNone "no outcome yet"
+                        | other -> failtest $"expected RedirectTo, got {other}"
+                    }
+
+                    test "the same key while the hop is open gets the same redirect (Rule 2, retry)" {
+                        let ids, d = fixture ()
+
+                        let state, first =
+                            Hop.present t0 ids (verifyAt t0) d.idp.authorizeUrl Hop.emptyState (launch1, keyA)
+
+                        let state2, again =
+                            Hop.present t0 ids (verifyAt t0) d.idp.authorizeUrl state (launch1, keyA)
+
+                        again |> Expect.equal "same redirect" first
+                        state2 |> Expect.equal "same state" state
+                    }
+
+                    test "another key is spent" {
+                        let ids, d = fixture ()
+
+                        let state, _ =
+                            Hop.present t0 ids (verifyAt t0) d.idp.authorizeUrl Hop.emptyState (launch1, keyA)
+
+                        let _, other =
+                            Hop.present t0 ids (verifyAt t0) d.idp.authorizeUrl state (launch1, keyB)
+
+                        other |> Expect.equal "spent" (LaunchResult.Refused LaunchRefusal.LaunchSpent)
+                    }
+
+                    test "after the hop opened, the same key gets the opened Session (Rule 2)" {
+                        let ids, d = fixture ()
+                        let state, cb = hop ids d Hop.emptyState launch1 keyA "prescriber"
+                        let state, opened = run ids d state cb
+
+                        let _, again =
+                            Hop.present t0 ids (verifyAt t0) d.idp.authorizeUrl state (launch1, keyA)
+
+                        match opened, again with
+                        | CallbackResult.Opened(id, _), LaunchResult.Opened(id', session) ->
+                            id' |> Expect.equal "same session" id
+
+                            session.User
+                            |> Option.map _.DisplayName
+                            |> Expect.equal "user" (Some "Stub Prescriber")
+                        | other -> failtest $"expected Opened twice, got {other}"
+                    }
+
+                    test "not sealed, or expired: refused and nothing recorded" {
+                        let ids, d = fixture ()
+
+                        let _, invalid =
+                            Hop.present t0 ids (verifyAt t0) d.idp.authorizeUrl Hop.emptyState (Launch "junk", keyA)
+
+                        invalid
+                        |> Expect.equal "invalid" (LaunchResult.Refused LaunchRefusal.LaunchInvalid)
+
+                        let late = t0 + lifetime + TimeSpan.FromSeconds 1.0
+
+                        let state, expired =
+                            Hop.present late ids (verifyAt late) d.idp.authorizeUrl Hop.emptyState (launch1, keyA)
+
+                        expired
+                        |> Expect.equal "expired" (LaunchResult.Refused LaunchRefusal.LaunchExpired)
+
+                        state.Launches |> Map.isEmpty |> Expect.isTrue "nothing recorded"
+                    }
+                ]
+
+
+        let callbackTests =
+            testList
+                "Hop.callback"
+                [
+                    test "prescriber: the Session opens for the Launch's Patient, the outcome is recorded" {
+                        let ids, d = fixture ()
+                        let state, cb = hop ids d Hop.emptyState launch1 keyA "prescriber"
+                        let state, result = run ids d state cb
+
+                        match result with
+                        | CallbackResult.Opened(id, url) ->
+                            url |> Expect.equal "to the app" "/#/session"
+                            let record = state.Sessions[id]
+                            record.Login |> Expect.equal "login" (Some "prescriber")
+
+                            record.Session.User
+                            |> Option.map _.Role
+                            |> Expect.equal "role" (Some UserRole.Prescriber)
+
+                            record.Session.PatientContext
+                            |> Option.map _.PatientId
+                            |> Expect.equal "patient" (Some "patient-1")
+
+                            record.Session.KeyThumbprint
+                            |> Expect.equal "thumbprint" (Some(PublicKey.thumbprint keyA))
+
+                            state.Launches["n-1"].Outcome |> Expect.isSome "outcome appended"
+                        | other -> failtest $"expected Opened, got {other}"
+                    }
+
+                    test "reader: opens without a PIN (ext 5c)" {
+                        let ids, d = fixture ()
+                        let state, cb = hop ids d Hop.emptyState launch1 keyA "reader"
+                        let state, result = run ids d state cb
+
+                        match result with
+                        | CallbackResult.Opened(id, _) ->
+                            state.Sessions[id].Session.User
+                            |> Option.map _.Role
+                            |> Expect.equal "role" (Some UserRole.Reader)
+                        | other -> failtest $"expected Opened, got {other}"
+                    }
+
+                    testList
+                        "refusals, each recorded and each with its word"
+                        [
+                            for choice, refusal in
+                                [
+                                    "none", LaunchRefusal.NoBrowserIdentity
+                                    "unknown", LaunchRefusal.NoRole
+                                    "prescriber-other-patient", LaunchRefusal.WrongActivePatient
+                                    "no-pin", LaunchRefusal.EnrolmentRequired
+                                ] do
+                                test choice {
+                                    let ids, d = fixture ()
+                                    let state, cb = hop ids d Hop.emptyState launch1 keyA choice
+                                    let state, result = run ids d state cb
+
+                                    result
+                                    |> Expect.equal
+                                        "refused"
+                                        (CallbackResult.Refused(
+                                            refusal,
+                                            $"/#/session?refused={Hop.refusalWord refusal}"
+                                        ))
+
+                                    state.Sessions |> Map.isEmpty |> Expect.isTrue "no session (Rule 7)"
+
+                                    state.Launches["n-1"].Outcome
+                                    |> Expect.equal "recorded" (Some(LaunchResult.Refused refusal))
+                                }
+                        ]
+
+                    test "a callback reload gets the same answer without a second redeem (Rule 45)" {
+                        let ids, d = fixture ()
+                        let state, cb = hop ids d Hop.emptyState launch1 keyA "prescriber"
+                        let state, first = run ids d state cb
+                        // the code was consumed by the first redeem; the replay must not need it
+                        let state2, again = run ids d state cb
+                        again |> Expect.equal "same answer" first
+                        state2 |> Expect.equal "same state" state
+                    }
+
+                    test "a state cookie that does not match is invalid, and nothing is redeemed" {
+                        let ids, d = fixture ()
+                        let state, cb = hop ids d Hop.emptyState launch1 keyA "prescriber"
+
+                        for cookie in [ None; Some "other" ] do
+                            let state2, result = run ids d state { cb with StateCookie = cookie }
+
+                            result
+                            |> Expect.equal
+                                $"cookie {cookie}"
+                                (CallbackResult.Refused(LaunchRefusal.LaunchInvalid, "/#/session?refused=invalid"))
+
+                            state2.Launches["n-1"].Outcome |> Expect.isNone "hop still open"
+                    }
+
+                    test "an unknown state is invalid" {
+                        let ids, d = fixture ()
+
+                        let _, result =
+                            run
+                                ids
+                                d
+                                Hop.emptyState
+                                {
+                                    State = "nope"
+                                    StateCookie = Some "nope"
+                                    Code = Some "c"
+                                    Error = None
+                                }
+
+                        result
+                        |> Expect.equal
+                            "invalid"
+                            (CallbackResult.Refused(LaunchRefusal.LaunchInvalid, "/#/session?refused=invalid"))
+                    }
+
+                    test "a code that does not redeem is no browser identity" {
+                        let ids, d = fixture ()
+                        let state, cb = hop ids d Hop.emptyState launch1 keyA "prescriber"
+                        let _, result = run ids d state { cb with Code = Some "forged" }
+
+                        result
+                        |> Expect.equal
+                            "no identity"
+                            (CallbackResult.Refused(LaunchRefusal.NoBrowserIdentity, "/#/session?refused=no-identity"))
+                    }
+
+                    test "after the lifetime the callback is invalid: the record is gone (Rule 29)" {
+                        let ids, d = fixture ()
+                        let state, cb = hop ids d Hop.emptyState launch1 keyA "prescriber"
+                        let late = t0 + lifetime + TimeSpan.FromSeconds 1.0
+
+                        let state2, result =
+                            Hop.callback late ids d.idp.redeem d.registry.standing StubPatientData.port.read state cb
+
+                        result
+                        |> Expect.equal
+                            "invalid"
+                            (CallbackResult.Refused(LaunchRefusal.LaunchInvalid, "/#/session?refused=invalid"))
+
+                        state2.Launches |> Map.isEmpty |> Expect.isTrue "dropped"
+                    }
+
+                    test "no patient data (ext 6a): the Session opens with the PatientId and an empty Patient" {
+                        let ids, d = fixture ()
+                        let launch = mintFor "n-nd" "no-data"
+
+                        let state, result =
+                            Hop.present t0 ids (verifyAt t0) d.idp.authorizeUrl Hop.emptyState (launch, keyA)
+
+                        let st =
+                            match result with
+                            | LaunchResult.RedirectTo(_, st) -> st
+                            | other -> failtest $"{other}"
+
+                        let cb =
+                            {
+                                State = st
+                                StateCookie = Some st
+                                Code = Some(d.issue "prescriber" "no-data")
+                                Error = None
                             }
-                    ]
 
-                testAsync "a sealed Launch opens a session with the stub prescriber for its PatientId" {
-                    let port, _ = makePort ()
+                        let state, result = run ids d state cb
 
-                    match! port.present (launch1, keyA) with
-                    | LaunchResult.Opened(id, session) ->
-                        id |> Expect.equal "session id" "session-1"
+                        match result with
+                        | CallbackResult.Opened(id, _) ->
+                            let ctx = state.Sessions[id].Session.PatientContext
+                            ctx |> Option.map _.PatientId |> Expect.equal "patient id" (Some "no-data")
+                            ctx |> Option.map _.Patient |> Expect.equal "empty patient" (Some Patient.empty)
+                        | other -> failtest $"expected Opened, got {other}"
+                    }
 
-                        session.User
-                        |> Option.map _.Role
-                        |> Expect.equal "role" (Some UserRole.Prescriber)
+                    test "a second launch of the same login closes the first Session and marks it (Rule 8)" {
+                        let ids, d = fixture ()
+                        let state, cb1 = hop ids d Hop.emptyState launch1 keyA "prescriber"
+                        let state, first = run ids d state cb1
+                        let state, cb2 = hop ids d state (mintFor "n-2" "patient-1") keyB "prescriber"
+                        let state, second = run ids d state cb2
 
-                        session.PatientContext
-                        |> Option.map _.PatientId
-                        |> Expect.equal "patient" (Some "stub-patient")
+                        match first, second with
+                        | CallbackResult.Opened(id1, _), CallbackResult.Opened(id2, _) ->
+                            state.Sessions |> Map.containsKey id1 |> Expect.isFalse "first closed"
+                            state.Sessions |> Map.containsKey id2 |> Expect.isTrue "second open"
 
-                        session.OpenedToken |> Expect.isSome "opened token"
+                            state.Endings
+                            |> Map.tryFind id1
+                            |> Expect.equal "marked" (Some Hop.SessionEnding.SupersededByLaunch)
+                        | other -> failtest $"expected two Opened, got {other}"
+                    }
 
-                        session.KeyThumbprint
-                        |> Expect.equal "thumbprint of the presented key" (Some(PublicKey.thumbprint keyA))
+                    test "two logins keep two Sessions" {
+                        let ids, d = fixture ()
+                        let state, cb1 = hop ids d Hop.emptyState launch1 keyA "prescriber"
+                        let state, _ = run ids d state cb1
+                        let state, cb2 = hop ids d state (mintFor "n-2" "patient-1") keyB "reader"
+                        let state, _ = run ids d state cb2
+                        state.Sessions |> Map.count |> Expect.equal "two" 2
+                        state.Endings |> Map.isEmpty |> Expect.isTrue "none ended"
+                    }
+                ]
 
-                        let! found = port.find id
-                        found |> Expect.equal "find returns the session" (Some session)
-                    | other -> failtest $"expected Opened, got {other}"
-                }
 
-                testAsync "a second presentation with the same key within the lifetime is answered as the first" {
-                    let port, clock = makePort ()
+        let portTests =
+            testList
+                "makeSessionPort"
+                [
+                    testAsync "present, callback, find, close over the port" {
+                        let ids, d = fixture ()
 
-                    let! first = port.present (launch1, keyA)
-                    clock.Value <- t0 + TimeSpan.FromSeconds 90.0
-                    let! second = port.present (launch1, keyA)
+                        let port =
+                            Hop.makeSessionPort (fun () -> t0) ids (verifyAt t0) d.idp d.registry StubPatientData.port
 
-                    second |> Expect.equal "same session, same content" first
+                        let! redirect = port.present (launch1, keyA)
 
-                    let! second' = port.find "session-2"
-                    second' |> Expect.isNone "nothing opened twice"
-                }
+                        let st =
+                            match redirect with
+                            | LaunchResult.RedirectTo(_, st) -> st
+                            | other -> failtest $"{other}"
 
-                testAsync "a second presentation with another key is LaunchSpent and opens nothing" {
-                    let port, _ = makePort ()
+                        let! opened =
+                            port.callback
+                                {
+                                    State = st
+                                    StateCookie = Some st
+                                    Code = Some(d.issue "prescriber" "patient-1")
+                                    Error = None
+                                }
 
-                    let! _ = port.present (launch1, keyA)
-                    let! other = port.present (launch1, keyB)
+                        match opened with
+                        | CallbackResult.Opened(id, _) ->
+                            let! found = port.find id
 
-                    other |> Expect.equal "spent" (LaunchResult.Refused LaunchRefusal.LaunchSpent)
+                            found
+                            |> Option.bind _.User
+                            |> Option.map _.UserId
+                            |> Expect.equal "found" (Some "prescriber")
 
-                    let! first = port.find "session-1"
-                    first |> Expect.isSome "the first session is untouched"
+                            do! port.close id
+                            let! gone = port.find id
+                            gone |> Expect.isNone "closed"
+                        | other -> failtest $"expected Opened, got {other}"
+                    }
+                ]
 
-                    let! second = port.find "session-2"
-                    second |> Expect.isNone "no second session"
-                }
 
-                testAsync "after the lifetime the launch is LaunchExpired, even for the same key" {
-                    let port, clock = makePort ()
+        let identityCookieTests =
+            testList
+                "StubLaunch identity cookie"
+                [
+                    test "round trip, with characters the cookie cannot carry" {
+                        StubLaunch.identityCookie "prescriber" "p 1;2"
+                        |> Some
+                        |> StubLaunch.parseIdentityCookie
+                        |> Expect.equal "same" (Some("prescriber", "p 1;2"))
+                    }
 
-                    let! _ = port.present (launch1, keyA)
-                    clock.Value <- t0 + lifetime + TimeSpan.FromSeconds 1.0
-                    let! late = port.present (launch1, keyA)
+                    test "an unknown choice, garbage or nothing is None" {
+                        for v in [ Some "hacker.p"; Some "prescriber"; Some ""; None ] do
+                            StubLaunch.parseIdentityCookie v |> Expect.isNone $"{v}"
+                    }
+                ]
 
-                    late
-                    |> Expect.equal "expired" (LaunchResult.Refused LaunchRefusal.LaunchExpired)
-                }
 
-                testAsync "a second Launch with another nonce opens a second session" {
-                    let port, _ = makePort ()
+        let directoryTests =
+            testList
+                "StubDirectory"
+                [
+                    test "a code redeems once" {
+                        let d = StubDirectory.make (counter "code")
+                        let code = d.issue "prescriber" "p"
 
-                    let! _ = port.present (launch1, keyA)
+                        d.idp.redeem code
+                        |> Option.map _.Login
+                        |> Expect.equal "first" (Some "prescriber")
 
-                    match! port.present (launch2, keyB) with
-                    | LaunchResult.Opened(id, session) ->
-                        id |> Expect.equal "second id" "session-2"
+                        d.idp.redeem code |> Expect.isNone "second"
+                    }
 
-                        session.PatientContext
-                        |> Option.map _.PatientId
-                        |> Expect.equal "its own patient" (Some "p-2")
-                    | other -> failtest $"expected Opened, got {other}"
-                }
+                    test "every choice but none has an identity; unknown has no standing" {
+                        let d = StubDirectory.make (counter "code")
 
-                testAsync "close removes the session" {
-                    let port, _ = makePort ()
+                        for choice in StubDirectory.choices |> List.filter ((<>) "none") do
+                            let identity = d.idp.redeem (d.issue choice "p") |> Option.get
+                            identity.Login |> Expect.equal "login" choice
 
-                    let! _ = port.present (launch1, keyA)
-                    do! port.close "session-1"
+                            match choice, d.registry.standing identity with
+                            | "unknown", None -> ()
+                            | "unknown", Some _ -> failtest "unknown has standing"
+                            | _, None -> failtest $"{choice} has no standing"
+                            | _, Some _ -> ()
+                    }
+                ]
 
-                    let! found = port.find "session-1"
-                    found |> Expect.isNone "closed"
-                }
 
-                testAsync "find of an unknown id is None" {
-                    let port, _ = makePort ()
-                    let! found = port.find "nope"
-                    found |> Expect.isNone "unknown"
-                }
-
-                test "present is pure: the same state and input give the same answer" {
-                    let ids = ref 0
-
-                    let newId () =
-                        ids.Value <- ids.Value + 1
-                        $"s{ids.Value}"
-
-                    let verify = LaunchSeal.verify t0 sealKey
-
-                    let state1, r1 = present t0 newId verify Patient.empty emptyState (launch1, keyA)
-
-                    let _, r2 = present t0 newId verify Patient.empty state1 (launch1, keyA)
-
-                    r2 |> Expect.equal "recorded answer" r1
-                    state1.Launches |> Map.count |> Expect.equal "one record" 1
-                    state1.Sessions |> Map.count |> Expect.equal "one session" 1
-                }
-            ]
+        let tests =
+            testList
+                "Hop"
+                [
+                    presentTests
+                    callbackTests
+                    portTests
+                    directoryTests
+                    identityCookieTests
+                ]
 
 
     /// An in-memory cookie: what the browser would hold after the response.
@@ -560,9 +855,22 @@ module SessionStubTests =
         value
 
 
-    /// The stub env with a fresh, counting session stub.
+    /// An in-memory state cookie: what the browser would hold after the redirect.
+    let memoryStateCookie (initial: string option) =
+        let value = ref initial
+
+        {
+            LaunchStateCookie.read = fun () -> value.Value
+            write = fun state -> value.Value <- Some state
+        },
+        value
+
+
+    /// The stub env with a fresh session port over its own stub directory.
     let envWithStub () =
-        let port, _ = makePort ()
+        let port, _, directory = makePort ()
+
+        directory,
 
         { makeEnv
               (formularyAlwaysOk Formulary.empty)
@@ -570,6 +878,46 @@ module SessionStubTests =
               (orderPlanAlwaysOk (OrderPlan.create Patient.empty [||]))
               (nutritionPlanAlwaysOk (NutritionPlan.create Patient.empty [||])) with
             session = port
+        }
+
+
+    /// Runs the whole hop for `choice`: present, the stub IdentityProvider, the callback.
+    /// Returns the redirect the callback answered with.
+    let openVia
+        (directory: StubDirectory.Directory)
+        env
+        (cookie: SessionCookie)
+        (stateCookie: LaunchStateCookie)
+        launch
+        key
+        choice
+        =
+        async {
+            let! outcome =
+                CompositionRoot.processLaunch env cookie stateCookie (LaunchCommand.PresentLaunch(launch, key))
+
+            match outcome with
+            | LaunchOutcome.RedirectTo url ->
+                let state = url.Substring(url.IndexOf "state=" + 6) |> Uri.UnescapeDataString
+
+                let cb: Callback =
+                    if choice = "none" then
+                        {
+                            State = state
+                            StateCookie = None
+                            Code = None
+                            Error = Some "no-identity"
+                        }
+                    else
+                        {
+                            State = state
+                            StateCookie = None
+                            Code = Some(directory.issue choice "stub-patient")
+                            Error = None
+                        }
+
+                return! CompositionRoot.processCallback env cookie stateCookie cb
+            | other -> return failtest $"expected RedirectTo, got {other}"
         }
 
 
@@ -689,7 +1037,7 @@ module SessionStubTests =
 
     let compositionTests =
         testList
-            "processLaunch and processSession"
+            "processLaunch, processCallback and processSession"
             [
                 testAsync "getSettings answers the settings the host composed with" {
                     let settings =
@@ -698,140 +1046,207 @@ module SessionStubTests =
                             IsDemo = false
                         }
 
+                    let _, env = envWithStub ()
                     let cookie, _ = memoryCookie None
-                    let api = CompositionRoot.compose settings (envWithStub ()) cookie
+                    let stateCookie, _ = memoryStateCookie None
+                    let api = CompositionRoot.compose settings env cookie stateCookie
                     let! answer = api.getSettings ()
                     answer |> Expect.equal "same value" settings
                 }
 
-                testAsync "PresentLaunch: Opened writes the session id to the cookie and returns the session without it" {
-                    let env = envWithStub ()
+                testAsync
+                    "PresentLaunch: a sealed Launch answers RedirectTo and writes the state cookie, not the session cookie" {
+                    let _, env = envWithStub ()
                     let cookie, held = memoryCookie None
+                    let stateCookie, heldState = memoryStateCookie None
 
-                    match! CompositionRoot.processLaunch env cookie (present "demo" keyA) with
-                    | LaunchOutcome.Opened session ->
-                        held.Value |> Expect.equal "cookie holds the id" (Some "session-1")
-                        session.User |> Expect.isSome "a user"
-
-                        session.OpenedToken
-                        |> Expect.notEqual "opened token is not the session id" (Some(OpenedToken "session-1"))
-                    | other -> failtest $"expected Opened, got {other}"
+                    match! CompositionRoot.processLaunch env cookie stateCookie (present "1" keyA) with
+                    | LaunchOutcome.RedirectTo url ->
+                        url |> Expect.stringStarts "to the IdentityProvider" "/authorize?state="
+                        heldState.Value |> Expect.isSome "state cookie written"
+                        url |> Expect.stringContains "the same state" heldState.Value.Value
+                        held.Value |> Expect.isNone "no session cookie yet"
+                    | other -> failtest $"expected RedirectTo, got {other}"
                 }
 
                 testAsync "PresentLaunch: a refusal writes no cookie" {
-                    let env = envWithStub ()
+                    let _, env = envWithStub ()
                     let cookie, held = memoryCookie None
+                    let stateCookie, heldState = memoryStateCookie None
 
                     let! outcome =
                         CompositionRoot.processLaunch
                             env
                             cookie
+                            stateCookie
                             (LaunchCommand.PresentLaunch(Launch "not-a-launch", keyA))
 
                     outcome
                     |> Expect.equal "refused" (LaunchOutcome.Refused LaunchRefusal.LaunchInvalid)
 
+                    held.Value |> Expect.isNone "no session cookie"
+                    heldState.Value |> Expect.isNone "no state cookie"
+                }
+
+                testAsync "processCallback: Opened writes the session id to the cookie and sends the browser to the app" {
+                    let directory, env = envWithStub ()
+                    let cookie, held = memoryCookie None
+                    let stateCookie, _ = memoryStateCookie None
+
+                    let! redirect =
+                        openVia directory env cookie stateCookie (mintFor "n-1" "stub-patient") keyA "prescriber"
+
+                    redirect |> Expect.equal "to the app" "/#/session"
+                    held.Value |> Expect.isSome "cookie holds the id"
+                    let! found = env.session.find held.Value.Value
+
+                    found
+                    |> Option.bind _.User
+                    |> Option.map _.UserId
+                    |> Expect.equal "the opened session" (Some "prescriber")
+                }
+
+                testAsync "processCallback: a refusal writes no session cookie and names the reason in the url" {
+                    let directory, env = envWithStub ()
+                    let cookie, held = memoryCookie None
+                    let stateCookie, _ = memoryStateCookie None
+
+                    let! redirect =
+                        openVia directory env cookie stateCookie (mintFor "n-1" "stub-patient") keyA "unknown"
+
+                    redirect |> Expect.equal "refused" "/#/session?refused=no-role"
                     held.Value |> Expect.isNone "no cookie"
                 }
 
-                testAsync "GetSession: no cookie is None" {
-                    let env = envWithStub ()
-                    let cookie, _ = memoryCookie None
+                testAsync "processCallback: without the state cookie the callback is invalid" {
+                    let directory, env = envWithStub ()
+                    let cookie, held = memoryCookie None
+                    let stateCookie, heldState = memoryStateCookie None
 
-                    let! response = CompositionRoot.processSession env cookie SessionCommand.GetSession
-                    response |> Expect.equal "anonymous" (SessionResponse.SessionResp None)
+                    let! outcome = CompositionRoot.processLaunch env cookie stateCookie (present "1" keyA)
+
+                    let state =
+                        match outcome with
+                        | LaunchOutcome.RedirectTo url -> url.Substring(url.IndexOf "state=" + 6)
+                        | other -> failtest $"{other}"
+
+                    // another browser: it has no state cookie
+                    let noCookie, _ = memoryStateCookie None
+
+                    let! redirect =
+                        CompositionRoot.processCallback
+                            env
+                            cookie
+                            noCookie
+                            {
+                                State = state
+                                StateCookie = None
+                                Code = Some(directory.issue "prescriber" "stub-patient")
+                                Error = None
+                            }
+
+                    redirect |> Expect.equal "invalid" "/#/session?refused=invalid"
+                    held.Value |> Expect.isNone "no cookie"
+                    heldState.Value |> Expect.isSome "the first browser's state cookie is untouched"
                 }
 
-                testAsync "GetSession: the cookie of an opened session finds it" {
-                    let env = envWithStub ()
+                testAsync "GetSession: no cookie is None" {
+                    let _, env = envWithStub ()
+                    let cookie, _ = memoryCookie None
+                    let! response = CompositionRoot.processSession env cookie SessionCommand.GetSession
+                    response |> Expect.equal "none" (SessionResponse.SessionResp None)
+                }
+
+                testAsync "GetSession: the cookie of an opened session finds it, without the id" {
+                    let directory, env = envWithStub ()
                     let cookie, held = memoryCookie None
+                    let stateCookie, _ = memoryStateCookie None
+                    let! _ = openVia directory env cookie stateCookie (mintFor "n-1" "stub-patient") keyA "prescriber"
 
-                    let! opened = CompositionRoot.processLaunch env cookie (present "demo" keyA)
-                    // a later request carries the cookie the first response set
                     let later, _ = memoryCookie held.Value
-                    let! found = CompositionRoot.processSession env later SessionCommand.GetSession
 
-                    match opened, found with
-                    | LaunchOutcome.Opened s, SessionResponse.SessionResp(Some f) -> f |> Expect.equal "same session" s
-                    | _ -> failtest $"expected Opened and Some, got {opened} and {found}"
+                    match! CompositionRoot.processSession env later SessionCommand.GetSession with
+                    | SessionResponse.SessionResp(Some session) ->
+                        session.User
+                        |> Option.map _.DisplayName
+                        |> Expect.equal "user" (Some "Stub Prescriber")
+                    | other -> failtest $"expected the session, got {other}"
                 }
 
                 testAsync "GetSession: a cookie for an unknown session is None" {
-                    let env = envWithStub ()
+                    let _, env = envWithStub ()
                     let cookie, _ = memoryCookie (Some "stale")
-
                     let! response = CompositionRoot.processSession env cookie SessionCommand.GetSession
-                    response |> Expect.equal "unknown id" (SessionResponse.SessionResp None)
+                    response |> Expect.equal "none" (SessionResponse.SessionResp None)
                 }
 
                 testAsync "CloseSession: closes the session and deletes the cookie" {
-                    let env = envWithStub ()
+                    let directory, env = envWithStub ()
                     let cookie, held = memoryCookie None
-
-                    let! _ = CompositionRoot.processLaunch env cookie (present "demo" keyA)
-                    let! closed = CompositionRoot.processSession env cookie SessionCommand.CloseSession
-
-                    closed |> Expect.equal "closed" SessionResponse.SessionClosed
+                    let stateCookie, _ = memoryStateCookie None
+                    let! _ = openVia directory env cookie stateCookie (mintFor "n-1" "stub-patient") keyA "prescriber"
+                    let id = held.Value.Value
+                    let! response = CompositionRoot.processSession env cookie SessionCommand.CloseSession
+                    response |> Expect.equal "closed" SessionResponse.SessionClosed
                     held.Value |> Expect.isNone "cookie deleted"
-
-                    let! found = env.session.find "session-1"
-                    found |> Expect.isNone "session closed"
+                    let! found = env.session.find id
+                    found |> Expect.isNone "session gone"
                 }
 
                 testAsync "CloseSession without a cookie still deletes (idempotent)" {
-                    let env = envWithStub ()
-                    let deleted = ref false
-
-                    let cookie =
-                        {
-                            read = fun () -> None
-                            write = fun _ -> ()
-                            delete = fun () -> deleted.Value <- true
-                        }
-
-                    let! _ = CompositionRoot.processSession env cookie SessionCommand.CloseSession
-                    deleted.Value |> Expect.isTrue "delete called"
+                    let _, env = envWithStub ()
+                    let cookie, held = memoryCookie None
+                    let! response = CompositionRoot.processSession env cookie SessionCommand.CloseSession
+                    response |> Expect.equal "closed" SessionResponse.SessionClosed
+                    held.Value |> Expect.isNone "still none"
                 }
 
                 testAsync "CloseSession deletes the cookie even when the port's close throws" {
-                    let deleted = ref false
+                    let _, env = envWithStub ()
 
                     let env =
-                        { envWithStub () with
+                        { env with
                             session =
-                                { Adapters.sessionDisabled with
-                                    close = fun _ -> async { return raise (InvalidOperationException "store down") }
+                                { env.session with
+                                    close = fun _ -> async { return raise (InvalidOperationException "boom") }
                                 }
                         }
 
-                    let cookie =
-                        {
-                            read = fun () -> Some "session-1"
-                            write = fun _ -> ()
-                            delete = fun () -> deleted.Value <- true
-                        }
+                    let cookie, held = memoryCookie (Some "session-1")
 
-                    let! outcome =
+                    let! result =
                         CompositionRoot.processSession env cookie SessionCommand.CloseSession
                         |> Async.Catch
 
-                    match outcome with
-                    | Choice2Of2(:? InvalidOperationException) -> ()
-                    | other -> failtest $"expected the close exception to propagate, got {other}"
-
-                    deleted.Value |> Expect.isTrue "cookie deleted regardless"
+                    match result with
+                    | Choice2Of2 _ -> held.Value |> Expect.isNone "cookie deleted before the exception propagated"
+                    | Choice1Of2 _ -> failtest "expected the exception to propagate"
                 }
 
-                testAsync "sessionDisabled refuses every launch as invalid and finds nothing" {
-                    let env = { envWithStub () with session = Adapters.sessionDisabled }
-
+                testAsync "sessionDisabled refuses every launch and callback as invalid and finds nothing" {
+                    let _, env = envWithStub ()
+                    let env = { env with session = Adapters.sessionDisabled }
                     let cookie, held = memoryCookie (Some "any")
+                    let stateCookie, _ = memoryStateCookie (Some "st")
 
-                    let! outcome = CompositionRoot.processLaunch env cookie (present "demo" keyA)
+                    let! outcome = CompositionRoot.processLaunch env cookie stateCookie (present "1" keyA)
 
                     outcome
                     |> Expect.equal "invalid" (LaunchOutcome.Refused LaunchRefusal.LaunchInvalid)
 
+                    let! redirect =
+                        CompositionRoot.processCallback
+                            env
+                            cookie
+                            stateCookie
+                            {
+                                State = "st"
+                                StateCookie = None
+                                Code = Some "c"
+                                Error = None
+                            }
+
+                    redirect |> Expect.equal "invalid" "/#/session?refused=invalid"
                     held.Value |> Expect.equal "cookie untouched" (Some "any")
 
                     let! response = CompositionRoot.processSession env cookie SessionCommand.GetSession
@@ -846,7 +1261,7 @@ module SessionStubTests =
             [
                 thumbprintTests
                 sealTests
-                stubTests
+                HopTests.tests
                 stubLaunchTests
                 compositionTests
             ]


### PR DESCRIPTION
## Summary

Step 2 of plan #605: the identity hop of uc-01 step 4 and the step-5 checks, end to end against stubs hosted by the server.

- **Ports** (`Ports.fs`): `BrowserIdentity`, `UserStanding`, `IdentityProviderPort`, `UserRegistryPort`, `PatientDataPort`, `Callback`, `CallbackResult`, `LaunchStateCookie`; `LaunchResult.RedirectTo` carries the `state`; `SessionPort` gains `callback`.
- **`Hop`** (`Adapters.fs`, replacing `SessionStub`): the LaunchRecord keyed by the nonce with the state and the appended outcome; `present` answers the redirect or the recorded answer for the same key (Rule 2); `callback` runs the ladder as reviewed on #606: state cookie, record and lifetime, Rule 45 replay, no identity, no role, wrong active patient, a Prescriber without a PIN (a Reader opens), then the single act that spends the nonce, closes the login's other Sessions and marks them (Rule 8), and writes the Session. `read = None` opens with an empty patient (ext 6a).
- **Stubs**: `StubDirectory` is IdentityProvider and UserRegistry over the identity choice (`prescriber`, `reader`, `prescriber-other-patient`, `no-pin`, `unknown`, `none`), one-time codes, the active patient per login; `StubPatientData` answers `None` for `no-data`.
- **Edge** (`Server.fs`, `CompositionRoot.fs`): `processLaunch` writes the `genpres_launch_state` cookie (HttpOnly, Lax, `Path=/callback`, two minutes); `/authorize` (demo only) and `/callback` (always; refuses `invalid` with the disabled port); the stub page sets `genpres_stub_identity` (`choice.pid`) and accepts an `identity` field, defaulting to `prescriber`. The Vite proxy forwards both routes.

Deviation from the plan, on purpose: the routes and cookies are in this PR rather than PR 3, otherwise master would answer `RedirectTo` to a route that does not exist between the two merges. PR 3 keeps the page's identity select, the cookie attribute tests, the client's `invalid` word and the docs.

Drafted script-first in `Server/Scripts/Hop.fsx` (24 tests, kept verbatim as a nested test module), migrated after review.

## Verification

- `dotnet run Build`, `dotnet run ServerTests` (Server.Tests 148), Fantomas clean.
- Chrome, demo server, isolated contexts, via the stub page with a hidden `identity` field: `prescriber` → `#/session?launch=…` → `/authorize` → `/callback` → `#/session`, title bar "Stub Prescriber (Voorschrijver)"; `reader` → "Stub Reader (Lezer)"; `unknown` → no-role gate with "continue"; `prescriber-other-patient` → wrong-patient gate; `no-pin` → enrolment gate; `none` → no-identity gate, no retry. The server log shows PresentLaunch, `/authorize`, `/callback`, GetSession in that order.
- Reloading the `/callback?code&state` URL in the same context keeps the session open (Rule 45).
- `GENPRES_PROD=1`: `/authorize` and `/stub/launch` 404, `/callback` redirects to `#/session?refused=invalid`.

## Vibe coding disclosure

Drafted with Claude Code (script, tests, migration patch); reviewed and migrated by hand, verified as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZWjibQUW8uqCVbfV4vDTf
