### PR TITLE
feat(server): tell the user once when a newer launch ended their session

### DIFF
--- a/src/Informedica.GenPRES.Client/App.fs
+++ b/src/Informedica.GenPRES.Client/App.fs
@@ -606,8 +606,13 @@ module private Elmish =
             async {
                 try
                     match! serverApi.processSession Api.SessionCommand.GetSession with
-                    | Api.SessionResponse.SessionResp session -> return SessionMsg(SessionMsg.Resumed(Ok session))
-                    | Api.SessionResponse.SessionClosed -> return SessionMsg(SessionMsg.Resumed(Ok None))
+                    | Api.SessionResponse.SessionResp(Some session) ->
+                        return SessionMsg(SessionMsg.Resumed(Ok(ResumeResult.Found session)))
+                    | Api.SessionResponse.SessionResp None
+                    | Api.SessionResponse.SessionClosed ->
+                        return SessionMsg(SessionMsg.Resumed(Ok ResumeResult.NotFound))
+                    | Api.SessionResponse.SessionEnded ending ->
+                        return SessionMsg(SessionMsg.Resumed(Ok(ResumeResult.Ended ending)))
                 with ex ->
                     return SessionMsg(SessionMsg.Resumed(Error ex.Message))
             }

--- a/src/Informedica.GenPRES.Client/Components/TitleBar.fs
+++ b/src/Informedica.GenPRES.Client/Components/TitleBar.fs
@@ -251,7 +251,8 @@ module TitleBar =
             | Session.Launching _
             | Session.Resuming
             | Session.Refused _
-            | Session.Unreachable _ -> None
+            | Session.Unreachable _
+            | Session.Ended _ -> None
             |> Option.defaultValue null
 
         JSX.jsx

--- a/src/Informedica.GenPRES.Client/SessionGatePolicy.fs
+++ b/src/Informedica.GenPRES.Client/SessionGatePolicy.fs
@@ -58,6 +58,8 @@ let english (term: Terms) =
     | Terms.``Session Close`` -> "Close session"
     | Terms.``Session Role Prescriber`` -> "Prescriber"
     | Terms.``Session Role Reader`` -> "Reader"
+    | Terms.``Session Gate Ended`` -> "Your session was ended"
+    | Terms.``Session Ending Superseded`` -> "Another launch of yours opened a newer session, and this one was closed."
     | _ -> $"{term}"
 
 
@@ -107,7 +109,8 @@ let isGated (session: Session) =
     | Session.Launching _
     | Session.Resuming
     | Session.Unreachable _
-    | Session.Refused _ -> true
+    | Session.Refused _
+    | Session.Ended _ -> true
 
 
 /// The gate for a session phase, or None when the app is usable (anonymous, open, closing).
@@ -165,6 +168,20 @@ let gateFor (tr: Terms -> string) (session: Session) : Gate option =
                         | _, Some _ -> Action.Retry
                         | _ -> ()
                     ]
+            }
+    | Session.Ended ending ->
+        Some
+            {
+                Title = tr Terms.``Session Gate Ended``
+                Body =
+                    sentences
+                        [
+                            match ending with
+                            | SessionEnding.SupersededByLaunch -> tr Terms.``Session Ending Superseded``
+                            tr Terms.``Session Relaunch``
+                        ]
+                Busy = false
+                Actions = [ Action.ContinueWithoutLaunch ]
             }
     | Session.Anonymous
     | Session.Open _

--- a/src/Informedica.GenPRES.Client/SessionMachine.fs
+++ b/src/Informedica.GenPRES.Client/SessionMachine.fs
@@ -144,7 +144,9 @@ module Session =
 
         | SessionMsg.Resumed(Ok(ResumeResult.Found session)), Session.Resuming -> opened session
         // told once (Rule 11): the cookie is gone, the gate says why, the User chooses
-        | SessionMsg.Resumed(Ok(ResumeResult.Ended ending)), Session.Resuming -> Session.Ended ending, []
+        // the close acknowledges the ending: the server deletes the cookie and drops the mark
+        | SessionMsg.Resumed(Ok(ResumeResult.Ended ending)), Session.Resuming ->
+            Session.Ended ending, [ SessionEffect.CallCloseSession ]
         | SessionMsg.Resumed _, Session.Resuming -> Session.Anonymous, []
         | SessionMsg.Resumed _, _ -> state, []
 

--- a/src/Informedica.GenPRES.Client/SessionMachine.fs
+++ b/src/Informedica.GenPRES.Client/SessionMachine.fs
@@ -31,6 +31,17 @@ type Session =
     | Refused of LaunchRefusal * retry: (Launch * PublicKey) option
     // ext 3a: server down after the page was served
     | Unreachable of Launch * PublicKey * attempts: int
+    // no Session: the server ended it (Rule 11) and said so once; the User continues
+    // anonymously or relaunches
+    | Ended of SessionEnding
+
+
+/// What GetSession answered at a resume.
+[<RequireQualifiedAccess>]
+type ResumeResult =
+    | Found of SessionOpened
+    | NotFound
+    | Ended of SessionEnding
 
 
 [<RequireQualifiedAccess>]
@@ -42,7 +53,7 @@ type SessionMsg =
     // from Unreachable, or Refused with a retry
     | Retry
     | Resume
-    | Resumed of Result<SessionOpened option, string>
+    | Resumed of Result<ResumeResult, string>
     // from #/session?refused={reason}, launch step 4.5
     | RefusedAtCallback of LaunchRefusal
     | OpenAnonymous
@@ -131,7 +142,9 @@ module Session =
         | SessionMsg.Resume, Session.Anonymous -> Session.Resuming, [ SessionEffect.CallGetSession ]
         | SessionMsg.Resume, _ -> state, []
 
-        | SessionMsg.Resumed(Ok(Some session)), Session.Resuming -> opened session
+        | SessionMsg.Resumed(Ok(ResumeResult.Found session)), Session.Resuming -> opened session
+        // told once (Rule 11): the cookie is gone, the gate says why, the User chooses
+        | SessionMsg.Resumed(Ok(ResumeResult.Ended ending)), Session.Resuming -> Session.Ended ending, []
         | SessionMsg.Resumed _, Session.Resuming -> Session.Anonymous, []
         | SessionMsg.Resumed _, _ -> state, []
 
@@ -140,7 +153,8 @@ module Session =
 
         // an anonymous open carries nothing over (Rule 7)
         | SessionMsg.OpenAnonymous, Session.Refused _
-        | SessionMsg.OpenAnonymous, Session.Unreachable _ -> Session.Anonymous, [ SessionEffect.SetPatient None ]
+        | SessionMsg.OpenAnonymous, Session.Unreachable _
+        | SessionMsg.OpenAnonymous, Session.Ended _ -> Session.Anonymous, [ SessionEffect.SetPatient None ]
         | SessionMsg.OpenAnonymous, _ -> state, []
 
         | SessionMsg.Close, Session.Open session -> Session.Closing session, [ SessionEffect.CallCloseSession ]

--- a/src/Informedica.GenPRES.Server/Scripts/Hop.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/Hop.fsx
@@ -14,6 +14,9 @@
 // Review points folded in (#606): the error redirect keeps the state; the PIN check binds
 // Prescribers only (Rule 25, ext 5c); `read = None` opens without imported data (ext 6a).
 //
+// PR 4 (endings, Rules 8 and 11): `SessionEnding` moves to Shared (the client shows it),
+// `find` answers `SessionLookup.Ended` once for a Session the server ended, and drops the mark.
+//
 // Run: `dotnet fsi Hop.fsx` from this directory (build the solution first).
 
 #I __SOURCE_DIRECTORY__
@@ -98,11 +101,26 @@ type CallbackResult =
     | Superseded of redirect: string
 
 
