### PR TITLE
docs: describe the stubbed launch as built

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -59,6 +59,86 @@ dotnet run
 
 Open your browser to `http://localhost:5173`
 
+### Simulating the launch sequence
+
+In production a User reaches GenPRES from MainEHR: the LaunchScript opens the browser on a
+sealed Launch, the browser is signed on at the IdentityProvider, and the server opens a Session
+for the launched patient (steps 1 to 6 of [uc-01](docs/scenarios/integration/uc-01-launch.md)).
+In demo mode the server hosts stand-ins for every party outside GenPRES, so the whole sequence
+runs on one machine with nothing to install
+([plan 605](docs/implementation-plans/605-launch-with-server-stubs.md)). The stand-ins are
+mounted only when `GENPRES_PROD=0`; a production server answers 404 on their routes and refuses
+every launch as invalid until the scope switch
+([#580](https://github.com/informedica/GenPRES/issues/580)) decides what production exposes.
+
+#### Walkthrough
+
+1. Start the application with `GENPRES_PROD=0` (the `.env.example` default): `dotnet run`.
+2. Open `http://localhost:5173/stub/launch`. This is the stub LaunchScript page, served by the
+   server on port 8085 and reached through the Vite proxy. It has two fields:
+   - **PatientId**, default `stub-patient`. Any text works; `no-data` stands for a patient the
+     PatientDataPlatform has no record for (ext 6a).
+   - **Identity at the browser**: who the stub IdentityProvider will say is signed on. The
+     table below lists the choices.
+3. Press **Launch**. The server mints a Launch sealed under a key it made at start-up, valid for
+   two minutes, and redirects to `#/session?launch=<token>`. The client erases the token from
+   the address bar and history, generates a key pair, and presents the Launch.
+4. The server answers with a redirect to `/authorize` (the stub IdentityProvider), which sends
+   the browser straight back to `/callback` with a one-time code. The server redeems the code,
+   asks the stub UserRegistry for the role and the active patient, reads the patient data, and
+   opens the Session in one act.
+5. The browser lands on `#/session`. With `prescriber` the title bar shows a person button with
+   **Stub Prescriber** and the role; the session menu offers **Close session**.
+
+What each identity choice ends in:
+
+| Identity | Stands for | Ends in | uc-01 |
+|---|---|---|---|
+| `prescriber` | a Prescriber whose active patient is the launched one | an open Session as Prescriber | main path |
+| `reader` | a Reader; no PIN needed | an open Session as Reader | ext 5c |
+| `prescriber-other-patient` | a Prescriber with another patient active in MainEHR | the gate: wrong patient, relaunch | ext 5b |
+| `no-pin` | a Prescriber without a PIN | the gate: enrolment needed (UC-2 is not built; a relaunch is offered) | ext 5d |
+| `unknown` | a login the UserRegistry does not know | the gate: no role, with "continue without launch" | ext 5a |
+| `none` | nobody signed on at the browser | the gate: no browser identity, relaunch only | ext 3c |
+
+A refusal arrives as `#/session?refused=<word>` with the words `expired`, `spent`, `invalid`,
+`no-identity`, `no-role`, `wrong-patient` and `enrolment`; the client erases the parameter and
+shows the gate for it.
+
+#### Things worth trying
+
+- **Reload after the launch**: the Session resumes from the `genpres_session` cookie.
+- **Replay the Launch**: copy the `#/session?launch=…` URL from the Network tab (it never stays
+  in the address bar) and open it in another browser profile or an incognito window within two
+  minutes: `spent`. After two minutes: `expired`. A token from an earlier server run: `invalid`,
+  the key is new at every start.
+- **Reload the callback**: reload `/callback?code=…&state=…` from the Network tab within two
+  minutes: the same answer as the first time (Rule 45), no second Session.
+- **Two launches of the same user**: launch as `prescriber` in tab A, then again in tab B. B is
+  open; A's next request is told that a newer launch ended its Session and offers to continue
+  without a launch (Rules 8 and 11). Once A acknowledged, the notice is gone.
+- **Watch the wire**: in the Network tab, the `PresentLaunch` call answers `RedirectTo`, then
+  two 302s (`/authorize`, `/callback`), then `GetSession`. The Launch appears in none of the
+  responses after the first request.
+- **Production**: `GENPRES_PROD=1 GENPRES_PASSWORD=<16+ chars> dotnet run`; `/stub/launch`
+  and `/authorize` are 404, `/callback` redirects to `refused=invalid`.
+
+The stand-ins keep everything in memory: launches by nonce, sessions, endings, one-time codes.
+A restart forgets all of it and the browser's session cookie no longer finds a Session.
+
+#### Cookies and the development proxy
+
+| Cookie | Set by | Attributes | Purpose |
+|---|---|---|---|
+| `genpres_session` | the callback, on an open | HttpOnly, Strict, `Path=/`, Secure over HTTPS | names the Session (Rule 12) |
+| `genpres_launch_state.<state>` | the answer to `PresentLaunch` | HttpOnly, Lax, `Path=/callback`, `Max-Age` 2 min | proves the callback comes from the browser that started the hop; one per hop so two tabs can launch at once |
+| `genpres_stub_identity` | the stub launch page | HttpOnly, Lax, `Path=/`, `Max-Age` 2 min | carries the identity choice and the PatientId to the stub IdentityProvider; demo only |
+
+`vite.config.js` proxies `/api`, `/stub`, `/authorize` and `/callback` to the server on port
+8085, so in development the browser talks to one origin (`localhost:5173`) and the cookies,
+which are host-only and port-agnostic, reach both. In production the server serves the client
+itself and no proxy is involved.
+
 ## Build System Architecture
 
 ### How `dotnet run` Interacts with FAKE

--- a/docs/implementation-plans/409-client-launch-sequence.md
+++ b/docs/implementation-plans/409-client-launch-sequence.md
@@ -467,10 +467,12 @@ are listed per step with the reason.
 
 ### Still open
 
-- The identity hop (`RedirectTo`, the callback, the `state` cookie): the client handles the payload
-  and the `refused` return; the server stub never redirects.
 - Step 7, the signed request (`Keys.sign`, the DPoP proof, the OpenedToken inside it).
-- Session endings and the Rule 11 notice; UC-2 enrolment; WorkPlan carry-over (#518); decision D1.
+- UC-2 enrolment; WorkPlan carry-over (#518); decision D1 (#599).
 - The scope switch (#580), which retires the `IsProd` stop-gap.
-- On a launch URL the language ends up English (`UrlChanged` defaults to English without `la=`)
-  and the gate hides the language switcher; the gate itself is localised (#600).
+- On a launch URL the gate hides the language switcher; the language itself follows the
+  server default since #601.
+
+Closed since this list was written: the identity hop (`RedirectTo`, the callback, the `state`
+cookie), the Rule 8 and 11 endings, and the sealed Launch, all against server-hosted stubs
+([plan 605](605-launch-with-server-stubs.md)).

--- a/docs/implementation-plans/605-launch-with-server-stubs.md
+++ b/docs/implementation-plans/605-launch-with-server-stubs.md
@@ -173,3 +173,44 @@ the client, migration by the maintainer after review.
 - With `GENPRES_PROD=1` and a valid password: `/stub/launch` and `/authorize` are 404 and
   `/callback` refuses `invalid`.
 - `dotnet run ServerTests`, the Fable compile and Fantomas stay green after every step.
+
+## As built
+
+Every step landed as one PR from a fork branch against `master`, script-first for the server
+and Shared code (`Server/Scripts/Launch.fsx`, `Server/Scripts/Hop.fsx`,
+`Shared/Scripts/Localization.fsx`), reviewed and migrated by the maintainer, client edits
+direct. The plan's shape held; the deviations are listed below.
+
+| Step | PR | Landed |
+|------|----|--------|
+| plan | [#606](https://github.com/informedica/GenPRES/pull/606) | this document; review added the `state` on the stub IdP's error redirect, the PIN check for Prescribers only, and the open on `read = None` |
+| 1 | [#607](https://github.com/informedica/GenPRES/pull/607) | `LaunchSeal`, the `/stub/launch` page, `SessionStub.present` over the seal, the Vite proxy for `/stub` |
+| 2 | [#609](https://github.com/informedica/GenPRES/pull/609) | the ports, `Hop` with `LaunchRecord` by nonce, `present` answering `RedirectTo`, the `callback` ladder, the stub directory and patient data; also the `/authorize` and `/callback` routes and both cookies, so `master` kept launching |
+| 3 | [#610](https://github.com/informedica/GenPRES/pull/610) | the identity select and the `no-data` hint on the stub page, `HttpTests` for the state cookie, the client's `invalid` word |
+| 4 | [#612](https://github.com/informedica/GenPRES/pull/612) | `SessionLookup`, `SessionResponse.SessionEnded`, `Session.Ended` and `ResumeResult` on the client, the gate text, two `Terms` with sheet rows |
+| 5 | this PR | uc-01 as-built note, plan 409 "Still open", `DEVELOPMENT.md` walkthrough, this table |
+
+### Deviations from the text above
+
+- **Routes in step 2, not 3.** `/authorize`, `/callback` and the two cookies went in with the
+  hop core: without them `master` would have presented a Launch that redirects nowhere. Step 3
+  became the page's identity select, the cookie tests and the client word.
+- **One state cookie per hop.** `genpres_launch_state.<state>` instead of one
+  `genpres_launch_state`, read by state, so two tabs launching at once keep both proofs
+  (ext 8b). `LaunchStateCookie.read` takes the state.
+- **`CallbackResult.Superseded`.** A callback replay whose recorded Session has since been
+  closed by a newer launch is answered with the plain redirect to `#/session`, cookie untouched;
+  the next `GetSession` tells the ending. Neither "open again" nor a refusal fit.
+- **Endings are acknowledged, not told once.** `GetSession` answers `SessionEnded` at every call
+  while the mark stands and does not delete the cookie; the client answers with the existing
+  `CloseSession`, whose `Hop.close` drops the Session and the mark and deletes the cookie. A lost
+  answer is repeated; an acknowledged one is not. The marks are not time-bound: they live as
+  long as the stub's sessions, and Rule 10's absolute lifetime will bound both.
+- **One-time codes are pruned.** The stub directory stamps each code and drops it after the
+  Launch lifetime, so a demo server does not grow with every launch.
+- **`SessionLookup`.** `find` answers `Found | NotFound | Ended`, a value, instead of an option
+  plus a second lookup.
+- **Two `Terms`, not three.** ``Session Gate Ended`` and ``Session Ending Superseded``; the
+  "continue without launch" action reuses its existing term.
+- **`makeAppEnvWith`.** The host passes its launch key and directory in; `makeAppEnv` keeps its
+  old signature with a key and directory of its own, so the other server tests were untouched.

--- a/docs/scenarios/integration/uc-01-launch.md
+++ b/docs/scenarios/integration/uc-01-launch.md
@@ -262,6 +262,43 @@ different race from two presentations of the *same* Launch: there the spend insi
 (5.7) settles it and exactly one Session opens; here two Launches contend for the per-User
 limit.
 
+## As built against stubs
+
+Steps 1 to 6 run end to end in the demo server since
+[plan 605](../../implementation-plans/605-launch-with-server-stubs.md): every message above is
+exchanged over HTTP as it will be with MainEHR and the IdentityProvider, and only the parties
+outside GenPRES are stand-ins, mounted when `GENPRES_PROD=0`. The walkthrough is in
+[DEVELOPMENT.md](../../../DEVELOPMENT.md#simulating-the-launch-sequence).
+
+| Party | Stand-in | What it does |
+|-------|----------|--------------|
+| MainEHR LaunchScript (step 1) | the `/stub/launch` page | mints a Launch sealed under a key made at server start, two minutes, and opens the browser on `#/session?launch=…`; the identity choice made on the page travels in a cookie to the stub IdentityProvider |
+| IdentityProvider (4.3, 4.4) | `/authorize` and an in-memory code store | issues a one-time code for the chosen identity, or reports `no-identity`; the code is redeemed on the server's side of the callback and pruned after the Launch lifetime |
+| UserRegistry (5.3, 5.4) | the stub directory | answers Role, active Patient and PIN state per identity choice: `prescriber`, `reader`, `prescriber-other-patient`, `no-pin`, `unknown` |
+| PatientDataPlatform (5.5) | the stub patient data | answers an empty patient for every PatientId, none for `no-data` |
+| GenPRES Database | one in-memory state per server start | LaunchRecords by nonce, SessionRecords, endings; every transition is a pure function over it, run under one lock, so 5.2 and 5.7 cannot interleave |
+
+Where the code departs from the text above, on purpose:
+
+- **One state cookie per hop.** The cookie of 4.2 is named `genpres_launch_state.<state>`, not
+  a single `state` cookie, so that two tabs launching at once (ext 8b) do not overwrite each
+  other's proof.
+- **A replay whose Session is gone.** A reloaded callback within the lifetime is answered as
+  the first time (4.5, Rule 45). When the Session it opened has since been superseded, the
+  answer is the same redirect to `#/session`, and the next `GetSession` tells the ending.
+- **The ending is acknowledged, not told once.** A Client whose Session ended is told at every
+  `GetSession` until it acknowledges with `CloseSession`, which drops the mark; a notice lost in
+  transit is repeated instead of lost. [session-endings.md](session-endings.md) stands: nothing
+  is discharged by the telling.
+- **A Reader needs no PIN.** 5.4 binds Prescribers only (Rule 25, ext 5c).
+- **No patient data is not a refusal.** When 5.5 finds nothing, the Session opens with the
+  Launch's PatientId and an empty patient (ext 6a); a data outage does not block prescribing.
+- **The key pair's thumbprint** is stored in the SessionRecord at 5.7, ready for step 7.
+
+Not built: step 7 (the signed request and the OpenedToken check), the PIN detour (UC-2; a
+Prescriber without a PIN is refused with `enrolment`), the audit (Rule 46), the newest
+TreatmentPlan of 5.6, and the absolute lifetime and idle endings of Rule 10.
+
 ## Left out
 
 - **The PIN detour.** A Prescriber with no PIN is not refused: the launch suspends into UC-2

--- a/docs/scenarios/integration/uc-01-launch.md
+++ b/docs/scenarios/integration/uc-01-launch.md
@@ -265,9 +265,13 @@ limit.
 ## As built against stubs
 
 Steps 1 to 6 run end to end in the demo server since
-[plan 605](../../implementation-plans/605-launch-with-server-stubs.md): every message above is
-exchanged over HTTP as it will be with MainEHR and the IdentityProvider, and only the parties
-outside GenPRES are stand-ins, mounted when `GENPRES_PROD=0`. The walkthrough is in
+[plan 605](../../implementation-plans/605-launch-with-server-stubs.md). What crosses the
+browser goes over HTTP as it will with MainEHR and the IdentityProvider: the Launch of step 1,
+the presentation of 4.1, the redirects of 4.2 and 4.3, the callback of 4.4 and the answer of
+4.5 and 6, with the cookies each sets. What the Server does on its own side (redeeming the code
+in 4.4, the UserRegistry and PatientDataPlatform reads of step 5, the Database) is an in-process
+call through a port, answered by a stand-in mounted when `GENPRES_PROD=0`; the real adapters
+will make those calls over the back channel without the port changing shape. The walkthrough is in
 [DEVELOPMENT.md](../../../DEVELOPMENT.md#simulating-the-launch-sequence).
 
 | Party | Stand-in | What it does |
@@ -301,8 +305,9 @@ TreatmentPlan of 5.6, and the absolute lifetime and idle endings of Rule 10.
 
 ## Left out
 
-- **The PIN detour.** A Prescriber with no PIN is not refused: the launch suspends into UC-2
-  and continues at 5.5 once the PIN is set.
+- **The PIN detour.** By design a Prescriber with no PIN is not refused: the launch suspends
+  into UC-2 and continues at 5.5 once the PIN is set. Until UC-2 is built, the code refuses
+  with `enrolment` and the Client asks for a relaunch (see [As built](#as-built-against-stubs)).
 - **The audit.** Every launch, honored or refused, is appended to the audit (Rule 46).
 - **Everything after the launch**: prescribing and signing, and the ten other use cases.
 - **The confirmation code.** UC-2 and UC-6 mail a code to set or replace a PIN. It is not the


### PR DESCRIPTION
## Summary

Plan [605](https://github.com/informedica/GenPRES/issues/605) step 5, documentation only.

- **uc-01** gets an "As built against stubs" section: a table of what each stand-in replaces (LaunchScript, IdentityProvider, UserRegistry, PatientDataPlatform, Database) and the deliberate departures from the page (state cookie per hop, `Superseded` replay, acknowledged endings, Reader without PIN, no data opens, thumbprint stored), plus what is not built.
- **Plan 409** "Still open" drops the identity hop, the endings and the sealed Launch.
- **Plan 605** gets its as-built table (#606, #607, #609, #610, #612, this PR) and the deviations.
- **DEVELOPMENT.md** gains "Simulating the launch sequence": a walkthrough of the demo launch from `/stub/launch`, a table of what each identity choice ends in, things worth trying (replay, callback reload, two tabs, production 404), and the three cookies with the development proxy.

## Checks

- `markdownlint-cli2` on the four files: no new findings (the remaining ones in DEVELOPMENT.md are pre-existing trailing spaces in the ShipIt and helper-script sections).
- Every behaviour described was exercised in Chrome while PRs 1 to 4 landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZWjibQUW8uqCVbfV4vDTf