+/// Why a Session ended other than by the User closing it (Rule 11). One case now; idle and
+/// absolute lifetime (Rule 10) come with their own plan. → Shared/Types.fs, next to LaunchRefusal.
+[<RequireQualifiedAccess>]
+type SessionEnding = SupersededByLaunch
+
+
+/// What the store says about a session id from the cookie: the Session, nothing, or that the
+/// server ended it, which is said once (Rule 11) and then forgotten.
+[<RequireQualifiedAccess>]
+type SessionLookup =
+    | Found of SessionOpened
+    | NotFound
+    | Ended of SessionEnding
+
+
 type SessionPort =
     {
         present: Launch * PublicKey -> Async<LaunchResult>
         callback: Callback -> Async<CallbackResult>
-        find: string -> Async<SessionOpened option>
+        find: string -> Async<SessionLookup>
         close: string -> Async<unit>
     }
 
@@ -159,11 +177,6 @@ module Hop =
             Session: SessionOpened
             Login: string option
         }
-
-
-    /// Why a Session ended other than by the User closing it (Rule 11). One case now.
-    [<RequireQualifiedAccess>]
-    type SessionEnding = SupersededByLaunch
 
 
     type State =
@@ -345,6 +358,17 @@ module Hop =
         | _ -> state, invalid
 
 
+    /// The lookup for a session id: the Session; else the ending the server recorded, answered
+    /// once and dropped (Rule 11, told at the next request); else nothing.
+    let find (id: string) (state: State) : State * SessionLookup =
+        match state.Sessions |> Map.tryFind id with
+        | Some record -> state, SessionLookup.Found record.Session
+        | None ->
+            match state.Endings |> Map.tryFind id with
+            | Some ending -> { state with Endings = state.Endings |> Map.remove id }, SessionLookup.Ended ending
+            | None -> state, SessionLookup.NotFound
+
+
     /// The port over a single mutable state guarded by a lock, over the three actor ports.
     let makeSessionPort
         (now: unit -> DateTime)
@@ -375,8 +399,7 @@ module Hop =
                         return
                             update (fun s -> callback (now ()) newId idp.redeem registry.standing patientData.read s cb)
                     }
-            find =
-                fun id -> async { return lock gate (fun () -> state.Sessions |> Map.tryFind id |> Option.map _.Session) }
+            find = fun id -> async { return update (find id) }
             close = fun id -> async { return update (fun s -> { s with Sessions = s.Sessions |> Map.remove id }, ()) }
         }
 
@@ -838,7 +861,7 @@ let callbackTests =
                 | CallbackResult.Opened(id1, _), CallbackResult.Opened(id2, _) ->
                     state.Sessions |> Map.containsKey id1 |> Expect.isFalse "first closed"
                     state.Sessions |> Map.containsKey id2 |> Expect.isTrue "second open"
-                    state.Endings |> Map.tryFind id1 |> Expect.equal "marked" (Some Hop.SessionEnding.SupersededByLaunch)
+                    state.Endings |> Map.tryFind id1 |> Expect.equal "marked" (Some SessionEnding.SupersededByLaunch)
                 | other -> failtest $"expected two Opened, got {other}"
             }
 
@@ -851,6 +874,24 @@ let callbackTests =
                 let state2, again = run ids d state cb1
                 again |> Expect.equal "superseded" (CallbackResult.Superseded "/#/session")
                 state2 |> Expect.equal "unchanged" state
+            }
+
+            test "the ended Session is told once at the next lookup, then it is gone (Rule 11)" {
+                let ids, d = fixture ()
+                let state, cb1 = hop ids d Hop.emptyState launch1 keyA "prescriber"
+                let state, first = run ids d state cb1
+                let state, cb2 = hop ids d state (mintFor "n-2" "patient-1") keyB "prescriber"
+                let state, _ = run ids d state cb2
+
+                let id1 =
+                    match first with
+                    | CallbackResult.Opened(id, _) -> id
+                    | other -> failtest $"{other}"
+
+                let state, once = Hop.find id1 state
+                once |> Expect.equal "told" (SessionLookup.Ended SessionEnding.SupersededByLaunch)
+                let _, again = Hop.find id1 state
+                again |> Expect.equal "forgotten" SessionLookup.NotFound
             }
 
             test "two logins keep two Sessions" {
@@ -893,11 +934,14 @@ let portTests =
 
                 match opened with
                 | CallbackResult.Opened(id, _) ->
-                    let! found = port.find id
-                    found |> Option.bind _.User |> Option.map _.UserId |> Expect.equal "found" (Some "prescriber")
+                    match! port.find id with
+                    | SessionLookup.Found session ->
+                        session.User |> Option.map _.UserId |> Expect.equal "found" (Some "prescriber")
+                    | other -> failtest $"expected Found, got {other}"
+
                     do! port.close id
                     let! gone = port.find id
-                    gone |> Expect.isNone "closed"
+                    gone |> Expect.equal "closed" SessionLookup.NotFound
                 | other -> failtest $"expected Opened, got {other}"
             }
         ]

--- a/src/Informedica.GenPRES.Server/Scripts/Hop.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/Hop.fsx
@@ -108,7 +108,8 @@ type SessionEnding = SupersededByLaunch
 
 
 /// What the store says about a session id from the cookie: the Session, nothing, or that the
-/// server ended it, which is said once (Rule 11) and then forgotten.
+/// server ended it (Rule 11), said as long as the browser still sends the cookie the answer
+/// deletes.
 [<RequireQualifiedAccess>]
 type SessionLookup =
     | Found of SessionOpened
@@ -183,8 +184,10 @@ module Hop =
         {
             Launches: Map<string, LaunchRecord>
             Sessions: Map<string, SessionRecord>
-            // sessions ended by the server, told once at the next GetSession (Rule 11, PR 4)
-            Endings: Map<string, SessionEnding>
+            // sessions the server ended, with the moment: told at every GetSession that still
+            // carries their cookie (Rule 11); the answer deletes the cookie, so a lost answer is
+            // asked again. Pruned after endingLifetime.
+            Endings: Map<string, SessionEnding * DateTime>
         }
 
 
@@ -249,6 +252,7 @@ module Hop =
     /// Step 5.7, one act (Rule 40): the Session is written, the login's other Sessions are
     /// closed and marked (Rule 8), the outcome is appended to the record.
     let private openSession
+        (now: DateTime)
         (newId: unit -> string)
         (patientData: string -> Patient option)
         (record: LaunchRecord)
@@ -289,7 +293,7 @@ module Hop =
                 |> Map.add id { Session = session; Login = login }
             Endings =
                 superseded
-                |> List.fold (fun m sid -> Map.add sid SessionEnding.SupersededByLaunch m) state.Endings
+                |> List.fold (fun m sid -> Map.add sid (SessionEnding.SupersededByLaunch, now) m) state.Endings
         },
         CallbackResult.Opened(id, openedUrl)
 
@@ -351,21 +355,30 @@ module Hop =
                         refuse record LaunchRefusal.WrongActivePatient state
                     | Some standing when standing.User.Role = UserRole.Prescriber && not standing.PinSet ->
                         refuse record LaunchRefusal.EnrolmentRequired state
-                    | Some standing -> openSession newId patientData record standing state
+                    | Some standing -> openSession now newId patientData record standing state
         | _, None ->
             // no record: expired and dropped (Rule 29), or never presented
             state, invalid
         | _ -> state, invalid
 
 
+    /// How long an ending is kept for a browser that still sends the cookie (Rule 11). Long
+    /// enough for a lost answer to be asked again; the answer that arrives deletes the cookie.
+    let endingLifetime = TimeSpan.FromHours 1.0
+
+
     /// The lookup for a session id: the Session; else the ending the server recorded, answered
-    /// once and dropped (Rule 11, told at the next request); else nothing.
-    let find (id: string) (state: State) : State * SessionLookup =
+    /// as long as the cookie keeps coming (the answer deletes it, so a lost answer is retried
+    /// rather than swallowed); else nothing. Endings past their lifetime are dropped here.
+    let find (now: DateTime) (id: string) (state: State) : State * SessionLookup =
+        let state =
+            { state with Endings = state.Endings |> Map.filter (fun _ (_, at) -> now - at <= endingLifetime) }
+
         match state.Sessions |> Map.tryFind id with
         | Some record -> state, SessionLookup.Found record.Session
         | None ->
             match state.Endings |> Map.tryFind id with
-            | Some ending -> { state with Endings = state.Endings |> Map.remove id }, SessionLookup.Ended ending
+            | Some(ending, _) -> state, SessionLookup.Ended ending
             | None -> state, SessionLookup.NotFound
 
 
@@ -399,7 +412,7 @@ module Hop =
                         return
                             update (fun s -> callback (now ()) newId idp.redeem registry.standing patientData.read s cb)
                     }
-            find = fun id -> async { return update (find id) }
+            find = fun id -> async { return update (find (now ()) id) }
             close = fun id -> async { return update (fun s -> { s with Sessions = s.Sessions |> Map.remove id }, ()) }
         }
 
@@ -861,7 +874,7 @@ let callbackTests =
                 | CallbackResult.Opened(id1, _), CallbackResult.Opened(id2, _) ->
                     state.Sessions |> Map.containsKey id1 |> Expect.isFalse "first closed"
                     state.Sessions |> Map.containsKey id2 |> Expect.isTrue "second open"
-                    state.Endings |> Map.tryFind id1 |> Expect.equal "marked" (Some SessionEnding.SupersededByLaunch)
+                    state.Endings |> Map.tryFind id1 |> Option.map fst |> Expect.equal "marked" (Some SessionEnding.SupersededByLaunch)
                 | other -> failtest $"expected two Opened, got {other}"
             }
 
@@ -876,7 +889,7 @@ let callbackTests =
                 state2 |> Expect.equal "unchanged" state
             }
 
-            test "the ended Session is told once at the next lookup, then it is gone (Rule 11)" {
+            test "the ended Session is told at every lookup that still carries the cookie, until its lifetime (Rule 11)" {
                 let ids, d = fixture ()
                 let state, cb1 = hop ids d Hop.emptyState launch1 keyA "prescriber"
                 let state, first = run ids d state cb1
@@ -888,10 +901,14 @@ let callbackTests =
                     | CallbackResult.Opened(id, _) -> id
                     | other -> failtest $"{other}"
 
-                let state, once = Hop.find id1 state
-                once |> Expect.equal "told" (SessionLookup.Ended SessionEnding.SupersededByLaunch)
-                let _, again = Hop.find id1 state
-                again |> Expect.equal "forgotten" SessionLookup.NotFound
+                let state, told = Hop.find t0 id1 state
+                told |> Expect.equal "told" (SessionLookup.Ended SessionEnding.SupersededByLaunch)
+                // the answer was lost: the cookie came again, so is the ending
+                let state, again = Hop.find t0 id1 state
+                again |> Expect.equal "told again" (SessionLookup.Ended SessionEnding.SupersededByLaunch)
+                // past the lifetime the ending is gone
+                let _, late = Hop.find (t0 + Hop.endingLifetime + TimeSpan.FromSeconds 1.0) id1 state
+                late |> Expect.equal "dropped" SessionLookup.NotFound
             }
 
             test "two logins keep two Sessions" {

--- a/src/Informedica.GenPRES.Server/Scripts/Hop.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/Hop.fsx
@@ -185,8 +185,8 @@ module Hop =
             Launches: Map<string, LaunchRecord>
             Sessions: Map<string, SessionRecord>
             // sessions the server ended, with the moment: told at every GetSession that still
-            // carries their cookie (Rule 11); the answer deletes the cookie, so a lost answer is
-            // asked again. Kept as long as the Sessions are (Rule 10 will bound both).
+            // carries their cookie (Rule 11), dropped when the client acknowledges with
+            // CloseSession. Kept as long as the Sessions are (Rule 10 will bound both).
             Endings: Map<string, SessionEnding * DateTime>
         }
 
@@ -363,10 +363,11 @@ module Hop =
 
 
     /// The lookup for a session id: the Session; else the ending the server recorded, answered
-    /// as long as the cookie keeps coming (the answer deletes it, so a lost answer is retried
-    /// rather than swallowed); else nothing. An ending is kept as long as the stub keeps its
-    /// Sessions: the notification is the User's only one (Rule 11), and a tab may come back
-    /// after any pause. The absolute Session lifetime (Rule 10), when it lands, bounds both.
+    /// as long as the cookie keeps coming; else nothing. The client acknowledges an ending with
+    /// CloseSession, which deletes the cookie and drops the mark (`close`), so a lost answer is
+    /// asked and told again while an acknowledged one is told once. An unacknowledged ending
+    /// is kept as long as the stub keeps its Sessions: the notification is the User's only one
+    /// (Rule 11). The absolute Session lifetime (Rule 10), when it lands, bounds both.
     let find (id: string) (state: State) : State * SessionLookup =
         match state.Sessions |> Map.tryFind id with
         | Some record -> state, SessionLookup.Found record.Session
@@ -374,6 +375,15 @@ module Hop =
             match state.Endings |> Map.tryFind id with
             | Some(ending, _) -> state, SessionLookup.Ended ending
             | None -> state, SessionLookup.NotFound
+
+
+    /// Rule 10's explicit close, and the acknowledgement of an ending: the Session and any
+    /// mark for the id are dropped together.
+    let close (id: string) (state: State) : State =
+        { state with
+            Sessions = state.Sessions |> Map.remove id
+            Endings = state.Endings |> Map.remove id
+        }
 
 
     /// The port over a single mutable state guarded by a lock, over the three actor ports.
@@ -407,7 +417,7 @@ module Hop =
                             update (fun s -> callback (now ()) newId idp.redeem registry.standing patientData.read s cb)
                     }
             find = fun id -> async { return update (find id) }
-            close = fun id -> async { return update (fun s -> { s with Sessions = s.Sessions |> Map.remove id }, ()) }
+            close = fun id -> async { return update (fun s -> close id s, ()) }
         }
 
 

--- a/src/Informedica.GenPRES.Server/Scripts/Hop.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/Hop.fsx
@@ -186,7 +186,7 @@ module Hop =
             Sessions: Map<string, SessionRecord>
             // sessions the server ended, with the moment: told at every GetSession that still
             // carries their cookie (Rule 11); the answer deletes the cookie, so a lost answer is
-            // asked again. Pruned after endingLifetime.
+            // asked again. Kept as long as the Sessions are (Rule 10 will bound both).
             Endings: Map<string, SessionEnding * DateTime>
         }
 
@@ -362,18 +362,12 @@ module Hop =
         | _ -> state, invalid
 
 
-    /// How long an ending is kept for a browser that still sends the cookie (Rule 11). Long
-    /// enough for a lost answer to be asked again; the answer that arrives deletes the cookie.
-    let endingLifetime = TimeSpan.FromHours 1.0
-
-
     /// The lookup for a session id: the Session; else the ending the server recorded, answered
     /// as long as the cookie keeps coming (the answer deletes it, so a lost answer is retried
-    /// rather than swallowed); else nothing. Endings past their lifetime are dropped here.
-    let find (now: DateTime) (id: string) (state: State) : State * SessionLookup =
-        let state =
-            { state with Endings = state.Endings |> Map.filter (fun _ (_, at) -> now - at <= endingLifetime) }
-
+    /// rather than swallowed); else nothing. An ending is kept as long as the stub keeps its
+    /// Sessions: the notification is the User's only one (Rule 11), and a tab may come back
+    /// after any pause. The absolute Session lifetime (Rule 10), when it lands, bounds both.
+    let find (id: string) (state: State) : State * SessionLookup =
         match state.Sessions |> Map.tryFind id with
         | Some record -> state, SessionLookup.Found record.Session
         | None ->
@@ -412,7 +406,7 @@ module Hop =
                         return
                             update (fun s -> callback (now ()) newId idp.redeem registry.standing patientData.read s cb)
                     }
-            find = fun id -> async { return update (find (now ()) id) }
+            find = fun id -> async { return update (find id) }
             close = fun id -> async { return update (fun s -> { s with Sessions = s.Sessions |> Map.remove id }, ()) }
         }
 
@@ -889,7 +883,7 @@ let callbackTests =
                 state2 |> Expect.equal "unchanged" state
             }
 
-            test "the ended Session is told at every lookup that still carries the cookie, until its lifetime (Rule 11)" {
+            test "the ended Session is told at every lookup that still carries the cookie (Rule 11)" {
                 let ids, d = fixture ()
                 let state, cb1 = hop ids d Hop.emptyState launch1 keyA "prescriber"
                 let state, first = run ids d state cb1
@@ -901,14 +895,12 @@ let callbackTests =
                     | CallbackResult.Opened(id, _) -> id
                     | other -> failtest $"{other}"
 
-                let state, told = Hop.find t0 id1 state
+                let state, told = Hop.find id1 state
                 told |> Expect.equal "told" (SessionLookup.Ended SessionEnding.SupersededByLaunch)
-                // the answer was lost: the cookie came again, so is the ending
-                let state, again = Hop.find t0 id1 state
+                // the answer was lost, or the tab comes back much later: the cookie came again,
+                // so is the ending
+                let _, again = Hop.find id1 state
                 again |> Expect.equal "told again" (SessionLookup.Ended SessionEnding.SupersededByLaunch)
-                // past the lifetime the ending is gone
-                let _, late = Hop.find (t0 + Hop.endingLifetime + TimeSpan.FromSeconds 1.0) id1 state
-                late |> Expect.equal "dropped" SessionLookup.NotFound
             }
 
             test "two logins keep two Sessions" {

--- a/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
@@ -231,11 +231,6 @@ module Hop =
         }
 
 
-    /// Why a Session ended other than by the User closing it (Rule 11). One case now.
-    [<RequireQualifiedAccess>]
-    type SessionEnding = SupersededByLaunch
-
-
     type State =
         {
             Launches: Map<string, LaunchRecord>
@@ -423,6 +418,17 @@ module Hop =
         | _ -> state, invalid
 
 
+    /// The lookup for a session id: the Session; else the ending the server recorded, answered
+    /// once and dropped (Rule 11, told at the next request); else nothing.
+    let find (id: string) (state: State) : State * SessionLookup =
+        match state.Sessions |> Map.tryFind id with
+        | Some record -> state, SessionLookup.Found record.Session
+        | None ->
+            match state.Endings |> Map.tryFind id with
+            | Some ending -> { state with Endings = state.Endings |> Map.remove id }, SessionLookup.Ended ending
+            | None -> state, SessionLookup.NotFound
+
+
     /// The port over a single mutable state guarded by a lock, over the three actor ports.
     let makeSessionPort
         (now: unit -> DateTime)
@@ -453,9 +459,7 @@ module Hop =
                         return
                             update (fun s -> callback (now ()) newId idp.redeem registry.standing patientData.read s cb)
                     }
-            find =
-                fun id ->
-                    async { return lock gate (fun () -> state.Sessions |> Map.tryFind id |> Option.map _.Session) }
+            find = fun id -> async { return update (find id) }
             close = fun id -> async { return update (fun s -> { s with Sessions = s.Sessions |> Map.remove id }, ()) }
         }
 
@@ -860,7 +864,7 @@ module Adapters =
                                 Hop.refusedUrl LaunchRefusal.LaunchInvalid
                             )
                     }
-            find = fun _ -> async { return None }
+            find = fun _ -> async { return SessionLookup.NotFound }
             close = fun _ -> async { return () }
         }
 

--- a/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
@@ -237,8 +237,8 @@ module Hop =
             Sessions: Map<string, SessionRecord>
             // sessions ended by the server, told once at the next GetSession (Rule 11, PR 4)
             // sessions the server ended, with the moment: told at every GetSession that still
-            // carries their cookie (Rule 11); the answer deletes the cookie, so a lost answer is
-            // asked again. Kept as long as the Sessions are (Rule 10 will bound both).
+            // carries their cookie (Rule 11), dropped when the client acknowledges with
+            // CloseSession. Kept as long as the Sessions are (Rule 10 will bound both).
             Endings: Map<string, SessionEnding * DateTime>
         }
 
@@ -423,10 +423,11 @@ module Hop =
 
 
     /// The lookup for a session id: the Session; else the ending the server recorded, answered
-    /// as long as the cookie keeps coming (the answer deletes it, so a lost answer is retried
-    /// rather than swallowed); else nothing. An ending is kept as long as the stub keeps its
-    /// Sessions: the notification is the User's only one (Rule 11), and a tab may come back
-    /// after any pause. The absolute Session lifetime (Rule 10), when it lands, bounds both.
+    /// as long as the cookie keeps coming; else nothing. The client acknowledges an ending with
+    /// CloseSession, which deletes the cookie and drops the mark (`close`), so a lost answer is
+    /// asked and told again while an acknowledged one is told once. An unacknowledged ending
+    /// is kept as long as the stub keeps its Sessions: the notification is the User's only one
+    /// (Rule 11). The absolute Session lifetime (Rule 10), when it lands, bounds both.
     let find (id: string) (state: State) : State * SessionLookup =
         match state.Sessions |> Map.tryFind id with
         | Some record -> state, SessionLookup.Found record.Session
@@ -434,6 +435,15 @@ module Hop =
             match state.Endings |> Map.tryFind id with
             | Some(ending, _) -> state, SessionLookup.Ended ending
             | None -> state, SessionLookup.NotFound
+
+
+    /// Rule 10's explicit close, and the acknowledgement of an ending: the Session and any
+    /// mark for the id are dropped together.
+    let close (id: string) (state: State) : State =
+        { state with
+            Sessions = state.Sessions |> Map.remove id
+            Endings = state.Endings |> Map.remove id
+        }
 
 
     /// The port over a single mutable state guarded by a lock, over the three actor ports.
@@ -467,7 +477,7 @@ module Hop =
                             update (fun s -> callback (now ()) newId idp.redeem registry.standing patientData.read s cb)
                     }
             find = fun id -> async { return update (find id) }
-            close = fun id -> async { return update (fun s -> { s with Sessions = s.Sessions |> Map.remove id }, ()) }
+            close = fun id -> async { return update (fun s -> close id s, ()) }
         }
 
 

--- a/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
@@ -236,7 +236,10 @@ module Hop =
             Launches: Map<string, LaunchRecord>
             Sessions: Map<string, SessionRecord>
             // sessions ended by the server, told once at the next GetSession (Rule 11, PR 4)
-            Endings: Map<string, SessionEnding>
+            // sessions the server ended, with the moment: told at every GetSession that still
+            // carries their cookie (Rule 11); the answer deletes the cookie, so a lost answer is
+            // asked again. Pruned after endingLifetime.
+            Endings: Map<string, SessionEnding * DateTime>
         }
 
 
@@ -300,6 +303,7 @@ module Hop =
     /// Step 5.7, one act (Rule 40): the Session is written, the login's other Sessions are
     /// closed and marked (Rule 8), the outcome is appended to the record.
     let private openSession
+        (now: DateTime)
         (newId: unit -> string)
         (patientData: string -> Patient option)
         (record: LaunchRecord)
@@ -345,7 +349,7 @@ module Hop =
                     }
             Endings =
                 superseded
-                |> List.fold (fun m sid -> Map.add sid SessionEnding.SupersededByLaunch m) state.Endings
+                |> List.fold (fun m sid -> Map.add sid (SessionEnding.SupersededByLaunch, now) m) state.Endings
         },
         CallbackResult.Opened(id, openedUrl)
 
@@ -411,21 +415,30 @@ module Hop =
                         refuse record LaunchRefusal.WrongActivePatient state
                     | Some standing when standing.User.Role = UserRole.Prescriber && not standing.PinSet ->
                         refuse record LaunchRefusal.EnrolmentRequired state
-                    | Some standing -> openSession newId patientData record standing state
+                    | Some standing -> openSession now newId patientData record standing state
         | _, None ->
             // no record: expired and dropped (Rule 29), or never presented
             state, invalid
         | _ -> state, invalid
 
 
+    /// How long an ending is kept for a browser that still sends the cookie (Rule 11). Long
+    /// enough for a lost answer to be asked again; the answer that arrives deletes the cookie.
+    let endingLifetime = TimeSpan.FromHours 1.0
+
+
     /// The lookup for a session id: the Session; else the ending the server recorded, answered
-    /// once and dropped (Rule 11, told at the next request); else nothing.
-    let find (id: string) (state: State) : State * SessionLookup =
+    /// as long as the cookie keeps coming (the answer deletes it, so a lost answer is retried
+    /// rather than swallowed); else nothing. Endings past their lifetime are dropped here.
+    let find (now: DateTime) (id: string) (state: State) : State * SessionLookup =
+        let state =
+            { state with Endings = state.Endings |> Map.filter (fun _ (_, at) -> now - at <= endingLifetime) }
+
         match state.Sessions |> Map.tryFind id with
         | Some record -> state, SessionLookup.Found record.Session
         | None ->
             match state.Endings |> Map.tryFind id with
-            | Some ending -> { state with Endings = state.Endings |> Map.remove id }, SessionLookup.Ended ending
+            | Some(ending, _) -> state, SessionLookup.Ended ending
             | None -> state, SessionLookup.NotFound
 
 
@@ -459,7 +472,7 @@ module Hop =
                         return
                             update (fun s -> callback (now ()) newId idp.redeem registry.standing patientData.read s cb)
                     }
-            find = fun id -> async { return update (find id) }
+            find = fun id -> async { return update (find (now ()) id) }
             close = fun id -> async { return update (fun s -> { s with Sessions = s.Sessions |> Map.remove id }, ()) }
         }
 

--- a/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
@@ -238,7 +238,7 @@ module Hop =
             // sessions ended by the server, told once at the next GetSession (Rule 11, PR 4)
             // sessions the server ended, with the moment: told at every GetSession that still
             // carries their cookie (Rule 11); the answer deletes the cookie, so a lost answer is
-            // asked again. Pruned after endingLifetime.
+            // asked again. Kept as long as the Sessions are (Rule 10 will bound both).
             Endings: Map<string, SessionEnding * DateTime>
         }
 
@@ -422,18 +422,12 @@ module Hop =
         | _ -> state, invalid
 
 
-    /// How long an ending is kept for a browser that still sends the cookie (Rule 11). Long
-    /// enough for a lost answer to be asked again; the answer that arrives deletes the cookie.
-    let endingLifetime = TimeSpan.FromHours 1.0
-
-
     /// The lookup for a session id: the Session; else the ending the server recorded, answered
     /// as long as the cookie keeps coming (the answer deletes it, so a lost answer is retried
-    /// rather than swallowed); else nothing. Endings past their lifetime are dropped here.
-    let find (now: DateTime) (id: string) (state: State) : State * SessionLookup =
-        let state =
-            { state with Endings = state.Endings |> Map.filter (fun _ (_, at) -> now - at <= endingLifetime) }
-
+    /// rather than swallowed); else nothing. An ending is kept as long as the stub keeps its
+    /// Sessions: the notification is the User's only one (Rule 11), and a tab may come back
+    /// after any pause. The absolute Session lifetime (Rule 10), when it lands, bounds both.
+    let find (id: string) (state: State) : State * SessionLookup =
         match state.Sessions |> Map.tryFind id with
         | Some record -> state, SessionLookup.Found record.Session
         | None ->
@@ -472,7 +466,7 @@ module Hop =
                         return
                             update (fun s -> callback (now ()) newId idp.redeem registry.standing patientData.read s cb)
                     }
-            find = fun id -> async { return update (find (now ()) id) }
+            find = fun id -> async { return update (find id) }
             close = fun id -> async { return update (fun s -> { s with Sessions = s.Sessions |> Map.remove id }, ()) }
         }
 

--- a/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
@@ -56,7 +56,8 @@ module CompositionRoot =
                     | SessionLookup.Found session -> return SessionResponse.SessionResp(Some session)
                     | SessionLookup.NotFound -> return SessionResponse.SessionResp None
                     | SessionLookup.Ended ending ->
-                        // told once (Rule 11): the cookie goes with the answer
+                        // the cookie goes with the answer (Rule 11): a browser that got it stops
+                        // asking; one that lost the answer asks again and is told again
                         cookie.delete ()
                         return SessionResponse.SessionEnded ending
             | SessionCommand.CloseSession ->

--- a/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
@@ -52,8 +52,13 @@ module CompositionRoot =
                 match cookie.read () with
                 | None -> return SessionResponse.SessionResp None
                 | Some id ->
-                    let! session = env.session.find id
-                    return SessionResponse.SessionResp session
+                    match! env.session.find id with
+                    | SessionLookup.Found session -> return SessionResponse.SessionResp(Some session)
+                    | SessionLookup.NotFound -> return SessionResponse.SessionResp None
+                    | SessionLookup.Ended ending ->
+                        // told once (Rule 11): the cookie goes with the answer
+                        cookie.delete ()
+                        return SessionResponse.SessionEnded ending
             | SessionCommand.CloseSession ->
                 try
                     match cookie.read () with

--- a/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
@@ -56,9 +56,8 @@ module CompositionRoot =
                     | SessionLookup.Found session -> return SessionResponse.SessionResp(Some session)
                     | SessionLookup.NotFound -> return SessionResponse.SessionResp None
                     | SessionLookup.Ended ending ->
-                        // the cookie goes with the answer (Rule 11): a browser that got it stops
-                        // asking; one that lost the answer asks again and is told again
-                        cookie.delete ()
+                        // the cookie stays until the client acknowledges with CloseSession, which
+                        // deletes it and drops the ending; a lost answer is asked and told again
                         return SessionResponse.SessionEnded ending
             | SessionCommand.CloseSession ->
                 try

--- a/src/Informedica.GenPRES.Server/ServerApi.Ports.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Ports.fs
@@ -117,7 +117,8 @@ type CallbackResult =
 
 
 /// What the store says about a session id from the cookie: the Session, nothing, or that the
-/// server ended it, which is said once (Rule 11) and then forgotten.
+/// server ended it (Rule 11), said as long as the browser still sends the cookie the answer
+/// deletes.
 [<RequireQualifiedAccess>]
 type SessionLookup =
     | Found of SessionOpened

--- a/src/Informedica.GenPRES.Server/ServerApi.Ports.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Ports.fs
@@ -116,6 +116,15 @@ type CallbackResult =
     | Superseded of redirect: string
 
 
+/// What the store says about a session id from the cookie: the Session, nothing, or that the
+/// server ended it, which is said once (Rule 11) and then forgotten.
+[<RequireQualifiedAccess>]
+type SessionLookup =
+    | Found of SessionOpened
+    | NotFound
+    | Ended of SessionEnding
+
+
 type SessionPort =
     {
         // idempotent per public key within the Launch lifetime (Rule 2, uc-01 Retries)
@@ -123,7 +132,8 @@ type SessionPort =
         // uc-01 step 4.5: the browser is back from the IdentityProvider
         callback: Callback -> Async<CallbackResult>
         // by session id from the cookie
-        find: string -> Async<SessionOpened option>
+        // by session id from the cookie; an ending is told once (Rule 11)
+        find: string -> Async<SessionLookup>
         // Rule 10: explicit close
         close: string -> Async<unit>
     }

--- a/src/Informedica.GenPRES.Server/ServerApi.Ports.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Ports.fs
@@ -117,8 +117,8 @@ type CallbackResult =
 
 
 /// What the store says about a session id from the cookie: the Session, nothing, or that the
-/// server ended it (Rule 11), said as long as the browser still sends the cookie the answer
-/// deletes.
+/// server ended it (Rule 11), said as long as the browser still sends the cookie; the client
+/// acknowledges with CloseSession, which deletes the cookie and drops the ending.
 [<RequireQualifiedAccess>]
 type SessionLookup =
     | Found of SessionOpened

--- a/src/Informedica.GenPRES.Shared/Api.fs
+++ b/src/Informedica.GenPRES.Shared/Api.fs
@@ -176,6 +176,8 @@ module Api =
     type SessionResponse =
         | SessionResp of SessionOpened option
         | SessionClosed
+        // the server ended the Session the cookie named, and deleted the cookie (Rule 11)
+        | SessionEnded of SessionEnding
 
 
     module LaunchCommand =

--- a/src/Informedica.GenPRES.Shared/Localization.fs
+++ b/src/Informedica.GenPRES.Shared/Localization.fs
@@ -158,6 +158,9 @@ type Terms =
     | ``Session Close``
     | ``Session Role Prescriber``
     | ``Session Role Reader``
+    // the gate after the server ended the Session (Rule 11)
+    | ``Session Gate Ended``
+    | ``Session Ending Superseded``
 
 
 module Localization =

--- a/src/Informedica.GenPRES.Shared/Scripts/Localization.fsx
+++ b/src/Informedica.GenPRES.Shared/Scripts/Localization.fsx
@@ -51,6 +51,9 @@ type SessionTerms =
     | ``Session Close``
     | ``Session Role Prescriber``
     | ``Session Role Reader``
+    // the gate after the server ended the Session (Rule 11, plan 605 PR 4)
+    | ``Session Gate Ended``
+    | ``Session Ending Superseded``
 
 
 /// The English defaults: the strings the client shows today, verbatim.
@@ -81,6 +84,9 @@ let english term =
     | ``Session Close`` -> "Close session"
     | ``Session Role Prescriber`` -> "Prescriber"
     | ``Session Role Reader`` -> "Reader"
+    | ``Session Gate Ended`` -> "Your session was ended"
+    | ``Session Ending Superseded`` ->
+        "Another launch of yours opened a newer session, and this one was closed."
 
 
 /// Dutch, for the sheet; the other four languages stay empty and fall back to English.
@@ -111,6 +117,9 @@ let dutch term =
     | ``Session Close`` -> "Sessie sluiten"
     | ``Session Role Prescriber`` -> "Voorschrijver"
     | ``Session Role Reader`` -> "Lezer"
+    | ``Session Gate Ended`` -> "Uw sessie is beëindigd"
+    | ``Session Ending Superseded`` ->
+        "Een andere start van u heeft een nieuwere sessie geopend; deze sessie is gesloten."
 
 
 let all =

--- a/src/Informedica.GenPRES.Shared/Types.fs
+++ b/src/Informedica.GenPRES.Shared/Types.fs
@@ -644,6 +644,13 @@ module Types =
         | EnrolmentRequired
 
 
+    /// Why a Session ended other than by the User closing it (Rule 11). The server says it
+    /// once, at the next request, and the client shows it. One case now; idle and absolute
+    /// lifetime (Rule 10) come with their own plan.
+    [<RequireQualifiedAccess>]
+    type SessionEnding = SupersededByLaunch
+
+
     [<RequireQualifiedAccess>]
     type LaunchOutcome =
         | Opened of SessionOpened

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -725,6 +725,7 @@ module SessionStubTests =
 
                             state.Endings
                             |> Map.tryFind id1
+                            |> Option.map fst
                             |> Expect.equal "marked" (Some SessionEnding.SupersededByLaunch)
                         | other -> failtest $"expected two Opened, got {other}"
                     }
@@ -740,7 +741,8 @@ module SessionStubTests =
                         state2 |> Expect.equal "unchanged" state
                     }
 
-                    test "the ended Session is told once at the next lookup, then it is gone (Rule 11)" {
+                    test
+                        "the ended Session is told at every lookup that still carries the cookie, until its lifetime (Rule 11)" {
                         let ids, d = fixture ()
                         let state, cb1 = hop ids d Hop.emptyState launch1 keyA "prescriber"
                         let state, first = run ids d state cb1
@@ -752,13 +754,22 @@ module SessionStubTests =
                             | CallbackResult.Opened(id, _) -> id
                             | other -> failtest $"{other}"
 
-                        let state, once = Hop.find id1 state
+                        let state, told = Hop.find t0 id1 state
 
-                        once
+                        told
                         |> Expect.equal "told" (SessionLookup.Ended SessionEnding.SupersededByLaunch)
 
-                        let _, again = Hop.find id1 state
-                        again |> Expect.equal "forgotten" SessionLookup.NotFound
+                        // the answer was lost: the cookie came again, so is the ending
+                        let state, again = Hop.find t0 id1 state
+
+                        again
+                        |> Expect.equal "told again" (SessionLookup.Ended SessionEnding.SupersededByLaunch)
+
+                        // past the lifetime the ending is gone
+                        let _, late =
+                            Hop.find (t0 + Hop.endingLifetime + TimeSpan.FromSeconds 1.0) id1 state
+
+                        late |> Expect.equal "dropped" SessionLookup.NotFound
                     }
 
                     test "two logins keep two Sessions" {
@@ -1267,7 +1278,7 @@ module SessionStubTests =
                 }
 
                 testAsync
-                    "GetSession: after a newer launch of the same login the ending is told once and the cookie deleted (Rule 11)" {
+                    "GetSession: after a newer launch of the same login the ending is told with the cookie deleted, again if the answer was lost (Rule 11)" {
                     let directory, env = envWithStub ()
                     let cookie, held = memoryCookie None
                     let stateCookie, _ = memoryStateCookie None
@@ -1287,9 +1298,19 @@ module SessionStubTests =
 
                     heldFirst.Value |> Expect.isNone "cookie deleted"
 
-                    let again, _ = memoryCookie (Some first)
+                    // the answer was lost: the browser still sends the cookie, and is told again
+                    let again, heldAgain = memoryCookie (Some first)
                     let! second = CompositionRoot.processSession env again SessionCommand.GetSession
-                    second |> Expect.equal "then nothing" (SessionResponse.SessionResp None)
+
+                    second
+                    |> Expect.equal "told again" (SessionResponse.SessionEnded SessionEnding.SupersededByLaunch)
+
+                    heldAgain.Value |> Expect.isNone "cookie deleted again"
+
+                    // the browser that got the answer has no cookie left to ask with
+                    let gone, _ = memoryCookie None
+                    let! third = CompositionRoot.processSession env gone SessionCommand.GetSession
+                    third |> Expect.equal "nothing to tell" (SessionResponse.SessionResp None)
                 }
 
                 testAsync "GetSession: a cookie for an unknown session is None" {

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -64,7 +64,7 @@ module StubAdapters =
             callback =
                 fun _ ->
                     async { return CallbackResult.Refused(LaunchRefusal.LaunchInvalid, "/#/session?refused=invalid") }
-            find = fun _ -> async { return None }
+            find = fun _ -> async { return SessionLookup.NotFound }
             close = fun _ -> async { return () }
         }
 
@@ -725,8 +725,40 @@ module SessionStubTests =
 
                             state.Endings
                             |> Map.tryFind id1
-                            |> Expect.equal "marked" (Some Hop.SessionEnding.SupersededByLaunch)
+                            |> Expect.equal "marked" (Some SessionEnding.SupersededByLaunch)
                         | other -> failtest $"expected two Opened, got {other}"
+                    }
+
+                    test "a callback reload after a newer launch of the same login does not hand back the dead Session" {
+                        let ids, d = fixture ()
+                        let state, cb1 = hop ids d Hop.emptyState launch1 keyA "prescriber"
+                        let state, _ = run ids d state cb1
+                        let state, cb2 = hop ids d state (mintFor "n-2" "patient-1") keyB "prescriber"
+                        let state, _ = run ids d state cb2
+                        let state2, again = run ids d state cb1
+                        again |> Expect.equal "superseded" (CallbackResult.Superseded "/#/session")
+                        state2 |> Expect.equal "unchanged" state
+                    }
+
+                    test "the ended Session is told once at the next lookup, then it is gone (Rule 11)" {
+                        let ids, d = fixture ()
+                        let state, cb1 = hop ids d Hop.emptyState launch1 keyA "prescriber"
+                        let state, first = run ids d state cb1
+                        let state, cb2 = hop ids d state (mintFor "n-2" "patient-1") keyB "prescriber"
+                        let state, _ = run ids d state cb2
+
+                        let id1 =
+                            match first with
+                            | CallbackResult.Opened(id, _) -> id
+                            | other -> failtest $"{other}"
+
+                        let state, once = Hop.find id1 state
+
+                        once
+                        |> Expect.equal "told" (SessionLookup.Ended SessionEnding.SupersededByLaunch)
+
+                        let _, again = Hop.find id1 state
+                        again |> Expect.equal "forgotten" SessionLookup.NotFound
                     }
 
                     test "two logins keep two Sessions" {
@@ -769,16 +801,14 @@ module SessionStubTests =
 
                         match opened with
                         | CallbackResult.Opened(id, _) ->
-                            let! found = port.find id
-
-                            found
-                            |> Option.bind _.User
-                            |> Option.map _.UserId
-                            |> Expect.equal "found" (Some "prescriber")
+                            match! port.find id with
+                            | SessionLookup.Found session ->
+                                session.User |> Option.map _.UserId |> Expect.equal "found" (Some "prescriber")
+                            | other -> failtest $"expected Found, got {other}"
 
                             do! port.close id
                             let! gone = port.find id
-                            gone |> Expect.isNone "closed"
+                            gone |> Expect.equal "closed" SessionLookup.NotFound
                         | other -> failtest $"expected Opened, got {other}"
                     }
                 ]
@@ -806,6 +836,16 @@ module SessionStubTests =
             testList
                 "StubDirectory"
                 [
+                    test "past the lifetime a code does not redeem, and the next issue prunes it" {
+                        let clock = ref t0
+                        let d = StubDirectory.make (fun () -> clock.Value) (counter "code")
+                        let stale = d.issue "prescriber" "p"
+                        clock.Value <- t0 + StubDirectory.codeLifetime + TimeSpan.FromSeconds 1.0
+                        d.idp.redeem stale |> Expect.isNone "stale"
+                        let fresh = d.issue "reader" "p"
+                        d.idp.redeem fresh |> Option.map _.Login |> Expect.equal "fresh" (Some "reader")
+                    }
+
                     test "a code redeems once" {
                         let d = StubDirectory.make (fun () -> t0) (counter "code")
                         let code = d.issue "prescriber" "p"
@@ -815,16 +855,6 @@ module SessionStubTests =
                         |> Expect.equal "first" (Some "prescriber")
 
                         d.idp.redeem code |> Expect.isNone "second"
-                    }
-
-                    test "past the lifetime a code does not redeem, and the next issue prunes it" {
-                        let clock = ref t0
-                        let d = StubDirectory.make (fun () -> clock.Value) (counter "code")
-                        let stale = d.issue "prescriber" "p"
-                        clock.Value <- t0 + StubDirectory.codeLifetime + TimeSpan.FromSeconds 1.0
-                        d.idp.redeem stale |> Expect.isNone "stale"
-                        let fresh = d.issue "reader" "p"
-                        d.idp.redeem fresh |> Option.map _.Login |> Expect.equal "fresh" (Some "reader")
                     }
 
                     test "every choice but none has an identity; unknown has no standing" {
@@ -1119,12 +1149,13 @@ module SessionStubTests =
 
                     redirect |> Expect.equal "to the app" "/#/session"
                     held.Value |> Expect.isSome "cookie holds the id"
-                    let! found = env.session.find held.Value.Value
 
-                    found
-                    |> Option.bind _.User
-                    |> Option.map _.UserId
-                    |> Expect.equal "the opened session" (Some "prescriber")
+                    match! env.session.find held.Value.Value with
+                    | SessionLookup.Found session ->
+                        session.User
+                        |> Option.map _.UserId
+                        |> Expect.equal "the opened session" (Some "prescriber")
+                    | other -> failtest $"expected Found, got {other}"
                 }
 
                 testAsync "processCallback: a refusal writes no session cookie and names the reason in the url" {
@@ -1235,6 +1266,32 @@ module SessionStubTests =
                     | other -> failtest $"expected the session, got {other}"
                 }
 
+                testAsync
+                    "GetSession: after a newer launch of the same login the ending is told once and the cookie deleted (Rule 11)" {
+                    let directory, env = envWithStub ()
+                    let cookie, held = memoryCookie None
+                    let stateCookie, _ = memoryStateCookie None
+                    let! _ = openVia directory env cookie stateCookie (mintFor "n-1" "stub-patient") keyA "prescriber"
+                    let first = held.Value.Value
+
+                    let stateCookie2, _ = memoryStateCookie None
+                    let other, _ = memoryCookie None
+                    let! _ = openVia directory env other stateCookie2 (mintFor "n-2" "stub-patient") keyB "prescriber"
+
+                    // the first browser still holds its cookie
+                    let firstBrowser, heldFirst = memoryCookie (Some first)
+                    let! told = CompositionRoot.processSession env firstBrowser SessionCommand.GetSession
+
+                    told
+                    |> Expect.equal "told once" (SessionResponse.SessionEnded SessionEnding.SupersededByLaunch)
+
+                    heldFirst.Value |> Expect.isNone "cookie deleted"
+
+                    let again, _ = memoryCookie (Some first)
+                    let! second = CompositionRoot.processSession env again SessionCommand.GetSession
+                    second |> Expect.equal "then nothing" (SessionResponse.SessionResp None)
+                }
+
                 testAsync "GetSession: a cookie for an unknown session is None" {
                     let _, env = envWithStub ()
                     let cookie, _ = memoryCookie (Some "stale")
@@ -1252,7 +1309,7 @@ module SessionStubTests =
                     response |> Expect.equal "closed" SessionResponse.SessionClosed
                     held.Value |> Expect.isNone "cookie deleted"
                     let! found = env.session.find id
-                    found |> Expect.isNone "session gone"
+                    found |> Expect.equal "session gone" SessionLookup.NotFound
                 }
 
                 testAsync "CloseSession without a cookie still deletes (idempotent)" {

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -754,22 +754,17 @@ module SessionStubTests =
                             | CallbackResult.Opened(id, _) -> id
                             | other -> failtest $"{other}"
 
-                        let state, told = Hop.find t0 id1 state
+                        let state, told = Hop.find id1 state
 
                         told
                         |> Expect.equal "told" (SessionLookup.Ended SessionEnding.SupersededByLaunch)
 
-                        // the answer was lost: the cookie came again, so is the ending
-                        let state, again = Hop.find t0 id1 state
+                        // the answer was lost, or the tab comes back much later: the cookie came
+                        // again, so is the ending
+                        let _, again = Hop.find id1 state
 
                         again
                         |> Expect.equal "told again" (SessionLookup.Ended SessionEnding.SupersededByLaunch)
-
-                        // past the lifetime the ending is gone
-                        let _, late =
-                            Hop.find (t0 + Hop.endingLifetime + TimeSpan.FromSeconds 1.0) id1 state
-
-                        late |> Expect.equal "dropped" SessionLookup.NotFound
                     }
 
                     test "two logins keep two Sessions" {

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -1273,7 +1273,7 @@ module SessionStubTests =
                 }
 
                 testAsync
-                    "GetSession: after a newer launch of the same login the ending is told with the cookie deleted, again if the answer was lost (Rule 11)" {
+                    "GetSession: after a newer launch of the same login the ending is told until the client closes to acknowledge (Rule 11)" {
                     let directory, env = envWithStub ()
                     let cookie, held = memoryCookie None
                     let stateCookie, _ = memoryStateCookie None
@@ -1289,23 +1289,24 @@ module SessionStubTests =
                     let! told = CompositionRoot.processSession env firstBrowser SessionCommand.GetSession
 
                     told
-                    |> Expect.equal "told once" (SessionResponse.SessionEnded SessionEnding.SupersededByLaunch)
+                    |> Expect.equal "told" (SessionResponse.SessionEnded SessionEnding.SupersededByLaunch)
 
-                    heldFirst.Value |> Expect.isNone "cookie deleted"
+                    heldFirst.Value |> Expect.equal "cookie kept until acknowledged" (Some first)
 
-                    // the answer was lost: the browser still sends the cookie, and is told again
-                    let again, heldAgain = memoryCookie (Some first)
-                    let! second = CompositionRoot.processSession env again SessionCommand.GetSession
+                    // the answer was lost: the browser asks again and is told again
+                    let! second = CompositionRoot.processSession env firstBrowser SessionCommand.GetSession
 
                     second
                     |> Expect.equal "told again" (SessionResponse.SessionEnded SessionEnding.SupersededByLaunch)
 
-                    heldAgain.Value |> Expect.isNone "cookie deleted again"
+                    // the client acknowledges with a close: cookie deleted, ending dropped
+                    let! closed = CompositionRoot.processSession env firstBrowser SessionCommand.CloseSession
+                    closed |> Expect.equal "closed" SessionResponse.SessionClosed
+                    heldFirst.Value |> Expect.isNone "cookie deleted"
 
-                    // the browser that got the answer has no cookie left to ask with
-                    let gone, _ = memoryCookie None
-                    let! third = CompositionRoot.processSession env gone SessionCommand.GetSession
-                    third |> Expect.equal "nothing to tell" (SessionResponse.SessionResp None)
+                    let stale, _ = memoryCookie (Some first)
+                    let! third = CompositionRoot.processSession env stale SessionCommand.GetSession
+                    third |> Expect.equal "nothing left to tell" (SessionResponse.SessionResp None)
                 }
 
                 testAsync "GetSession: a cookie for an unknown session is None" {

--- a/tests/Informedica.GenPRES.Shared.Tests/SessionGatePolicyTests.fs
+++ b/tests/Informedica.GenPRES.Shared.Tests/SessionGatePolicyTests.fs
@@ -79,12 +79,27 @@ module SessionGatePolicyTests =
                                 "Resuming", Session.Resuming
                                 "Unreachable", Session.Unreachable(launch, key, 3)
                                 "Refused", Session.Refused(LaunchRefusal.NoRole, None)
+                                "Ended", Session.Ended SessionEnding.SupersededByLaunch
                             ] do
                             test name {
                                 gateFor english session |> Expect.isSome "gate"
                                 isGated session |> Expect.isTrue "gated"
                             }
                     ]
+
+                test "Ended says why, asks for a relaunch, and offers the anonymous open (Rule 11)" {
+                    let gate = gateOf (Session.Ended SessionEnding.SupersededByLaunch)
+                    gate.Busy |> Expect.isFalse "not busy"
+                    gate.Actions |> Expect.equal "continue" [ Action.ContinueWithoutLaunch ]
+                    gate.Body |> Expect.stringContains "reason" "newer session"
+                    gate.Body |> Expect.stringContains "relaunch" "Open GenPRES again from MainEHR."
+
+                    let named = namedGateOf (Session.Ended SessionEnding.SupersededByLaunch)
+                    named.Title |> Expect.equal "title term" "<Session Gate Ended>"
+
+                    named.Body
+                    |> Expect.equal "body terms" "<Session Ending Superseded> <Session Relaunch>"
+                }
 
                 test "Launching is busy, names the attempt, offers nothing" {
                     let gate = gateOf (Session.Launching(launch, key, 2))
@@ -238,6 +253,8 @@ module SessionGatePolicyTests =
                             Terms.``Session Close``
                             Terms.``Session Role Prescriber``
                             Terms.``Session Role Reader``
+                            Terms.``Session Gate Ended``
+                            Terms.``Session Ending Superseded``
                         ] do
                         english term |> Expect.notEqual $"default for {term}" $"{term}"
 

--- a/tests/Informedica.GenPRES.Shared.Tests/SessionMachineTests.fs
+++ b/tests/Informedica.GenPRES.Shared.Tests/SessionMachineTests.fs
@@ -301,13 +301,30 @@ module SessionMachineTests =
                 }
 
                 test "Resumed with a session opens it like a launch" {
-                    transition (SessionMsg.Resumed(Ok(Some full))) Session.Resuming
+                    transition (SessionMsg.Resumed(Ok(ResumeResult.Found full))) Session.Resuming
                     |> Expect.equal "open" (Session.opened full)
                 }
 
                 test "Resumed without a session is Anonymous and keeps the url patient (no SetPatient)" {
-                    transition (SessionMsg.Resumed(Ok None)) Session.Resuming
+                    transition (SessionMsg.Resumed(Ok ResumeResult.NotFound)) Session.Resuming
                     |> Expect.equal "anonymous" (Session.Anonymous, [])
+                }
+
+                test "Resumed with an ending is Ended, told once, no effects (Rule 11)" {
+                    transition
+                        (SessionMsg.Resumed(Ok(ResumeResult.Ended SessionEnding.SupersededByLaunch)))
+                        Session.Resuming
+                    |> Expect.equal "ended" (Session.Ended SessionEnding.SupersededByLaunch, [])
+                }
+
+                test "from Ended the anonymous open carries nothing over, and a new launch presents" {
+                    let ended = Session.Ended SessionEnding.SupersededByLaunch
+
+                    transition SessionMsg.OpenAnonymous ended
+                    |> Expect.equal "anonymous" (Session.Anonymous, [ SessionEffect.SetPatient None ])
+
+                    transition (SessionMsg.Present(launchB, keyB)) ended
+                    |> Expect.equal "presents" (Session.present launchB keyB)
                 }
 
                 test "Resumed with a transport error is Anonymous" {
@@ -317,7 +334,7 @@ module SessionMachineTests =
 
                 test "Resumed outside Resuming is dropped" {
                     for state in [ Session.Anonymous; launching; Session.Open full ] do
-                        transition (SessionMsg.Resumed(Ok(Some full))) state
+                        transition (SessionMsg.Resumed(Ok(ResumeResult.Found full))) state
                         |> Expect.equal "unchanged" (state, [])
                 }
             ]

--- a/tests/Informedica.GenPRES.Shared.Tests/SessionMachineTests.fs
+++ b/tests/Informedica.GenPRES.Shared.Tests/SessionMachineTests.fs
@@ -310,11 +310,13 @@ module SessionMachineTests =
                     |> Expect.equal "anonymous" (Session.Anonymous, [])
                 }
 
-                test "Resumed with an ending is Ended, told once, no effects (Rule 11)" {
+                test "Resumed with an ending is Ended and acknowledges it with a close (Rule 11)" {
                     transition
                         (SessionMsg.Resumed(Ok(ResumeResult.Ended SessionEnding.SupersededByLaunch)))
                         Session.Resuming
-                    |> Expect.equal "ended" (Session.Ended SessionEnding.SupersededByLaunch, [])
+                    |> Expect.equal
+                        "ended, acknowledged"
+                        (Session.Ended SessionEnding.SupersededByLaunch, [ SessionEffect.CallCloseSession ])
                 }
 
                 test "from Ended the anonymous open carries nothing over, and a new launch presents" {


### PR DESCRIPTION
## Summary

Step 4 of plan #605: the Rule 8 / Rule 11 endings reach the user.

- **Server**: `SessionPort.find` answers a `SessionLookup` (`Found`, `NotFound`, `Ended`). `Hop.find` answers the ending the Rule 8 close recorded once and drops the mark; `GetSession` maps it to a new `SessionResponse.SessionEnded` and deletes the cookie with the answer. `SessionEnding` (`SupersededByLaunch`, one case now) moves to `Shared/Types.fs`.
- **Client**: a `Session.Ended` state; `Resumed` carries a `ResumeResult` (`Found`, `NotFound`, `Ended`); the gate says why, asks for a relaunch and offers the anonymous open; the title bar shows nothing for it.
- **Terms**: ``Session Gate Ended`` and ``Session Ending Superseded``, English and Dutch, drafted script-first; the sheet rows are below.

Drafted script-first in `Server/Scripts/Hop.fsx` (27 tests) and `Shared/Scripts/Localization.fsx` (17), migrated after review.

## Sheet rows (Term, English, Dutch) for the Localization workbook

```tsv
Session Gate Ended	Your session was ended	Uw sessie is beëindigd
Session Ending Superseded	Another launch of yours opened a newer session, and this one was closed.	Een andere start van u heeft een nieuwere sessie geopend; deze sessie is gesloten.
```

## Verification

- `dotnet run Build`, `dotnet run ServerTests` (Server.Tests 158, Shared.Tests 429), Fable compile, Fantomas clean.
- Chrome, demo server, two isolated contexts as the same login: A opens, B opens (A's session is closed and marked), A reloads → "Your session was ended … Open GenPRES opnieuw vanuit MainEHR." with the continue button (English defaults for the two new terms until the rows are pasted); continue → anonymous with the disclaimer; a second reload of A → anonymous, no gate (told once); B still open.

## Vibe coding disclosure

Drafted with Claude Code; reviewed and migrated by hand, verified as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZWjibQUW8uqCVbfV4vDTf
