### PR TITLE
feat(server): suspend the launch at the PIN question and take the PIN

### DIFF
--- a/src/Informedica.GenPRES.Client/App.fs
+++ b/src/Informedica.GenPRES.Client/App.fs
@@ -613,6 +613,11 @@ module private Elmish =
                         return SessionMsg(SessionMsg.Resumed(Ok ResumeResult.NotFound))
                     | Api.SessionResponse.SessionEnded ending ->
                         return SessionMsg(SessionMsg.Resumed(Ok(ResumeResult.Ended ending)))
+                    | Api.SessionResponse.EnrolmentPending pending ->
+                        return SessionMsg(SessionMsg.Resumed(Ok(ResumeResult.Enrolling pending)))
+                    // never an answer to GetSession
+                    | Api.SessionResponse.PinRefused _ ->
+                        return SessionMsg(SessionMsg.Resumed(Ok ResumeResult.NotFound))
                 with ex ->
                     return SessionMsg(SessionMsg.Resumed(Error ex.Message))
             }

--- a/src/Informedica.GenPRES.Client/Components/TitleBar.fs
+++ b/src/Informedica.GenPRES.Client/Components/TitleBar.fs
@@ -252,7 +252,8 @@ module TitleBar =
             | Session.Resuming
             | Session.Refused _
             | Session.Unreachable _
-            | Session.Ended _ -> None
+            | Session.Ended _
+            | Session.Enrolling _ -> None
             |> Option.defaultValue null
 
         JSX.jsx

--- a/src/Informedica.GenPRES.Client/SessionGatePolicy.fs
+++ b/src/Informedica.GenPRES.Client/SessionGatePolicy.fs
@@ -110,7 +110,8 @@ let isGated (session: Session) =
     | Session.Resuming
     | Session.Unreachable _
     | Session.Refused _
-    | Session.Ended _ -> true
+    | Session.Ended _
+    | Session.Enrolling _ -> true
 
 
 /// The gate for a session phase, or None when the app is usable (anonymous, open, closing).
@@ -182,6 +183,16 @@ let gateFor (tr: Terms -> string) (session: Session) : Gate option =
                         ]
                 Busy = false
                 Actions = [ Action.ContinueWithoutLaunch ]
+            }
+    // UC-2, until the form lands (plan 615, step 3): the launch waits on a PIN and the gate
+    // says what the refusal said, a relaunch
+    | Session.Enrolling _ ->
+        Some
+            {
+                Title = tr Terms.``Session Gate Refused``
+                Body = sentences [ tr Terms.``Session Refusal Enrolment`` ]
+                Busy = false
+                Actions = []
             }
     | Session.Anonymous
     | Session.Open _

--- a/src/Informedica.GenPRES.Client/SessionMachine.fs
+++ b/src/Informedica.GenPRES.Client/SessionMachine.fs
@@ -34,6 +34,9 @@ type Session =
     // no Session: the server ended it (Rule 11) and said so once; the User continues
     // anonymously or relaunches
     | Ended of SessionEnding
+    // no Session yet: the launch waits on a PIN (UC-2); the browser holds the attempt in a
+    // cookie, and the form to supply the code and the PIN follows (plan 615, step 3)
+    | Enrolling of EnrolmentPending
 
 
 /// What GetSession answered at a resume.
@@ -42,6 +45,7 @@ type ResumeResult =
     | Found of SessionOpened
     | NotFound
     | Ended of SessionEnding
+    | Enrolling of EnrolmentPending
 
 
 [<RequireQualifiedAccess>]
@@ -147,6 +151,8 @@ module Session =
         // the close acknowledges the ending: the server deletes the cookie and drops the mark
         | SessionMsg.Resumed(Ok(ResumeResult.Ended ending)), Session.Resuming ->
             Session.Ended ending, [ SessionEffect.CallCloseSession ]
+        // the launch waits on a PIN (UC-2): the gate says so, the form follows in step 3
+        | SessionMsg.Resumed(Ok(ResumeResult.Enrolling pending)), Session.Resuming -> Session.Enrolling pending, []
         | SessionMsg.Resumed _, Session.Resuming -> Session.Anonymous, []
         | SessionMsg.Resumed _, _ -> state, []
 

--- a/src/Informedica.GenPRES.Server/Scripts/Enrolment.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/Enrolment.fsx
@@ -1,25 +1,25 @@
-// UC-2 enrolment against server-hosted stubs (plan 615), PR 1: the credential store and the
-// MailService, with no change in behaviour yet.
+// UC-2 enrolment against server-hosted stubs (plan 615), PR 2: the launch suspends at the PIN
+// question and continues when the PIN is supplied.
 //
 // Script-first draft (script-only policy) of:
-//   - `UserStanding` without `PinSet` and with the registry's `MailAddress` (Rule 27): the PIN
-//     is the Database's to know (Rule 24, uc-02 `ReadCredential`), not the registry's
-//     → `ServerApi.Ports.fs`;
-//   - `Mail` and `MailPort` (Actor M, edge C10) → `Ports.fs`;
-//   - `PinHash` (PBKDF2-SHA256, per-credential salt, constant-time compare) and `Credential`
-//     (Concept 7: the PIN and the wrong-count, keyed by the person) → `ServerApi.Adapters.fs`;
-//   - `Hop.State.Credentials`, `Hop.initialState`, the callback reading the credential at 5.4,
-//     `makeSessionPort` over an initial state → `Adapters.fs`;
-//   - `StubMail` (an outbox behind a lock and the `/stub/mail` page) and `StubCredentials`
-//     (the seed per stub login: `prescriber` and `prescriber-other-patient` with the PIN
-//     `1234`, `no-pin` without one) → `Adapters.fs`; `Server.fs` mounts `GET /stub/mail`
-//     behind `not IsProd`;
-//   - `StubDirectory` re-stated over the new `UserStanding`.
+//   - the wire: `EnrolmentPending`, `PinRefusal` → `Shared/Types.fs`;
+//     `SessionCommand.SupplyPin`, `SessionResponse.EnrolmentPending | PinRefused` → `Shared/Api.fs`;
+//   - the ports: `LaunchResult.Enrolling`, `CallbackResult.Enrolling`, `SupplyPinResult`,
+//     `EnrolmentCookie`, `SessionPort.supplyPin / findEnrolment / dropEnrolment` → `Ports.fs`;
+//   - `Pin.isValid`, `MailHint`, the two mails → `Adapters.fs`;
+//   - `Hop`: `PendingCode` (one per credential, Rule 37), `Enrolment` (one per launch, with the
+//     key of the browser that made it), the suspended callback, `findEnrolment`, `supplyPin` as
+//     one act (Rules 37, 40, 28, 27), `dropEnrolment` → `Adapters.fs`;
+//   - `sessionDisabled` refusing → `Adapters.fs`;
+//   - the composition root over the enrolment cookie → `CompositionRoot.fs`.
 //
-// PR 2 adds the suspended launch: the enrolment attempt, the code as a mac, `supplyPin` as
-// one act, and the two mails.
+// Review points folded in (#616): the code is per credential and the attempt per launch, so
+// the Session opens on the key of the browser that supplied the PIN; the third wrong code
+// answers a terminal `CodeVoid`; an attempt has no lifetime of its own, it lives as long as
+// its code.
 //
-// Run: `dotnet fsi Enrolment.fsx` from this directory (build the solution first).
+// PR 1 (merged, #617) put the credential store and the mail stub in place; this script
+// re-states `Hop` over them. Run: `dotnet fsi Enrolment.fsx` from this directory (build first).
 
 #I __SOURCE_DIRECTORY__
 #r "nuget: Expecto, 10.2.3"
@@ -27,135 +27,196 @@
 #load "load.fsx"
 
 open System
-open System.Security.Cryptography
 open Shared.Types
 open Shared.Models
+open Shared.Api
 open ServerApi
+
+
+// ---------------------------------------------------------------------------------------------
+// Wire (→ Shared/Types.fs, Shared/Api.fs)
+// ---------------------------------------------------------------------------------------------
+
+/// What the client learns when its launch is waiting on a PIN (UC-2): whom to greet and where
+/// the confirmation code went, hinted so that a shoulder cannot read the address.
+type EnrolmentPending =
+    {
+        DisplayName: string
+        MailHint: string
+    }
+
+
+/// Why a supplied PIN did not set (UC-2 ext 2b). `WrongCode` leaves the form open with the
+/// tries left; `CodeVoid` and `AttemptExpired` are terminal: the launch has to start over.
+[<RequireQualifiedAccess>]
+type PinRefusal =
+    | WrongCode of attemptsLeft: int
+    | CodeVoid
+    | AttemptExpired
+    | PinFormat
+
+
+[<RequireQualifiedAccess>]
+type SessionCommand =
+    | GetSession
+    | CloseSession
+    // UC-2: the confirmation code from the mail and the chosen PIN
+    | SupplyPin of code: string * pin: string
+
+
+[<RequireQualifiedAccess>]
+type SessionResponse =
+    | SessionResp of SessionOpened option
+    | SessionClosed
+    | SessionEnded of SessionEnding
+    // the launch waits on a PIN (UC-2); answered to GetSession while the attempt stands
+    | EnrolmentPending of EnrolmentPending
+    | PinRefused of PinRefusal
 
 
 // ---------------------------------------------------------------------------------------------
 // Ports (→ ServerApi.Ports.fs)
 // ---------------------------------------------------------------------------------------------
 
-/// What the UserRegistry says about a login at this launch (Rules 5, 6, 27): the User with the
-/// Role, the Patient active in MainEHR, and the mail address a confirmation code goes to.
-/// Whether a PIN is set is the Database's answer (Rule 24), not the registry's.
-type UserStanding =
+[<RequireQualifiedAccess>]
+type LaunchResult =
+    | Opened of sessionId: string * SessionOpened
+    | RedirectTo of url: string * state: string
+    | Refused of LaunchRefusal
+    // the launch suspended into enrolment (UC-2); the browser holds the attempt in a cookie
+    | Enrolling of attemptId: string
+
+
+[<RequireQualifiedAccess>]
+type CallbackResult =
+    | Opened of sessionId: string * redirect: string
+    | Refused of LaunchRefusal * redirect: string
+    | Superseded of redirect: string
+    // UC-2: the attempt for the enrolment cookie, and how long the code it is bound to lives
+    | Enrolling of attemptId: string * redirect: string * until: DateTime
+
+
+/// The answer to a supplied PIN: the Session that opened, or why not.
+[<RequireQualifiedAccess>]
+type SupplyPinResult =
+    | Opened of sessionId: string * SessionOpened
+    | Refused of PinRefusal
+
+
+/// The enrolment cookie of one request: written at the callback with the code's expiry, read
+/// at GetSession and SupplyPin, deleted when the attempt is spent or gone.
+type EnrolmentCookie =
     {
-        User: UserContext
-        ActivePatientId: string option
-        MailAddress: string
+        read: unit -> string option
+        write: string -> DateTime -> unit
+        delete: unit -> unit
     }
 
 
-type UserRegistryPort = { standing: BrowserIdentity -> UserStanding option }
-
-
-/// One mail from the Server to a User (Rule 27): a confirmation code, a notice that the PIN
-/// was set, a notice at the wrong-PIN limit.
-type Mail =
+type SessionPort =
     {
-        To: string
-        Subject: string
-        Body: string
+        present: Launch * PublicKey -> Async<LaunchResult>
+        callback: Callback -> Async<CallbackResult>
+        find: string -> Async<SessionLookup>
+        close: string -> Async<unit>
+        // UC-2: what a browser holding an attempt is told
+        findEnrolment: string -> Async<EnrolmentPending option>
+        // UC-2: the code and the chosen PIN, for the attempt in the cookie
+        supplyPin: string -> string -> string -> Async<SupplyPinResult>
+        // an attempt the browser gave up on (CloseSession while enrolling)
+        dropEnrolment: string -> Async<unit>
     }
-
-
-/// Actor M, the MailService, over edge C10. Sending is fire and forget: the Server records
-/// what it sent in the audit (Rule 46, later), not the outcome of delivery.
-type MailPort = { send: Mail -> unit }
 
 
 // ---------------------------------------------------------------------------------------------
-// The credential (→ ServerApi.Adapters.fs, before `Hop`)
+// Pure helpers (→ ServerApi.Adapters.fs)
 // ---------------------------------------------------------------------------------------------
 
-/// A PIN as the Database keeps it: never the PIN, a PBKDF2-SHA256 derivation under a salt of
-/// its own, so that two Users with the same PIN have nothing in common on disk.
-type PinHash =
-    {
-        Salt: byte[]
-        Hash: byte[]
-    }
+module Pin =
+
+    /// Four to six digits. V8 names no format; this is the assumption plan 615 records.
+    let isValid (pin: string) =
+        not (isNull pin) && pin.Length >= 4 && pin.Length <= 6 && pin |> Seq.forall Char.IsAsciiDigit
 
 
-module PinHash =
+module MailHint =
 
-    /// Enough rounds to make guessing a four-to-six-digit PIN offline slow, few enough for a
-    /// signing check to feel immediate. One place to tune.
-    let iterations = 100_000
-
-    let saltLength = 16
-
-    let hashLength = 32
-
-
-    let private derive (salt: byte[]) (pin: string) =
-        Rfc2898DeriveBytes.Pbkdf2(pin, salt, iterations, HashAlgorithmName.SHA256, hashLength)
+    /// `n***@stub.example`: enough for the User to know which mailbox, not enough for a
+    /// shoulder to read the address.
+    let ofAddress (address: string) =
+        match address.IndexOf '@' with
+        | i when i > 0 -> $"{address[0]}***{address.Substring i}"
+        | _ -> "***"
 
 
-    /// Derives the hash of a PIN under a fresh salt from `newSalt` (the CSPRNG in the host).
-    let make (newSalt: int -> byte[]) (pin: string) : PinHash =
-        let salt = newSalt saltLength
+/// The two mails of UC-2 (Rule 27). English only; the mail language is a later concern.
+module Mails =
 
-        {
-            Salt = salt
-            Hash = derive salt pin
-        }
+    let confirmationCode (displayName: string) (code: string) (minutes: int) : string * string =
+        "GenPRES: your confirmation code",
+        $"Hello {displayName},\n\nYour confirmation code is {code}. It is valid for {minutes} minutes. Enter it in GenPRES together with the PIN of your choice.\n\nIf you did not open GenPRES just now, somebody tried to enrol in your name; nothing was set."
 
 
-    /// Whether the PIN derives to the stored hash, compared in constant time.
-    let verify (pin: string) (hash: PinHash) =
-        CryptographicOperations.FixedTimeEquals(derive hash.Salt pin, hash.Hash)
-
-
-/// Concept 7, the UserCredential: what the Database holds per person (keyed by UserId, not by
-/// login). No PIN yet is a credential without one; the wrong-count is Rule 28's, counted across
-/// Sessions and reset to zero when the PIN is set.
-type Credential =
-    {
-        PinHash: PinHash option
-        WrongCount: int
-    }
-
-
-module Credential =
-
-    let empty =
-        {
-            PinHash = None
-            WrongCount = 0
-        }
-
-
-    /// Rule 24: whether a PIN is set.
-    let pinSet (credential: Credential) = credential.PinHash.IsSome
-
-
-    /// A credential with this PIN and a count of zero (Rule 28: setting the PIN resets it).
-    let withPin (newSalt: int -> byte[]) (pin: string) : Credential =
-        {
-            PinHash = Some(PinHash.make newSalt pin)
-            WrongCount = 0
-        }
+    let pinSet (displayName: string) : string * string =
+        "GenPRES: your PIN was set",
+        $"Hello {displayName},\n\nA PIN was set for your GenPRES account just now. If that was not you, tell your administrator."
 
 
 // ---------------------------------------------------------------------------------------------
-// Hop, re-stated with the credential store (→ ServerApi.Adapters.fs)
+// Hop, re-stated with the suspended launch (→ ServerApi.Adapters.fs)
 // ---------------------------------------------------------------------------------------------
 
 module Hop =
 
     open ServerApi.Hop
 
-    /// The state gains the credential half of the Database (Concept 7): what the callback reads
-    /// at 5.4 (Rule 24) and what enrolment writes (PR 2).
+    /// A confirmation code as the Database keeps it (Rule 37, "the code as a mac"): one per
+    /// credential, with the address it went to, its expiry and the wrong tries so far.
+    type PendingCode =
+        {
+            UserId: string
+            MailAddress: string
+            CodeMac: byte[]
+            Expiry: DateTime
+            Tries: int
+        }
+
+
+    /// One suspended launch (UC-2): what the open needs once the PIN is set, and the public key
+    /// of the browser that made it, so the Session opens on the key the supplying browser holds.
+    /// No lifetime of its own: it lives as long as the code it is bound to.
+    type Enrolment =
+        {
+            Attempt: string
+            UserId: string
+            Login: string
+            DisplayName: string
+            PatientId: string
+            PublicKey: PublicKey
+        }
+
+
+    type LaunchRecord =
+        {
+            Nonce: string
+            State: string
+            PatientId: string
+            PublicKey: PublicKey
+            Expiry: DateTime
+            Outcome: LaunchResult option
+        }
+
+
     type State =
         {
             Launches: Map<string, LaunchRecord>
             Sessions: Map<string, SessionRecord>
             Endings: Map<string, SessionEnding * DateTime>
             Credentials: Map<string, Credential>
+            // UC-2: the live confirmation code per person
+            Codes: Map<string, PendingCode>
+            // UC-2: the suspended launches by attempt
+            Enrolments: Map<string, Enrolment>
         }
 
 
@@ -165,25 +226,37 @@ module Hop =
             Sessions = Map.empty
             Endings = Map.empty
             Credentials = Map.empty
+            Codes = Map.empty
+            Enrolments = Map.empty
         }
 
 
-    /// The state a host starts from: the credentials it was seeded with (the stub's, or a
-    /// store's read once the Database exists), nothing else.
     let initialState (credentials: Map<string, Credential>) =
         { emptyState with
             Credentials = credentials
         }
 
 
-    /// Rule 24, uc-02 `ReadCredential`: the credential of a person, or an empty one.
+    /// How long a confirmation code lives: a mail round trip, not Rule 30's gap. Bounds the
+    /// half-finished launch too (plan 615's deviation from the model).
+    let codeLifetime = TimeSpan.FromMinutes 15.0
+
+    /// Wrong codes before the code is void (ext 2b).
+    let maxTries = 3
+
+
     let credentialOf (userId: string) (state: State) =
         state.Credentials |> Map.tryFind userId |> Option.defaultValue Credential.empty
 
 
     let private dropExpired (now: DateTime) (state: State) =
+        let codes = state.Codes |> Map.filter (fun _ c -> now <= c.Expiry)
+
         { state with
             Launches = state.Launches |> Map.filter (fun _ r -> now <= r.Expiry)
+            Codes = codes
+            // an attempt lives as long as its code
+            Enrolments = state.Enrolments |> Map.filter (fun _ e -> codes |> Map.containsKey e.UserId)
         }
 
 
@@ -227,30 +300,34 @@ module Hop =
                 answerOf authorizeUrl record
 
 
-    let private openSession
+    /// Step 5.7, one act (Rule 40), from whatever carried the launch this far: a LaunchRecord
+    /// at the callback, an Enrolment once the PIN is set. The Session is written, the login's
+    /// other Sessions are closed and marked (Rule 8).
+    let private openWith
         (now: DateTime)
         (newId: unit -> string)
         (patientData: string -> Patient option)
-        (record: LaunchRecord)
-        (standing: UserStanding)
+        (patientId: string)
+        (key: PublicKey)
+        (user: UserContext)
         (state: State)
         =
         let id = newId ()
 
         let session =
             {
-                User = Some standing.User
+                User = Some user
                 PatientContext =
                     Some
                         {
-                            PatientId = record.PatientId
-                            Patient = patientData record.PatientId |> Option.defaultValue Patient.empty
+                            PatientId = patientId
+                            Patient = patientData patientId |> Option.defaultValue Patient.empty
                         }
                 OpenedToken = Some(OpenedToken $"opened-{id}")
-                KeyThumbprint = Some(PublicKey.thumbprint record.PublicKey)
+                KeyThumbprint = Some(PublicKey.thumbprint key)
             }
 
-        let login = Some standing.User.UserId
+        let login = Some user.UserId
 
         let superseded =
             state.Sessions
@@ -258,10 +335,7 @@ module Hop =
             |> Map.toList
             |> List.map fst
 
-        let outcome = LaunchResult.Opened(id, session)
-
         { state with
-            Launches = state.Launches |> Map.add record.Nonce { record with Outcome = Some outcome }
             Sessions =
                 superseded
                 |> List.fold (fun m sid -> Map.remove sid m) state.Sessions
@@ -275,27 +349,104 @@ module Hop =
                 superseded
                 |> List.fold (fun m sid -> Map.add sid (SessionEnding.SupersededByLaunch, now) m) state.Endings
         },
-        CallbackResult.Opened(id, openedUrl)
+        (id, session)
+
+
+    let private recordOutcome (record: LaunchRecord) outcome (state: State) =
+        { state with
+            Launches = state.Launches |> Map.add record.Nonce { record with Outcome = Some outcome }
+        }
+
+
+    let private openSession now newId patientData (record: LaunchRecord) (standing: UserStanding) (state: State) =
+        let state, (id, session) =
+            openWith now newId patientData record.PatientId record.PublicKey standing.User state
+
+        recordOutcome record (LaunchResult.Opened(id, session)) state, CallbackResult.Opened(id, openedUrl)
 
 
     let private refuse (record: LaunchRecord) refusal (state: State) =
+        recordOutcome record (LaunchResult.Refused refusal) state, CallbackResult.Refused(refusal, refusedUrl refusal)
+
+
+    /// UC-2: the launch suspends at the PIN question. One live code per credential (Rule 37,
+    /// ext 2a): a code that still stands is reused and nothing is mailed; else a fresh code is
+    /// mailed to the address the registry gave on this request (Rule 27). The attempt is this
+    /// launch's own, with its browser's key.
+    let private suspend
+        (now: DateTime)
+        (newId: unit -> string)
+        (newCode: unit -> string)
+        (codeMac: string -> byte[])
+        (send: Mail -> unit)
+        (record: LaunchRecord)
+        (identity: BrowserIdentity)
+        (standing: UserStanding)
+        (state: State)
+        =
+        let userId = standing.User.UserId
+
+        let state =
+            match state.Codes |> Map.tryFind userId with
+            | Some _ -> state
+            | None ->
+                let code = newCode ()
+                let subject, body = Mails.confirmationCode identity.DisplayName code (int codeLifetime.TotalMinutes)
+
+                send
+                    {
+                        To = standing.MailAddress
+                        Subject = subject
+                        Body = body
+                    }
+
+                { state with
+                    Codes =
+                        state.Codes
+                        |> Map.add
+                            userId
+                            {
+                                UserId = userId
+                                MailAddress = standing.MailAddress
+                                CodeMac = codeMac code
+                                Expiry = now + codeLifetime
+                                Tries = 0
+                            }
+                }
+
+        let attempt = newId ()
+
+        let enrolment =
+            {
+                Attempt = attempt
+                UserId = userId
+                Login = identity.Login
+                DisplayName = identity.DisplayName
+                PatientId = record.PatientId
+                PublicKey = record.PublicKey
+            }
+
+        let until = state.Codes[userId].Expiry
+
         { state with
-            Launches =
-                state.Launches
-                |> Map.add record.Nonce { record with Outcome = Some(LaunchResult.Refused refusal) }
-        },
-        CallbackResult.Refused(refusal, refusedUrl refusal)
+            Enrolments = state.Enrolments |> Map.add attempt enrolment
+        }
+        |> recordOutcome record (LaunchResult.Enrolling attempt),
+        CallbackResult.Enrolling(attempt, openedUrl, until)
 
 
-    /// Step 4.5 and step 5, as before, except that 5.4 reads the credential from the state
-    /// (Rule 24) instead of asking the registry: a Prescriber whose credential has no PIN is
-    /// still refused here; PR 2 suspends the launch instead.
+    /// Step 4.5 and step 5. As before, except at 5.4: a Prescriber whose credential has no PIN
+    /// is not refused, the launch suspends (Rules 7, 25). A callback reload while the attempt
+    /// stands is answered with it again (Rule 45); once it is gone, a relaunch is asked for.
     let callback
         (now: DateTime)
         (newId: unit -> string)
+        (newCode: unit -> string)
+        (codeMac: string -> byte[])
         (redeem: string -> BrowserIdentity option)
         (standing: BrowserIdentity -> UserStanding option)
         (patientData: string -> Patient option)
+        (send: Mail -> unit)
         (state: State)
         (cb: Callback)
         : State * CallbackResult
@@ -318,6 +469,12 @@ module Hop =
                 state, CallbackResult.Opened(id, openedUrl)
             | Some(LaunchResult.Opened _) -> state, CallbackResult.Superseded openedUrl
             | Some(LaunchResult.Refused refusal) -> state, CallbackResult.Refused(refusal, refusedUrl refusal)
+            | Some(LaunchResult.Enrolling attempt) ->
+                match state.Enrolments |> Map.tryFind attempt with
+                | Some e -> state, CallbackResult.Enrolling(attempt, openedUrl, state.Codes[e.UserId].Expiry)
+                | None ->
+                    state,
+                    CallbackResult.Refused(LaunchRefusal.EnrolmentRequired, refusedUrl LaunchRefusal.EnrolmentRequired)
             | Some(LaunchResult.RedirectTo _)
             | None ->
                 let identity =
@@ -332,16 +489,140 @@ module Hop =
                     | None -> refuse record LaunchRefusal.NoRole state
                     | Some standing when standing.ActivePatientId <> Some record.PatientId ->
                         refuse record LaunchRefusal.WrongActivePatient state
-                    // 5.4, Rule 24: the credential is the Database's; Rule 25 binds Prescribers
-                    // only, a Reader is never asked (Rule 26, ext 5c)
                     | Some standing when
                         standing.User.Role = UserRole.Prescriber
                         && not (credentialOf standing.User.UserId state |> Credential.pinSet)
                         ->
-                        refuse record LaunchRefusal.EnrolmentRequired state
+                        suspend now newId newCode codeMac send record identity standing state
                     | Some standing -> openSession now newId patientData record standing state
         | _, None -> state, invalid
         | _ -> state, invalid
+
+
+    /// What a browser holding an attempt is told at GetSession: whom the launch is for and where
+    /// the code went, while the attempt (that is, its code) stands; nothing once it is gone.
+    let findEnrolment (now: DateTime) (attempt: string) (state: State) : State * EnrolmentPending option =
+        let state = dropExpired now state
+
+        match state.Enrolments |> Map.tryFind attempt with
+        | Some e ->
+            state,
+            Some
+                {
+                    DisplayName = e.DisplayName
+                    MailHint = MailHint.ofAddress state.Codes[e.UserId].MailAddress
+                }
+        | None -> state, None
+
+
+    /// The code and every attempt bound to it, gone (the PIN was set, the code is void, or
+    /// the browser gave up).
+    let private dropCode (userId: string) (state: State) =
+        { state with
+            Codes = state.Codes |> Map.remove userId
+            Enrolments = state.Enrolments |> Map.filter (fun _ e -> e.UserId <> userId)
+        }
+
+
+    /// The browser gave up on its attempt (CloseSession while enrolling). The code stands for
+    /// any other attempt bound to it; when this was the last one it goes too, so that the next
+    /// launch mails a fresh code.
+    let dropEnrolment (attempt: string) (state: State) : State =
+        match state.Enrolments |> Map.tryFind attempt with
+        | None -> state
+        | Some e ->
+            let state =
+                { state with
+                    Enrolments = state.Enrolments |> Map.remove attempt
+                }
+
+            if state.Enrolments |> Map.exists (fun _ o -> o.UserId = e.UserId) then
+                state
+            else
+                dropCode e.UserId state
+
+
+    /// UC-2, the PIN comes back with the code. In order: the attempt (and its code) must stand;
+    /// the PIN must have the format, else no try is spent; a wrong code counts, and the third
+    /// voids the code for every attempt (ext 2b); else one act (Rules 37, 40): the PIN is set
+    /// with a count of zero (Rule 28), the code and its attempts are dropped, the User is
+    /// told (Rule 27, at the address the registry answers now, else the one the code went to),
+    /// and the launch continues at 5.5 to 5.7 on the supplying attempt's key.
+    let supplyPin
+        (now: DateTime)
+        (newId: unit -> string)
+        (newSalt: int -> byte[])
+        (codeMac: string -> byte[])
+        (standing: BrowserIdentity -> UserStanding option)
+        (patientData: string -> Patient option)
+        (send: Mail -> unit)
+        (attempt: string)
+        (code: string)
+        (pin: string)
+        (state: State)
+        : State * SupplyPinResult
+        =
+        let state = dropExpired now state
+
+        match state.Enrolments |> Map.tryFind attempt with
+        | None -> state, SupplyPinResult.Refused PinRefusal.AttemptExpired
+        | Some e ->
+            let pending = state.Codes[e.UserId]
+
+            if not (Pin.isValid pin) then
+                state, SupplyPinResult.Refused PinRefusal.PinFormat
+            elif
+                not (System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(codeMac code, pending.CodeMac))
+            then
+                let tries = pending.Tries + 1
+
+                if tries >= maxTries then
+                    dropCode e.UserId state, SupplyPinResult.Refused PinRefusal.CodeVoid
+                else
+                    { state with
+                        Codes = state.Codes |> Map.add e.UserId { pending with Tries = tries }
+                    },
+                    SupplyPinResult.Refused(PinRefusal.WrongCode(maxTries - tries))
+            else
+                let identity =
+                    {
+                        Login = e.Login
+                        DisplayName = e.DisplayName
+                    }
+
+                // Rule 27: the address, asked fresh on the request that sends the mail; the
+                // code's address when the registry cannot answer (uc-02, last bullet)
+                let address =
+                    standing identity
+                    |> Option.map _.MailAddress
+                    |> Option.defaultValue pending.MailAddress
+
+                let subject, body = Mails.pinSet e.DisplayName
+
+                send
+                    {
+                        To = address
+                        Subject = subject
+                        Body = body
+                    }
+
+                let user =
+                    {
+                        UserId = e.UserId
+                        DisplayName = e.DisplayName
+                        Role = UserRole.Prescriber
+                    }
+
+                let state =
+                    { state with
+                        Credentials = state.Credentials |> Map.add e.UserId (Credential.withPin newSalt pin)
+                    }
+                    |> dropCode e.UserId
+
+                let state, (id, session) =
+                    openWith now newId patientData e.PatientId e.PublicKey user state
+
+                state, SupplyPinResult.Opened(id, session)
 
 
     let find (id: string) (state: State) : State * SessionLookup =
@@ -360,15 +641,28 @@ module Hop =
         }
 
 
-    /// The port over a single mutable state guarded by a lock, started from `initial`.
+    /// Six digits from a random source (the CSPRNG in the host).
+    let newCode (randomBelow: int -> int) () = (randomBelow 1_000_000).ToString "D6"
+
+
+    /// The mac of a code under the host key (Rule 37).
+    let codeMac (key: LaunchSeal.Key) (code: string) =
+        LaunchSeal.mac key (Text.Encoding.UTF8.GetBytes code)
+
+
     let makeSessionPort
         (now: unit -> DateTime)
         (newId: unit -> string)
+        (newCode: unit -> string)
+        (newSalt: int -> byte[])
+        (codeMac: string -> byte[])
         (verify: Launch -> Result<LaunchSeal.Claims, LaunchRefusal>)
         (idp: IdentityProviderPort)
         (registry: UserRegistryPort)
         (patientData: PatientDataPort)
+        (mail: MailPort)
         (initial: State)
+        : SessionPort
         =
         let gate = obj ()
         let mutable state = initial
@@ -389,190 +683,169 @@ module Hop =
                 fun cb ->
                     async {
                         return
-                            update (fun s -> callback (now ()) newId idp.redeem registry.standing patientData.read s cb)
+                            update (fun s ->
+                                callback
+                                    (now ())
+                                    newId
+                                    newCode
+                                    codeMac
+                                    idp.redeem
+                                    registry.standing
+                                    patientData.read
+                                    mail.send
+                                    s
+                                    cb
+                            )
                     }
             find = fun id -> async { return update (find id) }
             close = fun id -> async { return update (fun s -> close id s, ()) }
+            findEnrolment = fun attempt -> async { return update (findEnrolment (now ()) attempt) }
+            supplyPin =
+                fun attempt code pin ->
+                    async {
+                        return
+                            update (fun s ->
+                                supplyPin
+                                    (now ())
+                                    newId
+                                    newSalt
+                                    codeMac
+                                    registry.standing
+                                    patientData.read
+                                    mail.send
+                                    attempt
+                                    code
+                                    pin
+                                    s
+                            )
+                    }
+            dropEnrolment = fun attempt -> async { return update (fun s -> dropEnrolment attempt s, ()) }
         }
+
+
+/// The production stop-gap (until #580): nothing launches, nothing enrols.
+let sessionDisabled: SessionPort =
+    {
+        present = fun _ -> async { return LaunchResult.Refused LaunchRefusal.LaunchInvalid }
+        callback =
+            fun _ ->
+                async {
+                    return
+                        CallbackResult.Refused(LaunchRefusal.LaunchInvalid, ServerApi.Hop.refusedUrl LaunchRefusal.LaunchInvalid)
+                }
+        find = fun _ -> async { return SessionLookup.NotFound }
+        close = fun _ -> async { return () }
+        findEnrolment = fun _ -> async { return None }
+        supplyPin = fun _ _ _ -> async { return SupplyPinResult.Refused PinRefusal.AttemptExpired }
+        dropEnrolment = fun _ -> async { return () }
+    }
 
 
 // ---------------------------------------------------------------------------------------------
-// The stubs (→ ServerApi.Adapters.fs)
+// Composition root (→ ServerApi.CompositionRoot.fs; over `env.session` there)
 // ---------------------------------------------------------------------------------------------
 
-/// The IdentityProvider and the UserRegistry as one stub directory over an identity choice made
-/// on the stub launch page. Re-stated over the new `UserStanding`: the registry answers the
-/// mail address (`<login>@stub.example`) and no longer whether a PIN is set.
-module StubDirectory =
+module CompositionRoot =
 
-    open ServerApi.StubDirectory
-
-    /// Rule 27: the address the registry gives for a login. The stub's is derived from it.
-    let mailAddressOf (identity: BrowserIdentity) = $"{identity.Login}@stub.example"
-
-
-    /// The registry's answer for a login, given the Patient the launch page made active.
-    let standingOf (activePatientId: string) (identity: BrowserIdentity) : UserStanding option =
-        let standing role activePatientId =
-            Some
-                {
-                    User =
-                        {
-                            UserId = identity.Login
-                            DisplayName = identity.DisplayName
-                            Role = role
-                        }
-                    ActivePatientId = Some activePatientId
-                    MailAddress = mailAddressOf identity
-                }
-
-        match identity.Login with
-        | "prescriber"
-        | "no-pin" -> standing UserRole.Prescriber activePatientId
-        | "reader" -> standing UserRole.Reader activePatientId
-        | "prescriber-other-patient" -> standing UserRole.Prescriber "other-patient"
-        | _ -> None
-
-
-    type Directory =
-        {
-            idp: IdentityProviderPort
-            registry: UserRegistryPort
-            issue: string -> string -> string
+    let processLaunch (session: SessionPort) (cookie: SessionCookie) (stateCookie: LaunchStateCookie) (cmd: LaunchCommand) =
+        async {
+            match cmd with
+            | LaunchCommand.PresentLaunch(launch, key) ->
+                match! session.present (launch, key) with
+                | LaunchResult.Opened(id, opened) ->
+                    cookie.write id
+                    return LaunchOutcome.Opened opened
+                | LaunchResult.RedirectTo(url, state) ->
+                    stateCookie.write state
+                    return LaunchOutcome.RedirectTo url
+                | LaunchResult.Refused refusal -> return LaunchOutcome.Refused refusal
+                // a retry of a launch that suspended: the browser holds the attempt already, the
+                // app tells it at the next GetSession
+                | LaunchResult.Enrolling _ -> return LaunchOutcome.RedirectTo ServerApi.Hop.openedUrl
         }
 
 
-    let make (now: unit -> DateTime) (newCode: unit -> string) : Directory =
-        let gate = obj ()
-        let codes = Collections.Generic.Dictionary<string, BrowserIdentity * DateTime>()
-        let active = Collections.Generic.Dictionary<string, string>()
-
-        let prune () =
-            let cutoff = now () - codeLifetime
-
-            for stale in
-                codes
-                |> Seq.filter (fun kv -> snd kv.Value < cutoff)
-                |> Seq.map _.Key
-                |> Seq.toList do
-                codes.Remove stale |> ignore
-
-        {
-            idp =
-                {
-                    authorizeUrl = fun state -> $"/authorize?state={Uri.EscapeDataString state}"
-                    redeem =
-                        fun code ->
-                            lock
-                                gate
-                                (fun () ->
-                                    match codes.TryGetValue code with
-                                    | true, (identity, issued) when now () - issued <= codeLifetime ->
-                                        codes.Remove code |> ignore
-                                        Some identity
-                                    | _ -> None
-                                )
-                }
-            registry =
-                {
-                    standing =
-                        fun identity ->
-                            lock
-                                gate
-                                (fun () ->
-                                    match active.TryGetValue identity.Login with
-                                    | true, pid -> standingOf pid identity
-                                    | _ -> standingOf "" identity
-                                )
-                }
-            issue =
-                fun choice activePatientId ->
-                    lock
-                        gate
-                        (fun () ->
-                            prune ()
-                            let code = newCode ()
-                            codes[code] <- identityOf choice, now ()
-                            active[choice] <- activePatientId
-                            code
-                        )
+    let processCallback
+        (session: SessionPort)
+        (cookie: SessionCookie)
+        (stateCookie: LaunchStateCookie)
+        (enrolment: EnrolmentCookie)
+        (cb: Callback)
+        =
+        async {
+            match! session.callback { cb with StateCookie = stateCookie.read cb.State } with
+            | CallbackResult.Opened(id, redirect) ->
+                cookie.write id
+                return redirect
+            | CallbackResult.Enrolling(attempt, redirect, until) ->
+                enrolment.write attempt until
+                return redirect
+            | CallbackResult.Refused(_, redirect)
+            | CallbackResult.Superseded redirect -> return redirect
         }
 
 
-/// The credential half of the Database, seeded for the stub logins: the Prescribers that sign
-/// have the PIN `1234`, `no-pin` has none and enrols (UC-2), a Reader has no credential
-/// (Rule 26). Per host start; a PIN set by enrolment lives as long as the host.
-module StubCredentials =
+    /// The session commands over both cookies. GetSession answers the Session first; without
+    /// one, a standing attempt; a gone attempt loses its cookie. SupplyPin works on the attempt
+    /// in the cookie, never on one the client names. CloseSession drops both.
+    let processSession
+        (session: SessionPort)
+        (cookie: SessionCookie)
+        (enrolment: EnrolmentCookie)
+        (cmd: SessionCommand)
+        =
+        async {
+            match cmd with
+            | SessionCommand.GetSession ->
+                let! bySession =
+                    async {
+                        match cookie.read () with
+                        | None -> return None
+                        | Some id ->
+                            match! session.find id with
+                            | SessionLookup.Found opened -> return Some(SessionResponse.SessionResp(Some opened))
+                            | SessionLookup.NotFound -> return None
+                            | SessionLookup.Ended ending -> return Some(SessionResponse.SessionEnded ending)
+                    }
 
-    /// The PIN every seeded stub Prescriber has. Development and test servers only.
-    let stubPin = "1234"
+                match bySession, enrolment.read () with
+                | Some response, _ -> return response
+                | None, None -> return SessionResponse.SessionResp None
+                | None, Some attempt ->
+                    match! session.findEnrolment attempt with
+                    | Some pending -> return SessionResponse.EnrolmentPending pending
+                    | None ->
+                        enrolment.delete ()
+                        return SessionResponse.SessionResp None
+            | SessionCommand.SupplyPin(code, pin) ->
+                match enrolment.read () with
+                | None -> return SessionResponse.PinRefused PinRefusal.AttemptExpired
+                | Some attempt ->
+                    match! session.supplyPin attempt code pin with
+                    | SupplyPinResult.Opened(id, opened) ->
+                        enrolment.delete ()
+                        cookie.write id
+                        return SessionResponse.SessionResp(Some opened)
+                    | SupplyPinResult.Refused(PinRefusal.CodeVoid as refusal)
+                    | SupplyPinResult.Refused(PinRefusal.AttemptExpired as refusal) ->
+                        enrolment.delete ()
+                        return SessionResponse.PinRefused refusal
+                    | SupplyPinResult.Refused refusal -> return SessionResponse.PinRefused refusal
+            | SessionCommand.CloseSession ->
+                try
+                    match cookie.read () with
+                    | Some id -> do! session.close id
+                    | None -> ()
 
+                    match enrolment.read () with
+                    | Some attempt -> do! session.dropEnrolment attempt
+                    | None -> ()
+                finally
+                    cookie.delete ()
+                    enrolment.delete ()
 
-    let seed (newSalt: int -> byte[]) : Map<string, Credential> =
-        [
-            "prescriber", Credential.withPin newSalt stubPin
-            "prescriber-other-patient", Credential.withPin newSalt stubPin
-            "no-pin", Credential.empty
-        ]
-        |> Map.ofList
-
-
-/// The MailService stub (Actor M): an outbox behind a lock and a page that shows it, newest
-/// first, so the tester reads a confirmation code where a User would read their mail.
-/// `Server.fs` mounts `GET /stub/mail` in full scope only.
-module StubMail =
-
-    let path = "/stub/mail"
-
-
-    type Outbox =
-        {
-            port: MailPort
-            // newest first
-            sent: unit -> Mail list
+                return SessionResponse.SessionClosed
         }
-
-
-    let make () : Outbox =
-        let gate = obj ()
-        let mutable mails: Mail list = []
-
-        {
-            port = { send = fun mail -> lock gate (fun () -> mails <- mail :: mails) }
-            sent = fun () -> lock gate (fun () -> mails)
-        }
-
-
-    let private encode (s: string) = Net.WebUtility.HtmlEncode s
-
-
-    /// The outbox as a page. No inline script or style, so the CSP (`default-src 'self'`)
-    /// holds; every field is HTML-encoded, the body keeps its line breaks.
-    let page (mails: Mail list) =
-        let items =
-            match mails with
-            | [] -> "<p>No mail sent yet.</p>"
-            | mails ->
-                mails
-                |> List.map (fun m ->
-                    $"""<article>
-<h2>{encode m.Subject}</h2>
-<p>To: <code>{encode m.To}</code></p>
-<pre>{encode m.Body}</pre>
-</article>"""
-                )
-                |> String.concat "\n"
-
-        $"""<!doctype html>
-<html lang="en">
-<head><meta charset="utf-8"><title>GenPRES stub mail</title></head>
-<body>
-<h1>Stub MailService outbox</h1>
-<p>Stands in for the MailService (uc-02, Rule 27): every mail the server sent since it started,
-newest first. Development and test servers only.</p>
-{items}
-</body>
-</html>"""
 
 
 // ---------------------------------------------------------------------------------------------
@@ -588,9 +861,9 @@ let t0 = DateTime(2026, 9, 10, 12, 0, 0, DateTimeKind.Utc)
 let lifetime = TimeSpan.FromMinutes 2.0
 let verifyAt (now: DateTime) = LaunchSeal.verify now sealKey
 let keyA = PublicKey "key-a"
-
-/// A deterministic salt source for the tests.
+let keyB = PublicKey "key-b"
 let salts (n: int) = Array.init n byte
+let codeMac = Hop.codeMac sealKey
 
 let mintFor nonce pid =
     LaunchSeal.mint
@@ -611,20 +884,39 @@ let counter prefix =
         $"{prefix}-{n.Value}"
 
 
+/// Codes are numbered so that a test can name the one that was mailed.
+let codes () =
+    let n = ref 0
+
+    fun () ->
+        n.Value <- n.Value + 1
+        $"%06d{n.Value}"
+
+
+type Fixture =
+    {
+        ids: unit -> string
+        d: StubDirectory.Directory
+        outbox: StubMail.Outbox
+        newCode: unit -> string
+    }
+
+
 let fixture () =
-    let ids = counter "id"
-    let directory = StubDirectory.make (fun () -> t0) (counter "code")
-    ids, directory
+    {
+        ids = counter "id"
+        d = StubDirectory.make (fun () -> t0) (counter "code")
+        outbox = StubMail.make ()
+        newCode = codes ()
+    }
 
 
-/// The state a stub host starts from.
 let seeded = Hop.initialState (StubCredentials.seed salts)
 
 
-/// Presents, then plays the stub IdP for `choice`, and returns the callback the browser brings.
-let hop (ids: unit -> string) (directory: StubDirectory.Directory) state launch key choice =
+let hop (f: Fixture) state launch key choice =
     let state, result =
-        Hop.present t0 ids (verifyAt t0) directory.idp.authorizeUrl state (launch, key)
+        Hop.present t0 f.ids (verifyAt t0) f.d.idp.authorizeUrl state (launch, key)
 
     match result with
     | LaunchResult.RedirectTo(_, st) ->
@@ -632,276 +924,616 @@ let hop (ids: unit -> string) (directory: StubDirectory.Directory) state launch 
         {
             State = st
             StateCookie = Some st
-            Code = Some(directory.issue choice "patient-1")
+            Code = Some(f.d.issue choice "patient-1")
             Error = None
         }
     | other -> failtest $"expected RedirectTo, got {other}"
 
 
-let run (ids: unit -> string) (directory: StubDirectory.Directory) state cb =
-    Hop.callback t0 ids directory.idp.redeem directory.registry.standing StubPatientData.port.read state cb
+let runAt now (f: Fixture) state cb =
+    Hop.callback
+        now
+        f.ids
+        f.newCode
+        codeMac
+        f.d.idp.redeem
+        f.d.registry.standing
+        StubPatientData.port.read
+        f.outbox.port.send
+        state
+        cb
 
 
-let pinHashTests =
+let run f state cb = runAt t0 f state cb
+
+
+/// Launches `choice` and expects the suspension; returns the state and the attempt.
+let suspendVia (f: Fixture) state launch key choice =
+    let state, cb = hop f state launch key choice
+    let state, result = run f state cb
+
+    match result with
+    | CallbackResult.Enrolling(attempt, redirect, until) ->
+        redirect |> Expect.equal "to the app" "/#/session"
+        until |> Expect.equal "until the code expires" (t0 + Hop.codeLifetime)
+        state, attempt
+    | other -> failtest $"expected Enrolling, got {other}"
+
+
+let supplyAt now (f: Fixture) state attempt code pin =
+    Hop.supplyPin
+        now
+        f.ids
+        salts
+        codeMac
+        f.d.registry.standing
+        StubPatientData.port.read
+        f.outbox.port.send
+        attempt
+        code
+        pin
+        state
+
+
+let supply f state attempt code pin = supplyAt t0 f state attempt code pin
+
+
+/// The code the newest confirmation mail carries, from its body.
+let mailedCode (f: Fixture) =
+    let body =
+        (f.outbox.sent () |> List.find (fun m -> m.Subject.Contains "confirmation code")).Body
+
+    let i = body.IndexOf "code is " + 8
+    body.Substring(i, 6)
+
+
+let helperTests =
     testList
-        "PinHash"
+        "helpers"
         [
-            test "the PIN it was made from verifies" {
-                let hash = PinHash.make salts "1234"
-                hash |> PinHash.verify "1234" |> Expect.isTrue "verifies"
+            test "a PIN is four to six digits" {
+                for ok in [ "1234"; "12345"; "123456"; "0000" ] do
+                    Pin.isValid ok |> Expect.isTrue ok
+
+                for bad in [ "123"; "1234567"; "12a4"; ""; "12 34"; "١٢٣٤" ] do
+                    Pin.isValid bad |> Expect.isFalse bad
             }
 
-            test "another PIN does not" {
-                let hash = PinHash.make salts "1234"
-                hash |> PinHash.verify "1235" |> Expect.isFalse "wrong PIN"
-                hash |> PinHash.verify "" |> Expect.isFalse "empty PIN"
+            test "the mail hint keeps the first letter and the domain" {
+                MailHint.ofAddress "no-pin@stub.example" |> Expect.equal "hint" "n***@stub.example"
+                MailHint.ofAddress "x" |> Expect.equal "no at" "***"
             }
 
-            test "the same PIN under another salt is another hash" {
-                let a = PinHash.make salts "1234"
-                let b = PinHash.make (fun n -> Array.init n (fun i -> byte (i + 1))) "1234"
-                a.Hash |> Expect.notEqual "different hashes" b.Hash
-                b |> PinHash.verify "1234" |> Expect.isTrue "still verifies"
+            test "codes are six digits" {
+                Hop.newCode (fun _ -> 42) () |> Expect.equal "padded" "000042"
+                Hop.newCode (fun _ -> 999_999) () |> Expect.equal "max" "999999"
             }
 
-            test "the hash is never the PIN, and has the declared lengths" {
-                let hash = PinHash.make salts "1234"
-                hash.Salt.Length |> Expect.equal "salt" PinHash.saltLength
-                hash.Hash.Length |> Expect.equal "hash" PinHash.hashLength
-                Text.Encoding.UTF8.GetString hash.Hash |> Expect.notEqual "not the PIN" "1234"
+            test "the code mac is keyed" {
+                codeMac "123456" |> Expect.notEqual "another key" (Hop.codeMac (LaunchSeal.Key(Array.zeroCreate 32)) "123456")
+                codeMac "123456" |> Expect.equal "deterministic" (codeMac "123456")
             }
         ]
 
 
-let credentialTests =
+let suspendTests =
     testList
-        "Credential"
+        "the launch suspends (uc-02)"
         [
-            test "an empty credential has no PIN set (Rule 24)" {
-                Credential.empty |> Credential.pinSet |> Expect.isFalse "no PIN"
+            test "a Prescriber without a PIN is not refused: an attempt and a code, one mail (Rules 7, 25, 27)" {
+                let f = fixture ()
+                let state, attempt = suspendVia f seeded launch1 keyA "no-pin"
+                state.Sessions |> Map.isEmpty |> Expect.isTrue "no Session yet (Rule 7)"
+                let e = state.Enrolments[attempt]
+                e.UserId |> Expect.equal "person" "no-pin"
+                e.PatientId |> Expect.equal "patient" "patient-1"
+                e.PublicKey |> Expect.equal "the browser's key" keyA
+                state.Codes["no-pin"].Expiry |> Expect.equal "code lifetime" (t0 + Hop.codeLifetime)
+                state.Launches["n-1"].Outcome |> Expect.equal "recorded" (Some(LaunchResult.Enrolling attempt))
+
+                match f.outbox.sent () with
+                | [ mail ] ->
+                    mail.To |> Expect.equal "the registry's address" "no-pin@stub.example"
+                    mail.Body |> Expect.stringContains "the code" (mailedCode f)
+                    mail.Body |> Expect.stringContains "the lifetime" "15 minutes"
+                | other -> failtest $"expected one mail, got {other.Length}"
             }
 
-            test "withPin sets the PIN and a count of zero (Rule 28)" {
-                let c = Credential.withPin salts "1234"
-                c |> Credential.pinSet |> Expect.isTrue "set"
-                c.WrongCount |> Expect.equal "zero" 0
-                c.PinHash |> Option.map (PinHash.verify "1234") |> Expect.equal "verifies" (Some true)
-            }
+            test "a Prescriber with a PIN, a Reader, an unknown login: as before" {
+                let f = fixture ()
+                let state, cb = hop f seeded launch1 keyA "prescriber"
+                let state, opened = run f state cb
 
-            test "the stub seed: the signing Prescribers have the stub PIN, no-pin has none" {
-                let seed = StubCredentials.seed salts
-
-                for login in [ "prescriber"; "prescriber-other-patient" ] do
-                    seed[login] |> Credential.pinSet |> Expect.isTrue $"{login} set"
-
-                    seed[login].PinHash
-                    |> Option.map (PinHash.verify StubCredentials.stubPin)
-                    |> Expect.equal $"{login} verifies" (Some true)
-
-                seed["no-pin"] |> Credential.pinSet |> Expect.isFalse "no-pin unset"
-                seed |> Map.containsKey "reader" |> Expect.isFalse "a Reader has no credential"
-            }
-
-            test "credentialOf answers the empty credential for a person the store does not know" {
-                Hop.credentialOf "nobody" seeded |> Expect.equal "empty" Credential.empty
-                Hop.credentialOf "no-pin" seeded |> Expect.equal "seeded" Credential.empty
-                Hop.credentialOf "prescriber" seeded |> Credential.pinSet |> Expect.isTrue "seeded with PIN"
-            }
-        ]
-
-
-let standingTests =
-    testList
-        "StubDirectory.standing"
-        [
-            test "the registry answers the mail address and no longer the PIN" {
-                let _, d = fixture ()
-                let code = d.issue "prescriber" "patient-1"
-                let identity = d.idp.redeem code |> Option.get
-
-                match d.registry.standing identity with
-                | Some standing ->
-                    standing.MailAddress |> Expect.equal "address" "prescriber@stub.example"
-                    standing.ActivePatientId |> Expect.equal "active" (Some "patient-1")
-                    standing.User.Role |> Expect.equal "role" UserRole.Prescriber
-                | None -> failtest "expected a standing"
-            }
-
-            test "no-pin is a Prescriber with the launch's patient active" {
-                let _, d = fixture ()
-                let identity = d.issue "no-pin" "patient-1" |> d.idp.redeem |> Option.get
-                let standing = d.registry.standing identity |> Option.get
-                standing.User.Role |> Expect.equal "role" UserRole.Prescriber
-                standing.ActivePatientId |> Expect.equal "active" (Some "patient-1")
-            }
-
-            test "unknown has no standing" {
-                let _, d = fixture ()
-                let identity = d.issue "unknown" "patient-1" |> d.idp.redeem |> Option.get
-                d.registry.standing identity |> Expect.isNone "unknown"
-            }
-        ]
-
-
-let callbackTests =
-    testList
-        "Hop.callback over the credential store"
-        [
-            test "a Prescriber with a PIN opens" {
-                let ids, d = fixture ()
-                let state, cb = hop ids d seeded launch1 keyA "prescriber"
-                let state, result = run ids d state cb
-
-                match result with
-                | CallbackResult.Opened(id, _) ->
-                    state.Sessions[id].Session.User
-                    |> Option.map _.UserId
-                    |> Expect.equal "user" (Some "prescriber")
-                | other -> failtest $"expected Opened, got {other}"
-            }
-
-            test "a Prescriber whose credential has no PIN is refused, as before PR 2 (Rule 25)" {
-                let ids, d = fixture ()
-                let state, cb = hop ids d seeded launch1 keyA "no-pin"
-                let state, result = run ids d state cb
-
-                result
-                |> Expect.equal
-                    "enrolment"
-                    (CallbackResult.Refused(LaunchRefusal.EnrolmentRequired, "/#/session?refused=enrolment"))
-
-                state.Sessions |> Map.isEmpty |> Expect.isTrue "no session (Rule 7)"
-            }
-
-            test "a Prescriber the store does not know at all has no PIN either" {
-                let ids, d = fixture ()
-                let state, cb = hop ids d Hop.emptyState launch1 keyA "prescriber"
-                let _, result = run ids d state cb
-
-                result
-                |> Expect.equal
-                    "enrolment"
-                    (CallbackResult.Refused(LaunchRefusal.EnrolmentRequired, "/#/session?refused=enrolment"))
-            }
-
-            test "a Reader is never asked for a PIN (Rule 26)" {
-                let ids, d = fixture ()
-                let state, cb = hop ids d Hop.emptyState launch1 keyA "reader"
-                let _, result = run ids d state cb
-
-                match result with
+                match opened with
                 | CallbackResult.Opened _ -> ()
                 | other -> failtest $"expected Opened, got {other}"
-            }
 
-            test "a PIN set in the store lets the next launch open" {
-                let ids, d = fixture ()
+                let state, cb = hop f state (mintFor "n-2" "patient-1") keyB "reader"
+                let state, opened = run f state cb
 
-                let state =
-                    { seeded with
-                        Credentials = seeded.Credentials |> Map.add "no-pin" (Credential.withPin salts "2468")
-                    }
-
-                let state, cb = hop ids d state launch1 keyA "no-pin"
-                let _, result = run ids d state cb
-
-                match result with
+                match opened with
                 | CallbackResult.Opened _ -> ()
                 | other -> failtest $"expected Opened, got {other}"
-            }
-        ]
 
-
-let mailTests =
-    testList
-        "StubMail"
-        [
-            test "the outbox lists what was sent, newest first" {
-                let outbox = StubMail.make ()
-                outbox.sent () |> Expect.isEmpty "nothing yet"
-
-                outbox.port.send
-                    {
-                        To = "a@stub.example"
-                        Subject = "first"
-                        Body = "1"
-                    }
-
-                outbox.port.send
-                    {
-                        To = "b@stub.example"
-                        Subject = "second"
-                        Body = "2"
-                    }
-
-                outbox.sent () |> List.map _.Subject |> Expect.equal "newest first" [ "second"; "first" ]
+                let state, cb = hop f state (mintFor "n-3" "patient-1") keyB "unknown"
+                let _, refused = run f state cb
+                refused |> Expect.equal "no role" (CallbackResult.Refused(LaunchRefusal.NoRole, "/#/session?refused=no-role"))
+                f.outbox.sent () |> Expect.isEmpty "no mail for any of them"
             }
 
-            test "the page shows every mail, HTML-encoded, and says when there is none" {
-                StubMail.page [] |> Expect.stringContains "empty" "No mail sent yet"
-
-                let page =
-                    StubMail.page
-                        [
-                            {
-                                To = "a@stub.example"
-                                Subject = "Your code <b>"
-                                Body = "code 123456\n& more"
-                            }
-                        ]
-
-                page |> Expect.stringContains "subject encoded" "Your code &lt;b&gt;"
-                page |> Expect.stringContains "body encoded" "code 123456\n&amp; more"
-                page |> Expect.stringContains "address" "a@stub.example"
-                page.Contains "<script" |> Expect.isFalse "no script"
+            test "a second launch while the code stands gets its own attempt and no second mail (Rule 37, ext 2a)" {
+                let f = fixture ()
+                let state, a1 = suspendVia f seeded launch1 keyA "no-pin"
+                let state, a2 = suspendVia f state (mintFor "n-2" "patient-1") keyB "no-pin"
+                a2 |> Expect.notEqual "another attempt" a1
+                state.Enrolments[a1].PublicKey |> Expect.equal "first keeps its key" keyA
+                state.Enrolments[a2].PublicKey |> Expect.equal "second has its own" keyB
+                state.Codes |> Map.count |> Expect.equal "one code" 1
+                f.outbox.sent () |> List.length |> Expect.equal "one mail" 1
             }
-        ]
 
+            test "a callback reload while the attempt stands is answered with it again (Rule 45)" {
+                let f = fixture ()
+                let state, cb = hop f seeded launch1 keyA "no-pin"
+                let state, first = run f state cb
+                let state2, again = run f state cb
+                again |> Expect.equal "same answer" first
+                state2 |> Expect.equal "same state" state
+                f.outbox.sent () |> List.length |> Expect.equal "still one mail" 1
+            }
 
-let portTests =
-    testList
-        "makeSessionPort over an initial state"
-        [
-            testAsync "the seeded store decides the PIN question" {
-                let ids, d = fixture ()
+            test "a callback reload after the attempt is gone asks for a relaunch" {
+                let f = fixture ()
+                let state, cb = hop f seeded launch1 keyA "no-pin"
+                let state, first = run f state cb
 
-                let port =
-                    Hop.makeSessionPort (fun () -> t0) ids (verifyAt t0) d.idp d.registry StubPatientData.port seeded
-
-                let! redirect = port.present (launch1, keyA)
-
-                let st =
-                    match redirect with
-                    | LaunchResult.RedirectTo(_, st) -> st
+                let attempt =
+                    match first with
+                    | CallbackResult.Enrolling(a, _, _) -> a
                     | other -> failtest $"{other}"
 
-                let! result =
-                    port.callback
-                        {
-                            State = st
-                            StateCookie = Some st
-                            Code = Some(d.issue "no-pin" "patient-1")
-                            Error = None
-                        }
+                // within the Launch lifetime, the attempt dropped: enrolment, relaunch
+                let state = Hop.dropEnrolment attempt state
+                let _, relaunch = run f state cb
+                relaunch |> Expect.equal "enrolment" (CallbackResult.Refused(LaunchRefusal.EnrolmentRequired, "/#/session?refused=enrolment"))
+                // after the code's lifetime the LaunchRecord is long gone too (Rule 29): invalid
+                let late = t0 + Hop.codeLifetime + TimeSpan.FromSeconds 1.0
+                let _, gone = runAt late f state cb
+                gone |> Expect.equal "invalid" (CallbackResult.Refused(LaunchRefusal.LaunchInvalid, "/#/session?refused=invalid"))
+            }
 
-                result
+            test "a retry of the presentation after the suspension is sent to the app" {
+                let f = fixture ()
+                let state, _ = suspendVia f seeded launch1 keyA "no-pin"
+                let _, again = Hop.present t0 f.ids (verifyAt t0) f.d.idp.authorizeUrl state (launch1, keyA)
+
+                match again with
+                | LaunchResult.Enrolling _ -> ()
+                | other -> failtest $"expected Enrolling, got {other}"
+            }
+        ]
+
+
+let findTests =
+    testList
+        "findEnrolment"
+        [
+            test "a standing attempt tells whom and the hinted address" {
+                let f = fixture ()
+                let state, attempt = suspendVia f seeded launch1 keyA "no-pin"
+                let _, pending = Hop.findEnrolment t0 attempt state
+
+                pending
                 |> Expect.equal
-                    "enrolment"
-                    (CallbackResult.Refused(LaunchRefusal.EnrolmentRequired, "/#/session?refused=enrolment"))
+                    "pending"
+                    (Some
+                        {
+                            DisplayName = "Stub Prescriber (no PIN)"
+                            MailHint = "n***@stub.example"
+                        })
+            }
+
+            test "an unknown attempt is nothing" {
+                let _, pending = Hop.findEnrolment t0 "nope" seeded
+                pending |> Expect.isNone "nothing"
+            }
+
+            test "after the code's lifetime the attempt is gone with it" {
+                let f = fixture ()
+                let state, attempt = suspendVia f seeded launch1 keyA "no-pin"
+                let late = t0 + Hop.codeLifetime + TimeSpan.FromSeconds 1.0
+                let state, pending = Hop.findEnrolment late attempt state
+                pending |> Expect.isNone "gone"
+                state.Codes |> Map.isEmpty |> Expect.isTrue "code dropped"
+                state.Enrolments |> Map.isEmpty |> Expect.isTrue "attempt dropped"
+            }
+        ]
+
+
+let supplyTests =
+    testList
+        "supplyPin"
+        [
+            test "the right code and a PIN: set with a count of zero, both dropped, told, and open on the attempt's key (Rules 37, 40, 28, 27)" {
+                let f = fixture ()
+                let state, attempt = suspendVia f seeded launch1 keyA "no-pin"
+                let code = mailedCode f
+                let state, result = supply f state attempt code "2468"
+
+                match result with
+                | SupplyPinResult.Opened(id, session) ->
+                    session.User |> Option.map _.UserId |> Expect.equal "user" (Some "no-pin")
+                    session.User |> Option.map _.Role |> Expect.equal "role" (Some UserRole.Prescriber)
+                    session.PatientContext |> Option.map _.PatientId |> Expect.equal "patient" (Some "patient-1")
+                    session.KeyThumbprint |> Expect.equal "the attempt's key" (Some(PublicKey.thumbprint keyA))
+                    state.Sessions |> Map.containsKey id |> Expect.isTrue "open"
+                | other -> failtest $"expected Opened, got {other}"
+
+                let credential = state.Credentials["no-pin"]
+                credential.PinHash |> Option.map (PinHash.verify "2468") |> Expect.equal "the PIN" (Some true)
+                credential.WrongCount |> Expect.equal "zero" 0
+                state.Codes |> Map.isEmpty |> Expect.isTrue "code dropped"
+                state.Enrolments |> Map.isEmpty |> Expect.isTrue "attempt dropped"
+
+                match f.outbox.sent () with
+                | [ second; first ] ->
+                    first.Subject |> Expect.stringContains "first" "confirmation code"
+                    second.Subject |> Expect.stringContains "second" "PIN was set"
+                    second.To |> Expect.equal "the registry's address, fresh" "no-pin@stub.example"
+                | other -> failtest $"expected two mails, got {other.Length}"
+            }
+
+            test "the next launch of that person opens directly" {
+                let f = fixture ()
+                let state, attempt = suspendVia f seeded launch1 keyA "no-pin"
+                let state, _ = supply f state attempt (mailedCode f) "2468"
+                let state, cb = hop f state (mintFor "n-2" "patient-1") keyB "no-pin"
+                let _, result = run f state cb
+
+                match result with
+                | CallbackResult.Opened _ -> ()
+                | other -> failtest $"expected Opened, got {other}"
+            }
+
+            test "two attempts on one code: whichever supplies opens on its own key, and the other is gone" {
+                let f = fixture ()
+                let state, a1 = suspendVia f seeded launch1 keyA "no-pin"
+                let state, a2 = suspendVia f state (mintFor "n-2" "patient-1") keyB "no-pin"
+                let state, result = supply f state a2 (mailedCode f) "2468"
+
+                match result with
+                | SupplyPinResult.Opened(_, session) ->
+                    session.KeyThumbprint |> Expect.equal "the second browser's key" (Some(PublicKey.thumbprint keyB))
+                | other -> failtest $"expected Opened, got {other}"
+
+                let _, first = supply f state a1 (mailedCode f) "2468"
+                first |> Expect.equal "the first attempt is gone" (SupplyPinResult.Refused PinRefusal.AttemptExpired)
+            }
+
+            test "a wrong code counts; the third voids the code for every attempt (ext 2b)" {
+                let f = fixture ()
+                let state, a1 = suspendVia f seeded launch1 keyA "no-pin"
+                let state, a2 = suspendVia f state (mintFor "n-2" "patient-1") keyB "no-pin"
+                let state, r1 = supply f state a1 "000000" "2468"
+                r1 |> Expect.equal "two left" (SupplyPinResult.Refused(PinRefusal.WrongCode 2))
+                let state, r2 = supply f state a2 "000000" "2468"
+                r2 |> Expect.equal "one left, counted across attempts" (SupplyPinResult.Refused(PinRefusal.WrongCode 1))
+                let state, r3 = supply f state a1 "000000" "2468"
+                r3 |> Expect.equal "void" (SupplyPinResult.Refused PinRefusal.CodeVoid)
+                state.Codes |> Map.isEmpty |> Expect.isTrue "code dropped"
+                state.Enrolments |> Map.isEmpty |> Expect.isTrue "both attempts dropped"
+                state.Credentials["no-pin"] |> Credential.pinSet |> Expect.isFalse "no PIN set"
+                let _, r4 = supply f state a2 (mailedCode f) "2468"
+                r4 |> Expect.equal "even the right code is too late" (SupplyPinResult.Refused PinRefusal.AttemptExpired)
+                f.outbox.sent () |> List.length |> Expect.equal "no second mail" 1
+            }
+
+            test "a fresh launch after a void code mails a fresh one" {
+                let f = fixture ()
+                let state, a1 = suspendVia f seeded launch1 keyA "no-pin"
+                let state, _ = supply f state a1 "000000" "2468"
+                let state, _ = supply f state a1 "000000" "2468"
+                let state, _ = supply f state a1 "000000" "2468"
+                let state, a2 = suspendVia f state (mintFor "n-2" "patient-1") keyB "no-pin"
+                f.outbox.sent () |> List.length |> Expect.equal "two mails" 2
+                let _, result = supply f state a2 (mailedCode f) "2468"
+
+                match result with
+                | SupplyPinResult.Opened _ -> ()
+                | other -> failtest $"expected Opened, got {other}"
+            }
+
+            test "a PIN without the format spends no try" {
+                let f = fixture ()
+                let state, attempt = suspendVia f seeded launch1 keyA "no-pin"
+                let state, result = supply f state attempt (mailedCode f) "12"
+                result |> Expect.equal "format" (SupplyPinResult.Refused PinRefusal.PinFormat)
+                state.Codes["no-pin"].Tries |> Expect.equal "no try spent" 0
+                let _, ok = supply f state attempt (mailedCode f) "1234"
+
+                match ok with
+                | SupplyPinResult.Opened _ -> ()
+                | other -> failtest $"expected Opened, got {other}"
+            }
+
+            test "an expired code is refused and dropped with its attempts" {
+                let f = fixture ()
+                let state, attempt = suspendVia f seeded launch1 keyA "no-pin"
+                let code = mailedCode f
+                let late = t0 + Hop.codeLifetime + TimeSpan.FromSeconds 1.0
+                let state, result = supplyAt late f state attempt code "2468"
+                result |> Expect.equal "expired" (SupplyPinResult.Refused PinRefusal.AttemptExpired)
+                state.Codes |> Map.isEmpty |> Expect.isTrue "code dropped"
+                state.Enrolments |> Map.isEmpty |> Expect.isTrue "attempt dropped"
+                state.Credentials["no-pin"] |> Credential.pinSet |> Expect.isFalse "no PIN set"
+            }
+
+            test "an unknown attempt is expired" {
+                let _, result = supply (fixture ()) seeded "nope" "123456" "2468"
+                result |> Expect.equal "expired" (SupplyPinResult.Refused PinRefusal.AttemptExpired)
+            }
+
+            test "the PIN-set mail falls back on the code's address when the registry cannot answer" {
+                let f = fixture ()
+                let state, attempt = suspendVia f seeded launch1 keyA "no-pin"
+                let code = mailedCode f
+
+                let _, result =
+                    Hop.supplyPin t0 f.ids salts codeMac (fun _ -> None) StubPatientData.port.read f.outbox.port.send attempt code "2468" state
+
+                match result with
+                | SupplyPinResult.Opened _ -> ()
+                | other -> failtest $"expected Opened, got {other}"
+
+                (f.outbox.sent () |> List.head).To |> Expect.equal "the code's address" "no-pin@stub.example"
+            }
+
+            test "the open closes the person's other Sessions (Rule 8)" {
+                let f = fixture ()
+                // a PIN set by an earlier enrolment, then a Session, then a launch that... cannot
+                // suspend any more. So: enrol in one browser while another Session of the same
+                // person, opened before the PIN existed, cannot exist. The Rule 8 close still
+                // runs in the same act; exercise it with a seeded prescriber turned no-pin.
+                let state =
+                    { seeded with
+                        Credentials = seeded.Credentials |> Map.add "prescriber" Credential.empty
+                    }
+
+                let state, a = suspendVia f state launch1 keyA "prescriber"
+                let state, _ = supply f state a (mailedCode f) "2468"
+                let state, cb = hop f state (mintFor "n-2" "patient-1") keyB "prescriber"
+                let state, second = run f state cb
+
+                match second with
+                | CallbackResult.Opened(id2, _) ->
+                    state.Sessions |> Map.count |> Expect.equal "one Session" 1
+                    state.Sessions |> Map.containsKey id2 |> Expect.isTrue "the newer"
+                    state.Endings |> Map.count |> Expect.equal "the older marked" 1
+                | other -> failtest $"expected Opened, got {other}"
+            }
+        ]
+
+
+let dropTests =
+    testList
+        "dropEnrolment"
+        [
+            test "the last attempt takes the code along; another attempt keeps it" {
+                let f = fixture ()
+                let state, a1 = suspendVia f seeded launch1 keyA "no-pin"
+                let state, a2 = suspendVia f state (mintFor "n-2" "patient-1") keyB "no-pin"
+                let state = Hop.dropEnrolment a1 state
+                state.Codes |> Map.containsKey "no-pin" |> Expect.isTrue "code stands for a2"
+                let state = Hop.dropEnrolment a2 state
+                state.Codes |> Map.isEmpty |> Expect.isTrue "code gone with the last attempt"
+                Hop.dropEnrolment "nope" state |> Expect.equal "unknown is nothing" state
+            }
+        ]
+
+
+/// In-memory cookies: what the browser would hold.
+let memoryCookie (initial: string option) =
+    let value = ref initial
+
+    {
+        SessionCookie.read = fun () -> value.Value
+        write = fun id -> value.Value <- Some id
+        delete = fun () -> value.Value <- None
+    },
+    value
+
+
+let memoryStateCookie (initial: string option) =
+    let value = ref initial
+
+    {
+        LaunchStateCookie.read = fun state -> value.Value |> Option.filter ((=) state)
+        write = fun state -> value.Value <- Some state
+    },
+    value
+
+
+let memoryEnrolmentCookie (initial: string option) =
+    let value = ref initial
+    let until = ref None
+
+    {
+        EnrolmentCookie.read = fun () -> value.Value
+        write =
+            fun attempt u ->
+                value.Value <- Some attempt
+                until.Value <- Some u
+        delete = fun () -> value.Value <- None
+    },
+    value,
+    until
+
+
+let makePort (f: Fixture) =
+    Hop.makeSessionPort
+        (fun () -> t0)
+        f.ids
+        f.newCode
+        salts
+        codeMac
+        (verifyAt t0)
+        f.d.idp
+        f.d.registry
+        StubPatientData.port
+        f.outbox.port
+        seeded
+
+
+/// Runs the hop for `choice` through the composition root, returning the redirect.
+let openVia (f: Fixture) port cookie stateCookie enrolment launch key choice =
+    async {
+        let! outcome =
+            CompositionRoot.processLaunch port cookie stateCookie (LaunchCommand.PresentLaunch(launch, key))
+
+        match outcome with
+        | LaunchOutcome.RedirectTo url ->
+            let state = url.Substring(url.IndexOf "state=" + 6) |> Uri.UnescapeDataString
+
+            let cb: Callback =
+                {
+                    State = state
+                    StateCookie = None
+                    Code = Some(f.d.issue choice "patient-1")
+                    Error = None
+                }
+
+            return! CompositionRoot.processCallback port cookie stateCookie enrolment cb
+        | other -> return failtest $"expected RedirectTo, got {other}"
+    }
+
+
+let compositionTests =
+    testList
+        "composition root"
+        [
+            testAsync "no-pin: the callback sets the enrolment cookie, GetSession tells the pending enrolment, SupplyPin opens and swaps the cookies" {
+                let f = fixture ()
+                let port = makePort f
+                let cookie, held = memoryCookie None
+                let stateCookie, _ = memoryStateCookie None
+                let enrolment, attempt, until = memoryEnrolmentCookie None
+                let! redirect = openVia f port cookie stateCookie enrolment launch1 keyA "no-pin"
+                redirect |> Expect.equal "to the app" "/#/session"
+                held.Value |> Expect.isNone "no session cookie"
+                attempt.Value |> Expect.isSome "enrolment cookie"
+                until.Value |> Expect.equal "until the code expires" (Some(t0 + Hop.codeLifetime))
+
+                let! pending = CompositionRoot.processSession port cookie enrolment SessionCommand.GetSession
+
+                pending
+                |> Expect.equal
+                    "pending"
+                    (SessionResponse.EnrolmentPending
+                        {
+                            DisplayName = "Stub Prescriber (no PIN)"
+                            MailHint = "n***@stub.example"
+                        })
+
+                let! wrong = CompositionRoot.processSession port cookie enrolment (SessionCommand.SupplyPin("000000", "2468"))
+                wrong |> Expect.equal "wrong code" (SessionResponse.PinRefused(PinRefusal.WrongCode 2))
+                attempt.Value |> Expect.isSome "cookie kept"
+
+                let! opened =
+                    CompositionRoot.processSession port cookie enrolment (SessionCommand.SupplyPin(mailedCode f, "2468"))
+
+                match opened with
+                | SessionResponse.SessionResp(Some session) ->
+                    session.User |> Option.map _.UserId |> Expect.equal "user" (Some "no-pin")
+                | other -> failtest $"expected SessionResp, got {other}"
+
+                held.Value |> Expect.isSome "session cookie set"
+                attempt.Value |> Expect.isNone "enrolment cookie deleted"
+
+                let! found = CompositionRoot.processSession port cookie enrolment SessionCommand.GetSession
+
+                match found with
+                | SessionResponse.SessionResp(Some _) -> ()
+                | other -> failtest $"expected the Session, got {other}"
+            }
+
+            testAsync "a void code deletes the enrolment cookie; a gone attempt at GetSession does too" {
+                let f = fixture ()
+                let port = makePort f
+                let cookie, _ = memoryCookie None
+                let stateCookie, _ = memoryStateCookie None
+                let enrolment, attempt, _ = memoryEnrolmentCookie None
+                let! _ = openVia f port cookie stateCookie enrolment launch1 keyA "no-pin"
+
+                for _ in 1..2 do
+                    let! _ = CompositionRoot.processSession port cookie enrolment (SessionCommand.SupplyPin("000000", "2468"))
+                    ()
+
+                let! void' = CompositionRoot.processSession port cookie enrolment (SessionCommand.SupplyPin("000000", "2468"))
+                void' |> Expect.equal "void" (SessionResponse.PinRefused PinRefusal.CodeVoid)
+                attempt.Value |> Expect.isNone "cookie deleted"
+
+                let stale, attemptRef, _ = memoryEnrolmentCookie (Some "gone")
+                let! nothing = CompositionRoot.processSession port cookie stale SessionCommand.GetSession
+                nothing |> Expect.equal "nothing" (SessionResponse.SessionResp None)
+                attemptRef.Value |> Expect.isNone "stale cookie deleted"
+            }
+
+            testAsync "SupplyPin without an enrolment cookie is expired; CloseSession while enrolling drops the attempt and the cookie" {
+                let f = fixture ()
+                let port = makePort f
+                let cookie, _ = memoryCookie None
+                let stateCookie, _ = memoryStateCookie None
+                let none, _, _ = memoryEnrolmentCookie None
+                let! expired = CompositionRoot.processSession port cookie none (SessionCommand.SupplyPin("123456", "2468"))
+                expired |> Expect.equal "expired" (SessionResponse.PinRefused PinRefusal.AttemptExpired)
+
+                let enrolment, attempt, _ = memoryEnrolmentCookie None
+                let! _ = openVia f port cookie stateCookie enrolment launch1 keyA "no-pin"
+                let! closed = CompositionRoot.processSession port cookie enrolment SessionCommand.CloseSession
+                closed |> Expect.equal "closed" SessionResponse.SessionClosed
+                attempt.Value |> Expect.isNone "cookie deleted"
+                let stale, _, _ = memoryEnrolmentCookie (Some "id-2")
+                let! nothing = CompositionRoot.processSession port cookie stale SessionCommand.GetSession
+                nothing |> Expect.equal "the attempt is gone" (SessionResponse.SessionResp None)
+            }
+
+            testAsync "the Session wins over a stale enrolment cookie" {
+                let f = fixture ()
+                let port = makePort f
+                let cookie, _ = memoryCookie None
+                let stateCookie, _ = memoryStateCookie None
+                let enrolment, _, _ = memoryEnrolmentCookie (Some "stale")
+                let! _ = openVia f port cookie stateCookie enrolment launch1 keyA "prescriber"
+                let! found = CompositionRoot.processSession port cookie enrolment SessionCommand.GetSession
+
+                match found with
+                | SessionResponse.SessionResp(Some _) -> ()
+                | other -> failtest $"expected the Session, got {other}"
+            }
+
+            testAsync "the disabled port refuses to enrol" {
+                let cookie, _ = memoryCookie None
+                let enrolment, attempt, _ = memoryEnrolmentCookie (Some "any")
+
+                let! refused =
+                    CompositionRoot.processSession sessionDisabled cookie enrolment (SessionCommand.SupplyPin("123456", "2468"))
+
+                refused |> Expect.equal "expired" (SessionResponse.PinRefused PinRefusal.AttemptExpired)
+                attempt.Value |> Expect.isNone "cookie deleted"
             }
         ]
 
 
 let tests =
     testList
-        "Enrolment PR 1"
+        "Enrolment PR 2"
         [
-            pinHashTests
-            credentialTests
-            standingTests
-            callbackTests
-            mailTests
-            portTests
+            helperTests
+            suspendTests
+            findTests
+            supplyTests
+            dropTests
+            compositionTests
         ]
 
 

--- a/src/Informedica.GenPRES.Server/Scripts/Enrolment.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/Enrolment.fsx
@@ -46,14 +46,17 @@ type EnrolmentPending =
     }
 
 
-/// Why a supplied PIN did not set (UC-2 ext 2b). `WrongCode` leaves the form open with the
-/// tries left; `CodeVoid` and `AttemptExpired` are terminal: the launch has to start over.
+/// Why a supplied PIN opened no Session (UC-2 ext 2b). `WrongCode` leaves the form open with
+/// the tries left; `PinFormat` spends no try; `CodeVoid` and `AttemptExpired` are terminal:
+/// the launch has to start over. `WrongActivePatient` is terminal too, and the PIN is set:
+/// the registry no longer has the launch's Patient active (Rule 6).
 [<RequireQualifiedAccess>]
 type PinRefusal =
     | WrongCode of attemptsLeft: int
     | CodeVoid
     | AttemptExpired
     | PinFormat
+    | WrongActivePatient
 
 
 [<RequireQualifiedAccess>]
@@ -547,7 +550,8 @@ module Hop =
     /// voids the code for every attempt (ext 2b); else one act (Rules 37, 40): the PIN is set
     /// with a count of zero (Rule 28), the code and its attempts are dropped, the User is
     /// told (Rule 27, at the address the registry answers now, else the one the code went to),
-    /// and the launch continues at 5.5 to 5.7 on the supplying attempt's key.
+    /// and the launch continues at 5.5 to 5.7 on the supplying attempt's key, with the Role the
+    /// registry answers now and only if the launch's Patient is still the active one (Rule 6).
     let supplyPin
         (now: DateTime)
         (newId: unit -> string)
@@ -590,12 +594,24 @@ module Hop =
                         DisplayName = e.DisplayName
                     }
 
-                // Rule 27: the address, asked fresh on the request that sends the mail; the
-                // code's address when the registry cannot answer (uc-02, last bullet)
+                // 5.3 again, fresh: the address for the mail (Rule 27), the Role re-taken and
+                // the active Patient (Rule 6), because the registry may have moved on during
+                // the wait. When it cannot answer, the code settles the PIN (Rule 37, uc-02 last
+                // bullet) and the launch continues on what it had.
+                let fresh = standing identity
+
                 let address =
-                    standing identity
-                    |> Option.map _.MailAddress
-                    |> Option.defaultValue pending.MailAddress
+                    fresh |> Option.map _.MailAddress |> Option.defaultValue pending.MailAddress
+
+                let user =
+                    fresh
+                    |> Option.map _.User
+                    |> Option.defaultValue
+                        {
+                            UserId = e.UserId
+                            DisplayName = e.DisplayName
+                            Role = UserRole.Prescriber
+                        }
 
                 let subject, body = Mails.pinSet e.DisplayName
 
@@ -606,23 +622,22 @@ module Hop =
                         Body = body
                     }
 
-                let user =
-                    {
-                        UserId = e.UserId
-                        DisplayName = e.DisplayName
-                        Role = UserRole.Prescriber
-                    }
-
                 let state =
                     { state with
                         Credentials = state.Credentials |> Map.add e.UserId (Credential.withPin newSalt pin)
                     }
                     |> dropCode e.UserId
 
-                let state, (id, session) =
-                    openWith now newId patientData e.PatientId e.PublicKey user state
+                match fresh with
+                | Some s when s.ActivePatientId <> Some e.PatientId ->
+                    // the PIN is set and told; no Session opens for a Patient that is no longer
+                    // the active one (Rule 6): a relaunch is asked for
+                    state, SupplyPinResult.Refused PinRefusal.WrongActivePatient
+                | _ ->
+                    let state, (id, session) =
+                        openWith now newId patientData e.PatientId e.PublicKey user state
 
-                state, SupplyPinResult.Opened(id, session)
+                    state, SupplyPinResult.Opened(id, session)
 
 
     let find (id: string) (state: State) : State * SessionLookup =
@@ -778,6 +793,14 @@ module CompositionRoot =
                 cookie.write id
                 return redirect
             | CallbackResult.Enrolling(attempt, redirect, until) ->
+                // the new launch replaces whatever Session this browser still held, as an open
+                // would (session-endings: ReplacedInBrowser owes nothing); left in place, its
+                // cookie would hide the enrolment at the next GetSession
+                match cookie.read () with
+                | Some id -> do! session.close id
+                | None -> ()
+
+                cookie.delete ()
                 enrolment.write attempt until
                 return redirect
             | CallbackResult.Refused(_, redirect)
@@ -827,7 +850,8 @@ module CompositionRoot =
                         cookie.write id
                         return SessionResponse.SessionResp(Some opened)
                     | SupplyPinResult.Refused(PinRefusal.CodeVoid as refusal)
-                    | SupplyPinResult.Refused(PinRefusal.AttemptExpired as refusal) ->
+                    | SupplyPinResult.Refused(PinRefusal.AttemptExpired as refusal)
+                    | SupplyPinResult.Refused(PinRefusal.WrongActivePatient as refusal) ->
                         enrolment.delete ()
                         return SessionResponse.PinRefused refusal
                     | SupplyPinResult.Refused refusal -> return SessionResponse.PinRefused refusal
@@ -1273,6 +1297,39 @@ let supplyTests =
                 result |> Expect.equal "expired" (SupplyPinResult.Refused PinRefusal.AttemptExpired)
             }
 
+            test "the registry is asked again at the supply: the Role is re-taken, another active Patient sets the PIN but opens nothing (Rule 6)" {
+                let f = fixture ()
+                let state, attempt = suspendVia f seeded launch1 keyA "no-pin"
+                let code = mailedCode f
+
+                let moved identity =
+                    f.d.registry.standing identity
+                    |> Option.map (fun s -> { s with ActivePatientId = Some "other-patient" })
+
+                let state, result =
+                    Hop.supplyPin t0 f.ids salts codeMac moved StubPatientData.port.read f.outbox.port.send attempt code "2468" state
+
+                result |> Expect.equal "no Session" (SupplyPinResult.Refused PinRefusal.WrongActivePatient)
+                state.Sessions |> Map.isEmpty |> Expect.isTrue "nothing opened"
+                state.Credentials["no-pin"] |> Credential.pinSet |> Expect.isTrue "the PIN is set (Rule 37)"
+                state.Codes |> Map.isEmpty |> Expect.isTrue "code dropped"
+                f.outbox.sent () |> List.length |> Expect.equal "told" 2
+
+                let state, attempt = suspendVia f seeded launch1 keyA "no-pin"
+
+                let reader identity =
+                    f.d.registry.standing identity
+                    |> Option.map (fun s -> { s with User = { s.User with Role = UserRole.Reader } })
+
+                let _, result =
+                    Hop.supplyPin t0 f.ids salts codeMac reader StubPatientData.port.read f.outbox.port.send attempt (mailedCode f) "2468" state
+
+                match result with
+                | SupplyPinResult.Opened(_, session) ->
+                    session.User |> Option.map _.Role |> Expect.equal "the fresh Role" (Some UserRole.Reader)
+                | other -> failtest $"expected Opened, got {other}"
+            }
+
             test "the PIN-set mail falls back on the code's address when the registry cannot answer" {
                 let f = fixture ()
                 let state, attempt = suspendVia f seeded launch1 keyA "no-pin"
@@ -1509,6 +1566,28 @@ let compositionTests =
                 match found with
                 | SessionResponse.SessionResp(Some _) -> ()
                 | other -> failtest $"expected the Session, got {other}"
+            }
+
+            testAsync "an enrolling callback replaces the Session this browser still held" {
+                let f = fixture ()
+                let port = makePort f
+                let cookie, held = memoryCookie None
+                let stateCookie, _ = memoryStateCookie None
+                let enrolment, attempt, _ = memoryEnrolmentCookie None
+                let! _ = openVia f port cookie stateCookie enrolment launch1 keyA "prescriber"
+                let old = held.Value
+                old |> Expect.isSome "a Session"
+                let! _ = openVia f port cookie stateCookie enrolment (mintFor "n-2" "patient-1") keyB "no-pin"
+                held.Value |> Expect.isNone "session cookie gone"
+                attempt.Value |> Expect.isSome "enrolment cookie"
+                let! pending = CompositionRoot.processSession port cookie enrolment SessionCommand.GetSession
+
+                match pending with
+                | SessionResponse.EnrolmentPending _ -> ()
+                | other -> failtest $"expected EnrolmentPending, got {other}"
+
+                let! gone = port.find old.Value
+                gone |> Expect.equal "the old Session is closed" SessionLookup.NotFound
             }
 
             testAsync "the disabled port refuses to enrol" {

--- a/src/Informedica.GenPRES.Server/Server.fs
+++ b/src/Informedica.GenPRES.Server/Server.fs
@@ -349,6 +349,45 @@ module Http =
         }
 
 
+    let enrolmentCookieName = "genpres_enrolment"
+
+
+    /// The enrolment cookie (UC-2): the attempt a suspended launch left in this browser. HttpOnly
+    /// and Strict (only the app's own calls carry it), Path=/, Max-Age what remains of the
+    /// confirmation code's lifetime, Secure over HTTPS. Not a bearer for anything without the
+    /// mailed code.
+    let enrolmentCookieOptions (isHttps: bool) (now: System.DateTime) (until: System.DateTime) =
+        CookieOptions(
+            HttpOnly = true,
+            Secure = isHttps,
+            SameSite = SameSiteMode.Strict,
+            Path = "/",
+            MaxAge = (if until > now then until - now else System.TimeSpan.Zero)
+        )
+
+
+    /// The enrolment cookie of this request as the port the composition root uses.
+    let enrolmentCookie (ctx: HttpContext) : EnrolmentCookie =
+        {
+            read =
+                fun () ->
+                    match ctx.Request.Cookies.TryGetValue enrolmentCookieName with
+                    | true, value when not (System.String.IsNullOrWhiteSpace value) -> Some value
+                    | _ -> None
+            write =
+                fun attempt until ->
+                    ctx.Response.Cookies.Append(
+                        enrolmentCookieName,
+                        attempt,
+                        enrolmentCookieOptions ctx.Request.IsHttps System.DateTime.UtcNow until
+                    )
+            delete =
+                fun () ->
+                    let now = System.DateTime.UtcNow
+                    ctx.Response.Cookies.Delete(enrolmentCookieName, enrolmentCookieOptions ctx.Request.IsHttps now now)
+        }
+
+
     /// The session cookie of this request as the port the composition root uses.
     let sessionCookie (ctx: HttpContext) : SessionCookie =
         {
@@ -617,7 +656,7 @@ module Host =
         let mail = StubMail.make ()
 
         let env =
-            let env = Adapters.makeAppEnvWith launchKey directory provider
+            let env = Adapters.makeAppEnvWith launchKey directory mail.port provider
 
             // Stop-gap until the scope switch (#580): a production server never opens a
             // stub Session. Drop this swap when #580 decides what production exposes.
@@ -632,7 +671,12 @@ module Host =
         let webApi =
             Remoting.createApi ()
             |> Remoting.fromContext (fun ctx ->
-                createServerApi serverSettings env (Http.sessionCookie ctx) (Http.launchStateCookie ctx)
+                createServerApi
+                    serverSettings
+                    env
+                    (Http.sessionCookie ctx)
+                    (Http.launchStateCookie ctx)
+                    (Http.enrolmentCookie ctx)
             )
             |> Remoting.withRouteBuilder routerPaths
             |> Remoting.buildHttpHandler
@@ -725,7 +769,12 @@ module Host =
                         }
 
                     let! redirect =
-                        CompositionRoot.processCallback env (Http.sessionCookie ctx) (Http.launchStateCookie ctx) cb
+                        CompositionRoot.processCallback
+                            env
+                            (Http.sessionCookie ctx)
+                            (Http.launchStateCookie ctx)
+                            (Http.enrolmentCookie ctx)
+                            cb
 
                     return! redirectTo false redirect next ctx
                 }

--- a/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
@@ -261,11 +261,44 @@ module Credential =
         }
 
 
+module Pin =
+
+    /// Four to six digits. V8 names no format; this is the assumption plan 615 records.
+    let isValid (pin: string) =
+        not (isNull pin)
+        && pin.Length >= 4
+        && pin.Length <= 6
+        && pin |> Seq.forall Char.IsAsciiDigit
+
+
+module MailHint =
+
+    /// `n***@stub.example`: enough for the User to know which mailbox, not enough for a
+    /// shoulder to read the address.
+    let ofAddress (address: string) =
+        match address.IndexOf '@' with
+        | i when i > 0 -> $"{address[0]}***{address.Substring i}"
+        | _ -> "***"
+
+
+/// The two mails of UC-2 (Rule 27). English only; the mail language is a later concern.
+module Mails =
+
+    let confirmationCode (displayName: string) (code: string) (minutes: int) : string * string =
+        "GenPRES: your confirmation code",
+        $"Hello {displayName},\n\nYour confirmation code is {code}. It is valid for {minutes} minutes. Enter it in GenPRES together with the PIN of your choice.\n\nIf you did not open GenPRES just now, somebody tried to enrol in your name; nothing was set."
+
+
+    let pinSet (displayName: string) : string * string =
+        "GenPRES: your PIN was set",
+        $"Hello {displayName},\n\nA PIN was set for your GenPRES account just now. If that was not you, tell your administrator."
+
+
 /// Launch steps 4 and 5 over server-hosted stubs (plan 605): the LaunchRecord keyed by the
 /// nonce (4.2), the redirect to the IdentityProvider, the callback (4.5) with the step-5 ladder,
-/// the Rule 45 replay and the Rule 40 single act with the Rule 8 closes, and the credential
-/// half of the Database (plan 615). Pure over a state record; `makeSessionPort` wraps it in a
-/// lock over the three actor ports.
+/// the Rule 45 replay and the Rule 40 single act with the Rule 8 closes; the credential half of
+/// the Database and the suspended launch of UC-2 (plan 615). Pure over a state record;
+/// `makeSessionPort` wraps it in a lock over the actor ports.
 module Hop =
 
     /// The refusal words of `#/session?refused=<word>`; the client's `parseRefusal` reads them.
@@ -286,8 +319,41 @@ module Hop =
         $"/#/session?refused={refusalWord refusal}"
 
 
-    /// One record per Launch (4.2), keyed by the nonce (Rule 2) and found by the `state` at the
-    /// callback. The outcome is appended once (Rule 45); the record is dropped whole at expiry.
+    /// A Session as the store holds it: what the client learns, plus the login it belongs to
+    /// (Rule 8: a User has at most one open Session).
+    type SessionRecord =
+        {
+            Session: SessionOpened
+            Login: string option
+        }
+
+
+    /// A confirmation code as the Database keeps it (Rule 37, "the code as a mac"): one per
+    /// credential, with the address it went to, its expiry and the wrong tries so far.
+    type PendingCode =
+        {
+            UserId: string
+            MailAddress: string
+            CodeMac: byte[]
+            Expiry: DateTime
+            Tries: int
+        }
+
+
+    /// One suspended launch (UC-2): what the open needs once the PIN is set, and the public key
+    /// of the browser that made it, so the Session opens on the key the supplying browser holds.
+    /// No lifetime of its own: it lives as long as the code it is bound to.
+    type Enrolment =
+        {
+            Attempt: string
+            UserId: string
+            Login: string
+            DisplayName: string
+            PatientId: string
+            PublicKey: PublicKey
+        }
+
+
     type LaunchRecord =
         {
             Nonce: string
@@ -299,27 +365,16 @@ module Hop =
         }
 
 
-    /// A Session as the store holds it: what the client learns, plus the login it belongs to
-    /// (Rule 8: a User has at most one open Session).
-    type SessionRecord =
-        {
-            Session: SessionOpened
-            Login: string option
-        }
-
-
     type State =
         {
             Launches: Map<string, LaunchRecord>
             Sessions: Map<string, SessionRecord>
-            // sessions ended by the server, told once at the next GetSession (Rule 11, PR 4)
-            // sessions the server ended, with the moment: told at every GetSession that still
-            // carries their cookie (Rule 11), dropped when the client acknowledges with
-            // CloseSession. Kept as long as the Sessions are (Rule 10 will bound both).
             Endings: Map<string, SessionEnding * DateTime>
-            // the credential per person (Concept 7): read at 5.4 (Rule 24), written by
-            // enrolment (UC-2)
             Credentials: Map<string, Credential>
+            // UC-2: the live confirmation code per person
+            Codes: Map<string, PendingCode>
+            // UC-2: the suspended launches by attempt
+            Enrolments: Map<string, Enrolment>
         }
 
 
@@ -329,38 +384,44 @@ module Hop =
             Sessions = Map.empty
             Endings = Map.empty
             Credentials = Map.empty
+            Codes = Map.empty
+            Enrolments = Map.empty
         }
 
 
-    /// The state a host starts from: the credentials it was seeded with (the stub's, or a
-    /// store's read once the Database exists), nothing else.
     let initialState (credentials: Map<string, Credential>) =
         { emptyState with Credentials = credentials }
 
 
-    /// Rule 24, uc-02 `ReadCredential`: the credential of a person, or an empty one.
+    /// How long a confirmation code lives: a mail round trip, not Rule 30's gap. Bounds the
+    /// half-finished launch too (plan 615's deviation from the model).
+    let codeLifetime = TimeSpan.FromMinutes 15.0
+
+    /// Wrong codes before the code is void (ext 2b).
+    let maxTries = 3
+
+
     let credentialOf (userId: string) (state: State) =
         state.Credentials |> Map.tryFind userId |> Option.defaultValue Credential.empty
 
 
     let private dropExpired (now: DateTime) (state: State) =
-        { state with Launches = state.Launches |> Map.filter (fun _ r -> now <= r.Expiry) }
+        let codes = state.Codes |> Map.filter (fun _ c -> now <= c.Expiry)
+
+        { state with
+            Launches = state.Launches |> Map.filter (fun _ r -> now <= r.Expiry)
+            Codes = codes
+            // an attempt lives as long as its code
+            Enrolments = state.Enrolments |> Map.filter (fun _ e -> codes |> Map.containsKey e.UserId)
+        }
 
 
-    /// The answer `present` gives for a record: the recorded outcome, else the redirect again.
     let private answerOf (authorizeUrl: string -> string) (record: LaunchRecord) =
         match record.Outcome with
         | Some outcome -> outcome
         | None -> LaunchResult.RedirectTo(authorizeUrl record.State, record.State)
 
 
-    /// Step 4.1 and 4.2. Pure over the state; the clock, the id source, the verifier and the
-    /// IdentityProvider's url are parameters.
-    ///
-    /// - not sealed under the key, or past its expiry: refused, nothing recorded (Rules 3, 29);
-    /// - a record under the nonce: the same public key gets the recorded answer, or the redirect
-    ///   again while the hop is still open (Rule 2, uc-01 Retries); another key is LaunchSpent;
-    /// - a new nonce appends the record and sends the browser to the IdentityProvider.
     let present
         (now: DateTime)
         (newId: unit -> string)
@@ -392,33 +453,34 @@ module Hop =
                 { state with Launches = state.Launches |> Map.add claims.Nonce record }, answerOf authorizeUrl record
 
 
-    /// Step 5.7, one act (Rule 40): the Session is written, the login's other Sessions are
-    /// closed and marked (Rule 8), the outcome is appended to the record.
-    let private openSession
+    /// Step 5.7, one act (Rule 40), from whatever carried the launch this far: a LaunchRecord
+    /// at the callback, an Enrolment once the PIN is set. The Session is written, the login's
+    /// other Sessions are closed and marked (Rule 8).
+    let private openWith
         (now: DateTime)
         (newId: unit -> string)
         (patientData: string -> Patient option)
-        (record: LaunchRecord)
-        (standing: UserStanding)
+        (patientId: string)
+        (key: PublicKey)
+        (user: UserContext)
         (state: State)
         =
         let id = newId ()
 
         let session =
             {
-                User = Some standing.User
+                User = Some user
                 PatientContext =
                     Some
                         {
-                            PatientId = record.PatientId
-                            // ext 6a: no imported data is not a refusal
-                            Patient = patientData record.PatientId |> Option.defaultValue Shared.Models.Patient.empty
+                            PatientId = patientId
+                            Patient = patientData patientId |> Option.defaultValue Shared.Models.Patient.empty
                         }
                 OpenedToken = Some(OpenedToken $"opened-{id}")
-                KeyThumbprint = Some(PublicKey.thumbprint record.PublicKey)
+                KeyThumbprint = Some(PublicKey.thumbprint key)
             }
 
-        let login = Some standing.User.UserId
+        let login = Some user.UserId
 
         let superseded =
             state.Sessions
@@ -426,10 +488,7 @@ module Hop =
             |> Map.toList
             |> List.map fst
 
-        let outcome = LaunchResult.Opened(id, session)
-
         { state with
-            Launches = state.Launches |> Map.add record.Nonce { record with Outcome = Some outcome }
             Sessions =
                 superseded
                 |> List.fold (fun m sid -> Map.remove sid m) state.Sessions
@@ -443,30 +502,102 @@ module Hop =
                 superseded
                 |> List.fold (fun m sid -> Map.add sid (SessionEnding.SupersededByLaunch, now) m) state.Endings
         },
-        CallbackResult.Opened(id, openedUrl)
+        (id, session)
+
+
+    let private recordOutcome (record: LaunchRecord) outcome (state: State) =
+        { state with Launches = state.Launches |> Map.add record.Nonce { record with Outcome = Some outcome } }
+
+
+    let private openSession now newId patientData (record: LaunchRecord) (standing: UserStanding) (state: State) =
+        let state, (id, session) =
+            openWith now newId patientData record.PatientId record.PublicKey standing.User state
+
+        recordOutcome record (LaunchResult.Opened(id, session)) state, CallbackResult.Opened(id, openedUrl)
 
 
     let private refuse (record: LaunchRecord) refusal (state: State) =
-        { state with
-            Launches =
-                state.Launches
-                |> Map.add record.Nonce { record with Outcome = Some(LaunchResult.Refused refusal) }
-        },
-        CallbackResult.Refused(refusal, refusedUrl refusal)
+        recordOutcome record (LaunchResult.Refused refusal) state, CallbackResult.Refused(refusal, refusedUrl refusal)
 
 
-    /// Step 4.5 and step 5. The ladder, in order: the state cookie must match (the browser that
-    /// started the hop), the record must exist and be within its lifetime, an outcome already
-    /// recorded is answered again (Rule 45), the IdentityProvider must have said who is there
-    /// (ext 3c), the UserRegistry must know them (5.3, ext 5a) with the Launch's Patient active
-    /// (ext 5b), and a Prescriber's credential must have a PIN (5.4, Rules 24 and 25, ext 5d;
-    /// a Reader needs none, Rule 26, ext 5c). Then the Session opens in one act.
+    /// UC-2: the launch suspends at the PIN question. One live code per credential (Rule 37,
+    /// ext 2a): a code that still stands is reused and nothing is mailed; else a fresh code is
+    /// mailed to the address the registry gave on this request (Rule 27). The attempt is this
+    /// launch's own, with its browser's key.
+    let private suspend
+        (now: DateTime)
+        (newId: unit -> string)
+        (newCode: unit -> string)
+        (codeMac: string -> byte[])
+        (send: Mail -> unit)
+        (record: LaunchRecord)
+        (identity: BrowserIdentity)
+        (standing: UserStanding)
+        (state: State)
+        =
+        let userId = standing.User.UserId
+
+        let state =
+            match state.Codes |> Map.tryFind userId with
+            | Some _ -> state
+            | None ->
+                let code = newCode ()
+
+                let subject, body =
+                    Mails.confirmationCode identity.DisplayName code (int codeLifetime.TotalMinutes)
+
+                send
+                    {
+                        To = standing.MailAddress
+                        Subject = subject
+                        Body = body
+                    }
+
+                { state with
+                    Codes =
+                        state.Codes
+                        |> Map.add
+                            userId
+                            {
+                                UserId = userId
+                                MailAddress = standing.MailAddress
+                                CodeMac = codeMac code
+                                Expiry = now + codeLifetime
+                                Tries = 0
+                            }
+                }
+
+        let attempt = newId ()
+
+        let enrolment =
+            {
+                Attempt = attempt
+                UserId = userId
+                Login = identity.Login
+                DisplayName = identity.DisplayName
+                PatientId = record.PatientId
+                PublicKey = record.PublicKey
+            }
+
+        let until = state.Codes[userId].Expiry
+
+        { state with Enrolments = state.Enrolments |> Map.add attempt enrolment }
+        |> recordOutcome record (LaunchResult.Enrolling attempt),
+        CallbackResult.Enrolling(attempt, openedUrl, until)
+
+
+    /// Step 4.5 and step 5. As before, except at 5.4: a Prescriber whose credential has no PIN
+    /// is not refused, the launch suspends (Rules 7, 25). A callback reload while the attempt
+    /// stands is answered with it again (Rule 45); once it is gone, a relaunch is asked for.
     let callback
         (now: DateTime)
         (newId: unit -> string)
+        (newCode: unit -> string)
+        (codeMac: string -> byte[])
         (redeem: string -> BrowserIdentity option)
         (standing: BrowserIdentity -> UserStanding option)
         (patientData: string -> Patient option)
+        (send: Mail -> unit)
         (state: State)
         (cb: Callback)
         : State * CallbackResult
@@ -487,10 +618,14 @@ module Hop =
             match record.Outcome with
             | Some(LaunchResult.Opened(id, _)) when state.Sessions |> Map.containsKey id ->
                 state, CallbackResult.Opened(id, openedUrl)
-            // the recorded Session was replaced by a newer launch of the same login (Rule 8):
-            // answering its id would put a dead cookie over the live one
             | Some(LaunchResult.Opened _) -> state, CallbackResult.Superseded openedUrl
             | Some(LaunchResult.Refused refusal) -> state, CallbackResult.Refused(refusal, refusedUrl refusal)
+            | Some(LaunchResult.Enrolling attempt) ->
+                match state.Enrolments |> Map.tryFind attempt with
+                | Some e -> state, CallbackResult.Enrolling(attempt, openedUrl, state.Codes[e.UserId].Expiry)
+                | None ->
+                    state,
+                    CallbackResult.Refused(LaunchRefusal.EnrolmentRequired, refusedUrl LaunchRefusal.EnrolmentRequired)
             | Some(LaunchResult.RedirectTo _)
             | None ->
                 let identity =
@@ -505,26 +640,137 @@ module Hop =
                     | None -> refuse record LaunchRefusal.NoRole state
                     | Some standing when standing.ActivePatientId <> Some record.PatientId ->
                         refuse record LaunchRefusal.WrongActivePatient state
-                    // 5.4, Rule 24: the credential is the Database's; Rule 25 binds Prescribers
-                    // only, a Reader is never asked (Rule 26, ext 5c)
                     | Some standing when
                         standing.User.Role = UserRole.Prescriber
                         && not (credentialOf standing.User.UserId state |> Credential.pinSet)
                         ->
-                        refuse record LaunchRefusal.EnrolmentRequired state
+                        suspend now newId newCode codeMac send record identity standing state
                     | Some standing -> openSession now newId patientData record standing state
-        | _, None ->
-            // no record: expired and dropped (Rule 29), or never presented
-            state, invalid
+        | _, None -> state, invalid
         | _ -> state, invalid
 
 
-    /// The lookup for a session id: the Session; else the ending the server recorded, answered
-    /// as long as the cookie keeps coming; else nothing. The client acknowledges an ending with
-    /// CloseSession, which deletes the cookie and drops the mark (`close`), so a lost answer is
-    /// asked and told again while an acknowledged one is told once. An unacknowledged ending
-    /// is kept as long as the stub keeps its Sessions: the notification is the User's only one
-    /// (Rule 11). The absolute Session lifetime (Rule 10), when it lands, bounds both.
+    /// What a browser holding an attempt is told at GetSession: whom the launch is for and where
+    /// the code went, while the attempt (that is, its code) stands; nothing once it is gone.
+    let findEnrolment (now: DateTime) (attempt: string) (state: State) : State * EnrolmentPending option =
+        let state = dropExpired now state
+
+        match state.Enrolments |> Map.tryFind attempt with
+        | Some e ->
+            state,
+            Some
+                {
+                    DisplayName = e.DisplayName
+                    MailHint = MailHint.ofAddress state.Codes[e.UserId].MailAddress
+                }
+        | None -> state, None
+
+
+    /// The code and every attempt bound to it, gone (the PIN was set, the code is void, or
+    /// the browser gave up).
+    let private dropCode (userId: string) (state: State) =
+        { state with
+            Codes = state.Codes |> Map.remove userId
+            Enrolments = state.Enrolments |> Map.filter (fun _ e -> e.UserId <> userId)
+        }
+
+
+    /// The browser gave up on its attempt (CloseSession while enrolling). The code stands for
+    /// any other attempt bound to it; when this was the last one it goes too, so that the next
+    /// launch mails a fresh code.
+    let dropEnrolment (attempt: string) (state: State) : State =
+        match state.Enrolments |> Map.tryFind attempt with
+        | None -> state
+        | Some e ->
+            let state = { state with Enrolments = state.Enrolments |> Map.remove attempt }
+
+            if state.Enrolments |> Map.exists (fun _ o -> o.UserId = e.UserId) then
+                state
+            else
+                dropCode e.UserId state
+
+
+    /// UC-2, the PIN comes back with the code. In order: the attempt (and its code) must stand;
+    /// the PIN must have the format, else no try is spent; a wrong code counts, and the third
+    /// voids the code for every attempt (ext 2b); else one act (Rules 37, 40): the PIN is set
+    /// with a count of zero (Rule 28), the code and its attempts are dropped, the User is
+    /// told (Rule 27, at the address the registry answers now, else the one the code went to),
+    /// and the launch continues at 5.5 to 5.7 on the supplying attempt's key.
+    let supplyPin
+        (now: DateTime)
+        (newId: unit -> string)
+        (newSalt: int -> byte[])
+        (codeMac: string -> byte[])
+        (standing: BrowserIdentity -> UserStanding option)
+        (patientData: string -> Patient option)
+        (send: Mail -> unit)
+        (attempt: string)
+        (code: string)
+        (pin: string)
+        (state: State)
+        : State * SupplyPinResult
+        =
+        let state = dropExpired now state
+
+        match state.Enrolments |> Map.tryFind attempt with
+        | None -> state, SupplyPinResult.Refused PinRefusal.AttemptExpired
+        | Some e ->
+            let pending = state.Codes[e.UserId]
+
+            if not (Pin.isValid pin) then
+                state, SupplyPinResult.Refused PinRefusal.PinFormat
+            elif
+                not (
+                    System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(codeMac code, pending.CodeMac)
+                )
+            then
+                let tries = pending.Tries + 1
+
+                if tries >= maxTries then
+                    dropCode e.UserId state, SupplyPinResult.Refused PinRefusal.CodeVoid
+                else
+                    { state with Codes = state.Codes |> Map.add e.UserId { pending with Tries = tries } },
+                    SupplyPinResult.Refused(PinRefusal.WrongCode(maxTries - tries))
+            else
+                let identity =
+                    {
+                        Login = e.Login
+                        DisplayName = e.DisplayName
+                    }
+
+                // Rule 27: the address, asked fresh on the request that sends the mail; the
+                // code's address when the registry cannot answer (uc-02, last bullet)
+                let address =
+                    standing identity
+                    |> Option.map _.MailAddress
+                    |> Option.defaultValue pending.MailAddress
+
+                let subject, body = Mails.pinSet e.DisplayName
+
+                send
+                    {
+                        To = address
+                        Subject = subject
+                        Body = body
+                    }
+
+                let user =
+                    {
+                        UserId = e.UserId
+                        DisplayName = e.DisplayName
+                        Role = UserRole.Prescriber
+                    }
+
+                let state =
+                    { state with Credentials = state.Credentials |> Map.add e.UserId (Credential.withPin newSalt pin) }
+                    |> dropCode e.UserId
+
+                let state, (id, session) =
+                    openWith now newId patientData e.PatientId e.PublicKey user state
+
+                state, SupplyPinResult.Opened(id, session)
+
+
     let find (id: string) (state: State) : State * SessionLookup =
         match state.Sessions |> Map.tryFind id with
         | Some record -> state, SessionLookup.Found record.Session
@@ -534,8 +780,6 @@ module Hop =
             | None -> state, SessionLookup.NotFound
 
 
-    /// Rule 10's explicit close, and the acknowledgement of an ending: the Session and any
-    /// mark for the id are dropped together.
     let close (id: string) (state: State) : State =
         { state with
             Sessions = state.Sessions |> Map.remove id
@@ -543,16 +787,28 @@ module Hop =
         }
 
 
-    /// The port over a single mutable state guarded by a lock, over the three actor ports,
-    /// started from `initial`.
+    /// Six digits from a random source (the CSPRNG in the host).
+    let newCode (randomBelow: int -> int) () = (randomBelow 1_000_000).ToString "D6"
+
+
+    /// The mac of a code under the host key (Rule 37).
+    let codeMac (key: LaunchSeal.Key) (code: string) =
+        LaunchSeal.mac key (Text.Encoding.UTF8.GetBytes code)
+
+
     let makeSessionPort
         (now: unit -> DateTime)
         (newId: unit -> string)
+        (newCode: unit -> string)
+        (newSalt: int -> byte[])
+        (codeMac: string -> byte[])
         (verify: Launch -> Result<LaunchSeal.Claims, LaunchRefusal>)
         (idp: IdentityProviderPort)
         (registry: UserRegistryPort)
         (patientData: PatientDataPort)
+        (mail: MailPort)
         (initial: State)
+        : SessionPort
         =
         let gate = obj ()
         let mutable state = initial
@@ -573,10 +829,43 @@ module Hop =
                 fun cb ->
                     async {
                         return
-                            update (fun s -> callback (now ()) newId idp.redeem registry.standing patientData.read s cb)
+                            update (fun s ->
+                                callback
+                                    (now ())
+                                    newId
+                                    newCode
+                                    codeMac
+                                    idp.redeem
+                                    registry.standing
+                                    patientData.read
+                                    mail.send
+                                    s
+                                    cb
+                            )
                     }
             find = fun id -> async { return update (find id) }
             close = fun id -> async { return update (fun s -> close id s, ()) }
+            findEnrolment = fun attempt -> async { return update (findEnrolment (now ()) attempt) }
+            supplyPin =
+                fun attempt code pin ->
+                    async {
+                        return
+                            update (fun s ->
+                                supplyPin
+                                    (now ())
+                                    newId
+                                    newSalt
+                                    codeMac
+                                    registry.standing
+                                    patientData.read
+                                    mail.send
+                                    attempt
+                                    code
+                                    pin
+                                    s
+                            )
+                    }
+            dropEnrolment = fun attempt -> async { return update (fun s -> dropEnrolment attempt s, ()) }
         }
 
 
@@ -1046,12 +1335,16 @@ module Adapters =
                     }
             find = fun _ -> async { return SessionLookup.NotFound }
             close = fun _ -> async { return () }
+            findEnrolment = fun _ -> async { return None }
+            supplyPin = fun _ _ _ -> async { return SupplyPinResult.Refused PinRefusal.AttemptExpired }
+            dropEnrolment = fun _ -> async { return () }
         }
 
 
     let makeAppEnvWith
         (launchKey: LaunchSeal.Key)
         (directory: StubDirectory.Directory)
+        (mail: MailPort)
         (provider: Resources.IResourceProvider)
         : AppEnv
         =
@@ -1115,10 +1408,16 @@ module Adapters =
                 Hop.makeSessionPort
                     (fun () -> DateTime.UtcNow)
                     PublicKey.randomId
+                    // the confirmation code and the salt from the CSPRNG, the code mac under
+                    // the host key (UC-2, Rule 37)
+                    (Hop.newCode System.Security.Cryptography.RandomNumberGenerator.GetInt32)
+                    System.Security.Cryptography.RandomNumberGenerator.GetBytes
+                    (Hop.codeMac launchKey)
                     (fun launch -> LaunchSeal.verify DateTime.UtcNow launchKey launch)
                     directory.idp
                     directory.registry
                     StubPatientData.port
+                    mail
                     // the credential store, seeded per stub login (plan 615)
                     (Hop.initialState (StubCredentials.seed System.Security.Cryptography.RandomNumberGenerator.GetBytes))
         }
@@ -1130,4 +1429,5 @@ module Adapters =
         makeAppEnvWith
             (LaunchSeal.newKey System.Security.Cryptography.RandomNumberGenerator.GetBytes)
             (StubDirectory.make (fun () -> DateTime.UtcNow) PublicKey.randomId)
+            (StubMail.make ()).port
             provider

--- a/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
@@ -695,7 +695,8 @@ module Hop =
     /// voids the code for every attempt (ext 2b); else one act (Rules 37, 40): the PIN is set
     /// with a count of zero (Rule 28), the code and its attempts are dropped, the User is
     /// told (Rule 27, at the address the registry answers now, else the one the code went to),
-    /// and the launch continues at 5.5 to 5.7 on the supplying attempt's key.
+    /// and the launch continues at 5.5 to 5.7 on the supplying attempt's key, with the Role the
+    /// registry answers now and only if the launch's Patient is still the active one (Rule 6).
     let supplyPin
         (now: DateTime)
         (newId: unit -> string)
@@ -738,12 +739,24 @@ module Hop =
                         DisplayName = e.DisplayName
                     }
 
-                // Rule 27: the address, asked fresh on the request that sends the mail; the
-                // code's address when the registry cannot answer (uc-02, last bullet)
+                // 5.3 again, fresh: the address for the mail (Rule 27), the Role re-taken and
+                // the active Patient (Rule 6), because the registry may have moved on during
+                // the wait. When it cannot answer, the code settles the PIN (Rule 37, uc-02 last
+                // bullet) and the launch continues on what it had.
+                let fresh = standing identity
+
                 let address =
-                    standing identity
-                    |> Option.map _.MailAddress
-                    |> Option.defaultValue pending.MailAddress
+                    fresh |> Option.map _.MailAddress |> Option.defaultValue pending.MailAddress
+
+                let user =
+                    fresh
+                    |> Option.map _.User
+                    |> Option.defaultValue
+                        {
+                            UserId = e.UserId
+                            DisplayName = e.DisplayName
+                            Role = UserRole.Prescriber
+                        }
 
                 let subject, body = Mails.pinSet e.DisplayName
 
@@ -754,21 +767,20 @@ module Hop =
                         Body = body
                     }
 
-                let user =
-                    {
-                        UserId = e.UserId
-                        DisplayName = e.DisplayName
-                        Role = UserRole.Prescriber
-                    }
-
                 let state =
                     { state with Credentials = state.Credentials |> Map.add e.UserId (Credential.withPin newSalt pin) }
                     |> dropCode e.UserId
 
-                let state, (id, session) =
-                    openWith now newId patientData e.PatientId e.PublicKey user state
+                match fresh with
+                | Some s when s.ActivePatientId <> Some e.PatientId ->
+                    // the PIN is set and told; no Session opens for a Patient that is no longer
+                    // the active one (Rule 6): a relaunch is asked for
+                    state, SupplyPinResult.Refused PinRefusal.WrongActivePatient
+                | _ ->
+                    let state, (id, session) =
+                        openWith now newId patientData e.PatientId e.PublicKey user state
 
-                state, SupplyPinResult.Opened(id, session)
+                    state, SupplyPinResult.Opened(id, session)
 
 
     let find (id: string) (state: State) : State * SessionLookup =

--- a/src/Informedica.GenPRES.Server/ServerApi.ApiImpl.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.ApiImpl.fs
@@ -10,6 +10,7 @@ module ApiImpl =
         (env: AppEnv)
         (cookie: SessionCookie)
         (stateCookie: LaunchStateCookie)
+        (enrolment: EnrolmentCookie)
         : Shared.Api.IServerApi
         =
-        CompositionRoot.compose settings env cookie stateCookie
+        CompositionRoot.compose settings env cookie stateCookie enrolment

--- a/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
@@ -16,56 +16,98 @@ module CompositionRoot =
             match cmd with
             | LaunchCommand.PresentLaunch(launch, key) ->
                 match! env.session.present (launch, key) with
-                | LaunchResult.Opened(id, session) ->
+                | LaunchResult.Opened(id, opened) ->
                     cookie.write id
-                    return LaunchOutcome.Opened session
+                    return LaunchOutcome.Opened opened
                 | LaunchResult.RedirectTo(url, state) ->
-                    // step 4.2: the state cookie is what proves, at the callback, that the same
-                    // browser started the hop
                     stateCookie.write state
                     return LaunchOutcome.RedirectTo url
                 | LaunchResult.Refused refusal -> return LaunchOutcome.Refused refusal
+                // a retry of a launch that suspended: the browser holds the attempt already, the
+                // app tells it at the next GetSession
+                | LaunchResult.Enrolling _ -> return LaunchOutcome.RedirectTo Hop.openedUrl
         }
 
 
     /// Launch step 4.5 over the session port: the browser is back from the IdentityProvider.
-    /// Answers where it goes next; the session cookie is set when a Session opened.
-    let processCallback (env: AppEnv) (cookie: SessionCookie) (stateCookie: LaunchStateCookie) (cb: Callback) =
+    /// Answers where it goes next; the session cookie is set when a Session opened, the
+    /// enrolment cookie when the launch suspended (UC-2).
+    let processCallback
+        (env: AppEnv)
+        (cookie: SessionCookie)
+        (stateCookie: LaunchStateCookie)
+        (enrolment: EnrolmentCookie)
+        (cb: Callback)
+        =
         async {
             match! env.session.callback { cb with StateCookie = stateCookie.read cb.State } with
             | CallbackResult.Opened(id, redirect) ->
                 cookie.write id
+                return redirect
+            | CallbackResult.Enrolling(attempt, redirect, until) ->
+                enrolment.write attempt until
                 return redirect
             | CallbackResult.Refused(_, redirect)
             | CallbackResult.Superseded redirect -> return redirect
         }
 
 
-    /// Cookie-authenticated session commands. CloseSession deletes the cookie even when no
-    /// session is found, and even when the server-side close throws: an explicit close
-    /// (Rule 10) always leaves the browser without a credential. The exception still
+    /// Cookie-authenticated session commands over both cookies. GetSession answers the Session
+    /// first; without one, a standing attempt (UC-2); a gone attempt loses its cookie. SupplyPin
+    /// works on the attempt in the cookie, never on one the client names. CloseSession drops
+    /// both, even when nothing is found and even when the server-side close throws: an explicit
+    /// close (Rule 10) always leaves the browser without a credential. The exception still
     /// propagates after the delete, so the failure stays visible.
-    let processSession (env: AppEnv) (cookie: SessionCookie) (cmd: SessionCommand) =
+    let processSession (env: AppEnv) (cookie: SessionCookie) (enrolment: EnrolmentCookie) (cmd: SessionCommand) =
         async {
             match cmd with
             | SessionCommand.GetSession ->
-                match cookie.read () with
-                | None -> return SessionResponse.SessionResp None
-                | Some id ->
-                    match! env.session.find id with
-                    | SessionLookup.Found session -> return SessionResponse.SessionResp(Some session)
-                    | SessionLookup.NotFound -> return SessionResponse.SessionResp None
-                    | SessionLookup.Ended ending ->
-                        // the cookie stays until the client acknowledges with CloseSession, which
-                        // deletes it and drops the ending; a lost answer is asked and told again
-                        return SessionResponse.SessionEnded ending
+                let! bySession =
+                    async {
+                        match cookie.read () with
+                        | None -> return None
+                        | Some id ->
+                            match! env.session.find id with
+                            | SessionLookup.Found opened -> return Some(SessionResponse.SessionResp(Some opened))
+                            | SessionLookup.NotFound -> return None
+                            | SessionLookup.Ended ending -> return Some(SessionResponse.SessionEnded ending)
+                    }
+
+                match bySession, enrolment.read () with
+                | Some response, _ -> return response
+                | None, None -> return SessionResponse.SessionResp None
+                | None, Some attempt ->
+                    match! env.session.findEnrolment attempt with
+                    | Some pending -> return SessionResponse.EnrolmentPending pending
+                    | None ->
+                        enrolment.delete ()
+                        return SessionResponse.SessionResp None
+            | SessionCommand.SupplyPin(code, pin) ->
+                match enrolment.read () with
+                | None -> return SessionResponse.PinRefused PinRefusal.AttemptExpired
+                | Some attempt ->
+                    match! env.session.supplyPin attempt code pin with
+                    | SupplyPinResult.Opened(id, opened) ->
+                        enrolment.delete ()
+                        cookie.write id
+                        return SessionResponse.SessionResp(Some opened)
+                    | SupplyPinResult.Refused(PinRefusal.CodeVoid as refusal)
+                    | SupplyPinResult.Refused(PinRefusal.AttemptExpired as refusal) ->
+                        enrolment.delete ()
+                        return SessionResponse.PinRefused refusal
+                    | SupplyPinResult.Refused refusal -> return SessionResponse.PinRefused refusal
             | SessionCommand.CloseSession ->
                 try
                     match cookie.read () with
                     | Some id -> do! env.session.close id
                     | None -> ()
+
+                    match enrolment.read () with
+                    | Some attempt -> do! env.session.dropEnrolment attempt
+                    | None -> ()
                 finally
                     cookie.delete ()
+                    enrolment.delete ()
 
                 return SessionResponse.SessionClosed
         }
@@ -78,6 +120,7 @@ module CompositionRoot =
         (env: AppEnv)
         (cookie: SessionCookie)
         (stateCookie: LaunchStateCookie)
+        (enrolment: EnrolmentCookie)
         : IServerApi
         =
         {
@@ -107,7 +150,7 @@ module CompositionRoot =
                 fun cmd ->
                     async {
                         writeInfoMessage $"Processing session: {cmd |> SessionCommand.toString}"
-                        let! response = processSession env cookie cmd
+                        let! response = processSession env cookie enrolment cmd
                         writeInfoMessage $"Finished processing session: {cmd |> SessionCommand.toString}"
                         return response
                     }

--- a/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
@@ -45,6 +45,14 @@ module CompositionRoot =
                 cookie.write id
                 return redirect
             | CallbackResult.Enrolling(attempt, redirect, until) ->
+                // the new launch replaces whatever Session this browser still held, as an open
+                // would (session-endings: ReplacedInBrowser owes nothing); left in place, its
+                // cookie would hide the enrolment at the next GetSession
+                match cookie.read () with
+                | Some id -> do! env.session.close id
+                | None -> ()
+
+                cookie.delete ()
                 enrolment.write attempt until
                 return redirect
             | CallbackResult.Refused(_, redirect)
@@ -92,7 +100,8 @@ module CompositionRoot =
                         cookie.write id
                         return SessionResponse.SessionResp(Some opened)
                     | SupplyPinResult.Refused(PinRefusal.CodeVoid as refusal)
-                    | SupplyPinResult.Refused(PinRefusal.AttemptExpired as refusal) ->
+                    | SupplyPinResult.Refused(PinRefusal.AttemptExpired as refusal)
+                    | SupplyPinResult.Refused(PinRefusal.WrongActivePatient as refusal) ->
                         enrolment.delete ()
                         return SessionResponse.PinRefused refusal
                     | SupplyPinResult.Refused refusal -> return SessionResponse.PinRefused refusal

--- a/src/Informedica.GenPRES.Server/ServerApi.Ports.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Ports.fs
@@ -108,6 +108,8 @@ type LaunchResult =
     | Opened of sessionId: string * SessionOpened
     | RedirectTo of url: string * state: string
     | Refused of LaunchRefusal
+    // the launch suspended into enrolment (UC-2); the browser holds the attempt in a cookie
+    | Enrolling of attemptId: string
 
 
 /// What the callback (4.5) brings: the `state` from the url and from the cookie, and either a
@@ -130,6 +132,15 @@ type CallbackResult =
     // a reload of a callback whose Session a newer launch has since replaced (Rule 8): the
     // browser goes to the app on whatever cookie it holds, which is the newer Session's
     | Superseded of redirect: string
+    // UC-2: the attempt for the enrolment cookie, and how long the code it is bound to lives
+    | Enrolling of attemptId: string * redirect: string * until: System.DateTime
+
+
+/// The answer to a supplied PIN: the Session that opened, or why not.
+[<RequireQualifiedAccess>]
+type SupplyPinResult =
+    | Opened of sessionId: string * SessionOpened
+    | Refused of PinRefusal
 
 
 /// What the store says about a session id from the cookie: the Session, nothing, or that the
@@ -153,6 +164,12 @@ type SessionPort =
         find: string -> Async<SessionLookup>
         // Rule 10: explicit close
         close: string -> Async<unit>
+        // UC-2: what a browser holding an attempt is told
+        findEnrolment: string -> Async<EnrolmentPending option>
+        // UC-2: the code and the chosen PIN, for the attempt in the cookie
+        supplyPin: string -> string -> string -> Async<SupplyPinResult>
+        // an attempt the browser gave up on (CloseSession while enrolling)
+        dropEnrolment: string -> Async<unit>
     }
 
 
@@ -172,6 +189,16 @@ type LaunchStateCookie =
         // the cookie of one hop, named by its state, so that two tabs can launch at once
         read: string -> string option
         write: string -> unit
+    }
+
+
+/// The enrolment cookie of one request (UC-2): written at the callback with the code's expiry,
+/// read at GetSession and SupplyPin, deleted when the attempt is spent or gone.
+type EnrolmentCookie =
+    {
+        read: unit -> string option
+        write: string -> System.DateTime -> unit
+        delete: unit -> unit
     }
 
 

--- a/src/Informedica.GenPRES.Shared/Api.fs
+++ b/src/Informedica.GenPRES.Shared/Api.fs
@@ -170,6 +170,9 @@ module Api =
         | GetSession
         // Rule 10: explicit close; always removes the cookie
         | CloseSession
+        // UC-2: the confirmation code from the mail and the chosen PIN, for the attempt the
+        // enrolment cookie names
+        | SupplyPin of code: string * pin: string
 
 
     [<RequireQualifiedAccess>]
@@ -178,6 +181,9 @@ module Api =
         | SessionClosed
         // the server ended the Session the cookie named, and deleted the cookie (Rule 11)
         | SessionEnded of SessionEnding
+        // the launch waits on a PIN (UC-2); answered to GetSession while the attempt stands
+        | EnrolmentPending of EnrolmentPending
+        | PinRefused of PinRefusal
 
 
     module LaunchCommand =
@@ -194,6 +200,8 @@ module Api =
             match cmd with
             | SessionCommand.GetSession -> "GetSession"
             | SessionCommand.CloseSession -> "CloseSession"
+            // never the code or the PIN
+            | SessionCommand.SupplyPin _ -> "SupplyPin"
 
 
     /// Defines how routes are generated on server and mapped from the client

--- a/src/Informedica.GenPRES.Shared/Types.fs
+++ b/src/Informedica.GenPRES.Shared/Types.fs
@@ -660,14 +660,17 @@ module Types =
         }
 
 
-    /// Why a supplied PIN did not set (UC-2 ext 2b). `WrongCode` leaves the form open with the
-    /// tries left; `CodeVoid` and `AttemptExpired` are terminal: the launch has to start over.
+    /// Why a supplied PIN opened no Session (UC-2 ext 2b). `WrongCode` leaves the form open with
+    /// the tries left; `PinFormat` spends no try; `CodeVoid` and `AttemptExpired` are terminal:
+    /// the launch has to start over. `WrongActivePatient` is terminal too, and the PIN is set:
+    /// the registry no longer has the launch's Patient active (Rule 6).
     [<RequireQualifiedAccess>]
     type PinRefusal =
         | WrongCode of attemptsLeft: int
         | CodeVoid
         | AttemptExpired
         | PinFormat
+        | WrongActivePatient
 
 
     [<RequireQualifiedAccess>]

--- a/src/Informedica.GenPRES.Shared/Types.fs
+++ b/src/Informedica.GenPRES.Shared/Types.fs
@@ -651,6 +651,25 @@ module Types =
     type SessionEnding = SupersededByLaunch
 
 
+    /// What the client learns when its launch is waiting on a PIN (UC-2): whom to greet and
+    /// where the confirmation code went, hinted so that a shoulder cannot read the address.
+    type EnrolmentPending =
+        {
+            DisplayName: string
+            MailHint: string
+        }
+
+
+    /// Why a supplied PIN did not set (UC-2 ext 2b). `WrongCode` leaves the form open with the
+    /// tries left; `CodeVoid` and `AttemptExpired` are terminal: the launch has to start over.
+    [<RequireQualifiedAccess>]
+    type PinRefusal =
+        | WrongCode of attemptsLeft: int
+        | CodeVoid
+        | AttemptExpired
+        | PinFormat
+
+
     [<RequireQualifiedAccess>]
     type LaunchOutcome =
         | Opened of SessionOpened

--- a/tests/Informedica.GenPRES.Server.Tests/HttpTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/HttpTests.fs
@@ -169,6 +169,65 @@ let launchStateCookieTests =
         ]
 
 
+/// The enrolment cookie adapter (UC-2): the attempt a suspended launch left in the browser.
+let enrolmentCookieTests =
+    testList
+        "enrolmentCookie"
+        [
+            test "write is HttpOnly, SameSite=Strict, Path=/, Max-Age what remains of the code, no Secure over http" {
+                let ctx = DefaultHttpContext()
+                let now = DateTime.UtcNow
+                (Server.Http.enrolmentCookie ctx).write "attempt-1" (now + TimeSpan.FromMinutes 15.0)
+                let header = setCookieHeader ctx
+
+                header |> Expect.stringStarts "name=value" "genpres_enrolment=attempt-1"
+                header |> Expect.stringContains "httponly" "httponly"
+                header |> Expect.stringContains "strict" "samesite=strict"
+                header |> Expect.stringContains "path" "path=/"
+
+                let maxAge =
+                    header.Split(';')
+                    |> Array.map _.Trim()
+                    |> Array.pick (fun part ->
+                        if part.StartsWith("max-age=", StringComparison.OrdinalIgnoreCase) then
+                            Some(int (part.Substring 8))
+                        else
+                            None
+                    )
+
+                (maxAge > 14 * 60 && maxAge <= 15 * 60)
+                |> Expect.isTrue $"about 15 minutes, was {maxAge}"
+
+                header.Contains("secure", StringComparison.OrdinalIgnoreCase)
+                |> Expect.isFalse "not secure over http"
+            }
+
+            test "a code already expired writes a Max-Age of zero, never a negative one" {
+                let ctx = DefaultHttpContext()
+                (Server.Http.enrolmentCookie ctx).write "attempt-1" (DateTime.UtcNow - TimeSpan.FromMinutes 1.0)
+                setCookieHeader ctx |> Expect.stringContains "zero" "max-age=0"
+            }
+
+            test "write sets Secure over https; read and delete work on the named cookie" {
+                let ctx = DefaultHttpContext()
+                ctx.Request.IsHttps <- true
+                (Server.Http.enrolmentCookie ctx).write "attempt-1" (DateTime.UtcNow + TimeSpan.FromMinutes 15.0)
+                setCookieHeader ctx |> Expect.stringContains "secure" "secure"
+
+                let ctx = DefaultHttpContext()
+
+                ctx.Request.Headers.Cookie <-
+                    Microsoft.Extensions.Primitives.StringValues "genpres_enrolment=a-1; other=1"
+
+                (Server.Http.enrolmentCookie ctx).read () |> Expect.equal "read" (Some "a-1")
+                (Server.Http.enrolmentCookie ctx).delete ()
+
+                setCookieHeader ctx
+                |> Expect.stringContains "deleted" "genpres_enrolment=; expires="
+            }
+        ]
+
+
 [<Tests>]
 let tests =
     testList
@@ -177,4 +236,5 @@ let tests =
             cacheControlTests
             sessionCookieTests
             launchStateCookieTests
+            enrolmentCookieTests
         ]

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -66,6 +66,9 @@ module StubAdapters =
                     async { return CallbackResult.Refused(LaunchRefusal.LaunchInvalid, "/#/session?refused=invalid") }
             find = fun _ -> async { return SessionLookup.NotFound }
             close = fun _ -> async { return () }
+            findEnrolment = fun _ -> async { return None }
+            supplyPin = fun _ _ _ -> async { return SupplyPinResult.Refused PinRefusal.AttemptExpired }
+            dropEnrolment = fun _ -> async { return () }
         }
 
 
@@ -340,9 +343,21 @@ module SessionStubTests =
     let launch2 = mintFor "n-2" "p-2"
 
 
-    /// A port with a settable clock, a counting id source, the seal check bound to the clock and
-    /// a stub directory of its own.
-    let makePort () =
+    let codeMac = Hop.codeMac sealKey
+
+
+    /// Confirmation codes are numbered, so that a test can name the one that was mailed.
+    let codes () =
+        let n = ref 0
+
+        fun () ->
+            n.Value <- n.Value + 1
+            $"%06d{n.Value}"
+
+
+    /// A port with a settable clock, a counting id source, the seal check bound to the clock, a
+    /// stub directory of its own and the given outbox.
+    let makePortWith (outbox: StubMail.Outbox) =
         let clock = ref t0
         let count = ref 0
 
@@ -356,13 +371,20 @@ module SessionStubTests =
                     count.Value <- count.Value + 1
                     $"session-{count.Value}"
                 )
+                (codes ())
+                salts
+                codeMac
                 (fun launch -> LaunchSeal.verify clock.Value sealKey launch)
                 directory.idp
                 directory.registry
                 StubPatientData.port
+                outbox.port
                 seeded
 
         port, clock, directory
+
+
+    let makePort () = makePortWith (StubMail.make ())
 
 
     let thumbprintTests =
@@ -453,8 +475,19 @@ module SessionStubTests =
             | other -> failtest $"expected RedirectTo, got {other}"
 
 
+        /// The callback at t0 with a throwaway outbox: for the tests that never suspend.
         let run (ids: unit -> string) (directory: StubDirectory.Directory) state cb =
-            Hop.callback t0 ids directory.idp.redeem directory.registry.standing StubPatientData.port.read state cb
+            Hop.callback
+                t0
+                ids
+                (codes ())
+                codeMac
+                directory.idp.redeem
+                directory.registry.standing
+                StubPatientData.port.read
+                (StubMail.make ()).port.send
+                state
+                cb
 
 
         let presentTests =
@@ -593,7 +626,6 @@ module SessionStubTests =
                                     "none", LaunchRefusal.NoBrowserIdentity
                                     "unknown", LaunchRefusal.NoRole
                                     "prescriber-other-patient", LaunchRefusal.WrongActivePatient
-                                    "no-pin", LaunchRefusal.EnrolmentRequired
                                 ] do
                                 test choice {
                                     let ids, d = fixture ()
@@ -678,7 +710,17 @@ module SessionStubTests =
                         let late = t0 + lifetime + TimeSpan.FromSeconds 1.0
 
                         let state2, result =
-                            Hop.callback late ids d.idp.redeem d.registry.standing StubPatientData.port.read state cb
+                            Hop.callback
+                                late
+                                ids
+                                (codes ())
+                                codeMac
+                                d.idp.redeem
+                                d.registry.standing
+                                StubPatientData.port.read
+                                (StubMail.make ()).port.send
+                                state
+                                cb
 
                         result
                         |> Expect.equal
@@ -797,10 +839,14 @@ module SessionStubTests =
                             Hop.makeSessionPort
                                 (fun () -> t0)
                                 ids
+                                (codes ())
+                                salts
+                                codeMac
                                 (verifyAt t0)
                                 d.idp
                                 d.registry
                                 StubPatientData.port
+                                (StubMail.make ()).port
                                 seeded
 
                         let! redirect = port.present (launch1, keyA)
@@ -996,15 +1042,14 @@ module SessionStubTests =
             testList
                 "Hop.callback over the credential store"
                 [
-                    test "a Prescriber the store does not know at all has no PIN either" {
+                    test "a Prescriber the store does not know at all has no PIN either, and suspends" {
                         let ids, d = fixture ()
                         let state, cb = hop ids d Hop.emptyState launch1 keyA "prescriber"
                         let _, result = run ids d state cb
 
-                        result
-                        |> Expect.equal
-                            "enrolment"
-                            (CallbackResult.Refused(LaunchRefusal.EnrolmentRequired, "/#/session?refused=enrolment"))
+                        match result with
+                        | CallbackResult.Enrolling _ -> ()
+                        | other -> failtest $"expected Enrolling, got {other}"
                     }
 
                     test "a Reader is never asked for a PIN (Rule 26)" {
@@ -1083,6 +1128,507 @@ module SessionStubTests =
                 ]
 
 
+        type Fixture =
+            {
+                ids: unit -> string
+                d: StubDirectory.Directory
+                outbox: StubMail.Outbox
+                newCode: unit -> string
+            }
+
+
+        let enrolFixture () =
+            {
+                ids = counter "id"
+                d = StubDirectory.make (fun () -> t0) (counter "code")
+                outbox = StubMail.make ()
+                newCode = codes ()
+            }
+
+
+        let hopE (f: Fixture) state launch key choice =
+            let state, result =
+                Hop.present t0 f.ids (verifyAt t0) f.d.idp.authorizeUrl state (launch, key)
+
+            match result with
+            | LaunchResult.RedirectTo(_, st) ->
+                state,
+                {
+                    State = st
+                    StateCookie = Some st
+                    Code = Some(f.d.issue choice "patient-1")
+                    Error = None
+                }
+            | other -> failtest $"expected RedirectTo, got {other}"
+
+
+        let runAt now (f: Fixture) state cb =
+            Hop.callback
+                now
+                f.ids
+                f.newCode
+                codeMac
+                f.d.idp.redeem
+                f.d.registry.standing
+                StubPatientData.port.read
+                f.outbox.port.send
+                state
+                cb
+
+
+        let runE f state cb = runAt t0 f state cb
+
+
+        /// Launches `choice` and expects the suspension; returns the state and the attempt.
+        let suspendVia (f: Fixture) state launch key choice =
+            let state, cb = hopE f state launch key choice
+            let state, result = runE f state cb
+
+            match result with
+            | CallbackResult.Enrolling(attempt, redirect, until) ->
+                redirect |> Expect.equal "to the app" "/#/session"
+                until |> Expect.equal "until the code expires" (t0 + Hop.codeLifetime)
+                state, attempt
+            | other -> failtest $"expected Enrolling, got {other}"
+
+
+        let supplyAt now (f: Fixture) state attempt code pin =
+            Hop.supplyPin
+                now
+                f.ids
+                salts
+                codeMac
+                f.d.registry.standing
+                StubPatientData.port.read
+                f.outbox.port.send
+                attempt
+                code
+                pin
+                state
+
+
+        let supply f state attempt code pin = supplyAt t0 f state attempt code pin
+
+
+        /// The code the newest confirmation mail carries, from its body.
+        let mailedCode (f: Fixture) =
+            let body =
+                (f.outbox.sent () |> List.find (fun m -> m.Subject.Contains "confirmation code")).Body
+
+            let i = body.IndexOf "code is " + 8
+            body.Substring(i, 6)
+
+
+        let helperTests =
+            testList
+                "helpers"
+                [
+                    test "a PIN is four to six digits" {
+                        for ok in [ "1234"; "12345"; "123456"; "0000" ] do
+                            Pin.isValid ok |> Expect.isTrue ok
+
+                        for bad in [ "123"; "1234567"; "12a4"; ""; "12 34"; "١٢٣٤" ] do
+                            Pin.isValid bad |> Expect.isFalse bad
+                    }
+
+                    test "the mail hint keeps the first letter and the domain" {
+                        MailHint.ofAddress "no-pin@stub.example"
+                        |> Expect.equal "hint" "n***@stub.example"
+
+                        MailHint.ofAddress "x" |> Expect.equal "no at" "***"
+                    }
+
+                    test "codes are six digits" {
+                        Hop.newCode (fun _ -> 42) () |> Expect.equal "padded" "000042"
+                        Hop.newCode (fun _ -> 999_999) () |> Expect.equal "max" "999999"
+                    }
+
+                    test "the code mac is keyed" {
+                        codeMac "123456"
+                        |> Expect.notEqual "another key" (Hop.codeMac (LaunchSeal.Key(Array.zeroCreate 32)) "123456")
+
+                        codeMac "123456" |> Expect.equal "deterministic" (codeMac "123456")
+                    }
+                ]
+
+
+        let suspendTests =
+            testList
+                "the launch suspends (uc-02)"
+                [
+                    test "a Prescriber without a PIN is not refused: an attempt and a code, one mail (Rules 7, 25, 27)" {
+                        let f = enrolFixture ()
+                        let state, attempt = suspendVia f seeded launch1 keyA "no-pin"
+                        state.Sessions |> Map.isEmpty |> Expect.isTrue "no Session yet (Rule 7)"
+                        let e = state.Enrolments[attempt]
+                        e.UserId |> Expect.equal "person" "no-pin"
+                        e.PatientId |> Expect.equal "patient" "patient-1"
+                        e.PublicKey |> Expect.equal "the browser's key" keyA
+
+                        state.Codes["no-pin"].Expiry
+                        |> Expect.equal "code lifetime" (t0 + Hop.codeLifetime)
+
+                        state.Launches["n-1"].Outcome
+                        |> Expect.equal "recorded" (Some(LaunchResult.Enrolling attempt))
+
+                        match f.outbox.sent () with
+                        | [ mail ] ->
+                            mail.To |> Expect.equal "the registry's address" "no-pin@stub.example"
+                            mail.Body |> Expect.stringContains "the code" (mailedCode f)
+                            mail.Body |> Expect.stringContains "the lifetime" "15 minutes"
+                        | other -> failtest $"expected one mail, got {other.Length}"
+                    }
+
+                    test "a Prescriber with a PIN, a Reader, an unknown login: as before" {
+                        let f = enrolFixture ()
+                        let state, cb = hopE f seeded launch1 keyA "prescriber"
+                        let state, opened = runE f state cb
+
+                        match opened with
+                        | CallbackResult.Opened _ -> ()
+                        | other -> failtest $"expected Opened, got {other}"
+
+                        let state, cb = hopE f state (mintFor "n-2" "patient-1") keyB "reader"
+                        let state, opened = runE f state cb
+
+                        match opened with
+                        | CallbackResult.Opened _ -> ()
+                        | other -> failtest $"expected Opened, got {other}"
+
+                        let state, cb = hopE f state (mintFor "n-3" "patient-1") keyB "unknown"
+                        let _, refused = runE f state cb
+
+                        refused
+                        |> Expect.equal
+                            "no role"
+                            (CallbackResult.Refused(LaunchRefusal.NoRole, "/#/session?refused=no-role"))
+
+                        f.outbox.sent () |> Expect.isEmpty "no mail for any of them"
+                    }
+
+                    test
+                        "a second launch while the code stands gets its own attempt and no second mail (Rule 37, ext 2a)" {
+                        let f = enrolFixture ()
+                        let state, a1 = suspendVia f seeded launch1 keyA "no-pin"
+                        let state, a2 = suspendVia f state (mintFor "n-2" "patient-1") keyB "no-pin"
+                        a2 |> Expect.notEqual "another attempt" a1
+                        state.Enrolments[a1].PublicKey |> Expect.equal "first keeps its key" keyA
+                        state.Enrolments[a2].PublicKey |> Expect.equal "second has its own" keyB
+                        state.Codes |> Map.count |> Expect.equal "one code" 1
+                        f.outbox.sent () |> List.length |> Expect.equal "one mail" 1
+                    }
+
+                    test "a callback reload while the attempt stands is answered with it again (Rule 45)" {
+                        let f = enrolFixture ()
+                        let state, cb = hopE f seeded launch1 keyA "no-pin"
+                        let state, first = runE f state cb
+                        let state2, again = runE f state cb
+                        again |> Expect.equal "same answer" first
+                        state2 |> Expect.equal "same state" state
+                        f.outbox.sent () |> List.length |> Expect.equal "still one mail" 1
+                    }
+
+                    test "a callback reload after the attempt is gone asks for a relaunch" {
+                        let f = enrolFixture ()
+                        let state, cb = hopE f seeded launch1 keyA "no-pin"
+                        let state, first = runE f state cb
+
+                        let attempt =
+                            match first with
+                            | CallbackResult.Enrolling(a, _, _) -> a
+                            | other -> failtest $"{other}"
+
+                        // within the Launch lifetime, the attempt dropped: enrolment, relaunch
+                        let state = Hop.dropEnrolment attempt state
+                        let _, relaunch = runE f state cb
+
+                        relaunch
+                        |> Expect.equal
+                            "enrolment"
+                            (CallbackResult.Refused(LaunchRefusal.EnrolmentRequired, "/#/session?refused=enrolment"))
+                        // after the code's lifetime the LaunchRecord is long gone too (Rule 29): invalid
+                        let late = t0 + Hop.codeLifetime + TimeSpan.FromSeconds 1.0
+                        let _, gone = runAt late f state cb
+
+                        gone
+                        |> Expect.equal
+                            "invalid"
+                            (CallbackResult.Refused(LaunchRefusal.LaunchInvalid, "/#/session?refused=invalid"))
+                    }
+
+                    test "a retry of the presentation after the suspension is sent to the app" {
+                        let f = enrolFixture ()
+                        let state, _ = suspendVia f seeded launch1 keyA "no-pin"
+
+                        let _, again =
+                            Hop.present t0 f.ids (verifyAt t0) f.d.idp.authorizeUrl state (launch1, keyA)
+
+                        match again with
+                        | LaunchResult.Enrolling _ -> ()
+                        | other -> failtest $"expected Enrolling, got {other}"
+                    }
+                ]
+
+
+        let findTests =
+            testList
+                "findEnrolment"
+                [
+                    test "a standing attempt tells whom and the hinted address" {
+                        let f = enrolFixture ()
+                        let state, attempt = suspendVia f seeded launch1 keyA "no-pin"
+                        let _, pending = Hop.findEnrolment t0 attempt state
+
+                        pending
+                        |> Expect.equal
+                            "pending"
+                            (Some
+                                {
+                                    DisplayName = "Stub Prescriber (no PIN)"
+                                    MailHint = "n***@stub.example"
+                                })
+                    }
+
+                    test "an unknown attempt is nothing" {
+                        let _, pending = Hop.findEnrolment t0 "nope" seeded
+                        pending |> Expect.isNone "nothing"
+                    }
+
+                    test "after the code's lifetime the attempt is gone with it" {
+                        let f = enrolFixture ()
+                        let state, attempt = suspendVia f seeded launch1 keyA "no-pin"
+                        let late = t0 + Hop.codeLifetime + TimeSpan.FromSeconds 1.0
+                        let state, pending = Hop.findEnrolment late attempt state
+                        pending |> Expect.isNone "gone"
+                        state.Codes |> Map.isEmpty |> Expect.isTrue "code dropped"
+                        state.Enrolments |> Map.isEmpty |> Expect.isTrue "attempt dropped"
+                    }
+                ]
+
+
+        let supplyTests =
+            testList
+                "supplyPin"
+                [
+                    test
+                        "the right code and a PIN: set with a count of zero, both dropped, told, and open on the attempt's key (Rules 37, 40, 28, 27)" {
+                        let f = enrolFixture ()
+                        let state, attempt = suspendVia f seeded launch1 keyA "no-pin"
+                        let code = mailedCode f
+                        let state, result = supply f state attempt code "2468"
+
+                        match result with
+                        | SupplyPinResult.Opened(id, session) ->
+                            session.User |> Option.map _.UserId |> Expect.equal "user" (Some "no-pin")
+
+                            session.User
+                            |> Option.map _.Role
+                            |> Expect.equal "role" (Some UserRole.Prescriber)
+
+                            session.PatientContext
+                            |> Option.map _.PatientId
+                            |> Expect.equal "patient" (Some "patient-1")
+
+                            session.KeyThumbprint
+                            |> Expect.equal "the attempt's key" (Some(PublicKey.thumbprint keyA))
+
+                            state.Sessions |> Map.containsKey id |> Expect.isTrue "open"
+                        | other -> failtest $"expected Opened, got {other}"
+
+                        let credential = state.Credentials["no-pin"]
+
+                        credential.PinHash
+                        |> Option.map (PinHash.verify "2468")
+                        |> Expect.equal "the PIN" (Some true)
+
+                        credential.WrongCount |> Expect.equal "zero" 0
+                        state.Codes |> Map.isEmpty |> Expect.isTrue "code dropped"
+                        state.Enrolments |> Map.isEmpty |> Expect.isTrue "attempt dropped"
+
+                        match f.outbox.sent () with
+                        | [ second; first ] ->
+                            first.Subject |> Expect.stringContains "first" "confirmation code"
+                            second.Subject |> Expect.stringContains "second" "PIN was set"
+                            second.To |> Expect.equal "the registry's address, fresh" "no-pin@stub.example"
+                        | other -> failtest $"expected two mails, got {other.Length}"
+                    }
+
+                    test "the next launch of that person opens directly" {
+                        let f = enrolFixture ()
+                        let state, attempt = suspendVia f seeded launch1 keyA "no-pin"
+                        let state, _ = supply f state attempt (mailedCode f) "2468"
+                        let state, cb = hopE f state (mintFor "n-2" "patient-1") keyB "no-pin"
+                        let _, result = runE f state cb
+
+                        match result with
+                        | CallbackResult.Opened _ -> ()
+                        | other -> failtest $"expected Opened, got {other}"
+                    }
+
+                    test "two attempts on one code: whichever supplies opens on its own key, and the other is gone" {
+                        let f = enrolFixture ()
+                        let state, a1 = suspendVia f seeded launch1 keyA "no-pin"
+                        let state, a2 = suspendVia f state (mintFor "n-2" "patient-1") keyB "no-pin"
+                        let state, result = supply f state a2 (mailedCode f) "2468"
+
+                        match result with
+                        | SupplyPinResult.Opened(_, session) ->
+                            session.KeyThumbprint
+                            |> Expect.equal "the second browser's key" (Some(PublicKey.thumbprint keyB))
+                        | other -> failtest $"expected Opened, got {other}"
+
+                        let _, first = supply f state a1 (mailedCode f) "2468"
+
+                        first
+                        |> Expect.equal "the first attempt is gone" (SupplyPinResult.Refused PinRefusal.AttemptExpired)
+                    }
+
+                    test "a wrong code counts; the third voids the code for every attempt (ext 2b)" {
+                        let f = enrolFixture ()
+                        let state, a1 = suspendVia f seeded launch1 keyA "no-pin"
+                        let state, a2 = suspendVia f state (mintFor "n-2" "patient-1") keyB "no-pin"
+                        let state, r1 = supply f state a1 "000000" "2468"
+                        r1 |> Expect.equal "two left" (SupplyPinResult.Refused(PinRefusal.WrongCode 2))
+                        let state, r2 = supply f state a2 "000000" "2468"
+
+                        r2
+                        |> Expect.equal
+                            "one left, counted across attempts"
+                            (SupplyPinResult.Refused(PinRefusal.WrongCode 1))
+
+                        let state, r3 = supply f state a1 "000000" "2468"
+                        r3 |> Expect.equal "void" (SupplyPinResult.Refused PinRefusal.CodeVoid)
+                        state.Codes |> Map.isEmpty |> Expect.isTrue "code dropped"
+                        state.Enrolments |> Map.isEmpty |> Expect.isTrue "both attempts dropped"
+                        state.Credentials["no-pin"] |> Credential.pinSet |> Expect.isFalse "no PIN set"
+                        let _, r4 = supply f state a2 (mailedCode f) "2468"
+
+                        r4
+                        |> Expect.equal
+                            "even the right code is too late"
+                            (SupplyPinResult.Refused PinRefusal.AttemptExpired)
+
+                        f.outbox.sent () |> List.length |> Expect.equal "no second mail" 1
+                    }
+
+                    test "a fresh launch after a void code mails a fresh one" {
+                        let f = enrolFixture ()
+                        let state, a1 = suspendVia f seeded launch1 keyA "no-pin"
+                        let state, _ = supply f state a1 "000000" "2468"
+                        let state, _ = supply f state a1 "000000" "2468"
+                        let state, _ = supply f state a1 "000000" "2468"
+                        let state, a2 = suspendVia f state (mintFor "n-2" "patient-1") keyB "no-pin"
+                        f.outbox.sent () |> List.length |> Expect.equal "two mails" 2
+                        let _, result = supply f state a2 (mailedCode f) "2468"
+
+                        match result with
+                        | SupplyPinResult.Opened _ -> ()
+                        | other -> failtest $"expected Opened, got {other}"
+                    }
+
+                    test "a PIN without the format spends no try" {
+                        let f = enrolFixture ()
+                        let state, attempt = suspendVia f seeded launch1 keyA "no-pin"
+                        let state, result = supply f state attempt (mailedCode f) "12"
+                        result |> Expect.equal "format" (SupplyPinResult.Refused PinRefusal.PinFormat)
+                        state.Codes["no-pin"].Tries |> Expect.equal "no try spent" 0
+                        let _, ok = supply f state attempt (mailedCode f) "1234"
+
+                        match ok with
+                        | SupplyPinResult.Opened _ -> ()
+                        | other -> failtest $"expected Opened, got {other}"
+                    }
+
+                    test "an expired code is refused and dropped with its attempts" {
+                        let f = enrolFixture ()
+                        let state, attempt = suspendVia f seeded launch1 keyA "no-pin"
+                        let code = mailedCode f
+                        let late = t0 + Hop.codeLifetime + TimeSpan.FromSeconds 1.0
+                        let state, result = supplyAt late f state attempt code "2468"
+
+                        result
+                        |> Expect.equal "expired" (SupplyPinResult.Refused PinRefusal.AttemptExpired)
+
+                        state.Codes |> Map.isEmpty |> Expect.isTrue "code dropped"
+                        state.Enrolments |> Map.isEmpty |> Expect.isTrue "attempt dropped"
+                        state.Credentials["no-pin"] |> Credential.pinSet |> Expect.isFalse "no PIN set"
+                    }
+
+                    test "an unknown attempt is expired" {
+                        let _, result = supply (enrolFixture ()) seeded "nope" "123456" "2468"
+
+                        result
+                        |> Expect.equal "expired" (SupplyPinResult.Refused PinRefusal.AttemptExpired)
+                    }
+
+                    test "the PIN-set mail falls back on the code's address when the registry cannot answer" {
+                        let f = enrolFixture ()
+                        let state, attempt = suspendVia f seeded launch1 keyA "no-pin"
+                        let code = mailedCode f
+
+                        let _, result =
+                            Hop.supplyPin
+                                t0
+                                f.ids
+                                salts
+                                codeMac
+                                (fun _ -> None)
+                                StubPatientData.port.read
+                                f.outbox.port.send
+                                attempt
+                                code
+                                "2468"
+                                state
+
+                        match result with
+                        | SupplyPinResult.Opened _ -> ()
+                        | other -> failtest $"expected Opened, got {other}"
+
+                        (f.outbox.sent () |> List.head).To
+                        |> Expect.equal "the code's address" "no-pin@stub.example"
+                    }
+
+                    test "the open closes the person's other Sessions (Rule 8)" {
+                        let f = enrolFixture ()
+                        // a PIN set by an earlier enrolment, then a Session, then a launch that... cannot
+                        // suspend any more. So: enrol in one browser while another Session of the same
+                        // person, opened before the PIN existed, cannot exist. The Rule 8 close still
+                        // runs in the same act; exercise it with a seeded prescriber turned no-pin.
+                        let state =
+                            { seeded with Credentials = seeded.Credentials |> Map.add "prescriber" Credential.empty }
+
+                        let state, a = suspendVia f state launch1 keyA "prescriber"
+                        let state, _ = supply f state a (mailedCode f) "2468"
+                        let state, cb = hopE f state (mintFor "n-2" "patient-1") keyB "prescriber"
+                        let state, second = runE f state cb
+
+                        match second with
+                        | CallbackResult.Opened(id2, _) ->
+                            state.Sessions |> Map.count |> Expect.equal "one Session" 1
+                            state.Sessions |> Map.containsKey id2 |> Expect.isTrue "the newer"
+                            state.Endings |> Map.count |> Expect.equal "the older marked" 1
+                        | other -> failtest $"expected Opened, got {other}"
+                    }
+                ]
+
+
+        let dropTests =
+            testList
+                "dropEnrolment"
+                [
+                    test "the last attempt takes the code along; another attempt keeps it" {
+                        let f = enrolFixture ()
+                        let state, a1 = suspendVia f seeded launch1 keyA "no-pin"
+                        let state, a2 = suspendVia f state (mintFor "n-2" "patient-1") keyB "no-pin"
+                        let state = Hop.dropEnrolment a1 state
+                        state.Codes |> Map.containsKey "no-pin" |> Expect.isTrue "code stands for a2"
+                        let state = Hop.dropEnrolment a2 state
+                        state.Codes |> Map.isEmpty |> Expect.isTrue "code gone with the last attempt"
+                        Hop.dropEnrolment "nope" state |> Expect.equal "unknown is nothing" state
+                    }
+                ]
+
+
         let tests =
             testList
                 "Hop"
@@ -1097,6 +1643,11 @@ module SessionStubTests =
                     standingTests
                     credentialStoreTests
                     mailTests
+                    helperTests
+                    suspendTests
+                    findTests
+                    supplyTests
+                    dropTests
                 ]
 
 
@@ -1105,7 +1656,7 @@ module SessionStubTests =
         let value = ref initial
 
         {
-            read = fun () -> value.Value
+            SessionCookie.read = fun () -> value.Value
             write = fun id -> value.Value <- Some id
             delete = fun () -> value.Value <- None
         },
@@ -1123,11 +1674,36 @@ module SessionStubTests =
         value
 
 
-    /// The stub env with a fresh session port over its own stub directory.
-    let envWithStub () =
-        let port, _, directory = makePort ()
+    /// An in-memory enrolment cookie: the attempt the browser would hold, and until when.
+    let memoryEnrolmentCookie (initial: string option) =
+        let value = ref initial
+        let until = ref None
+
+        {
+            EnrolmentCookie.read = fun () -> value.Value
+            write =
+                fun attempt u ->
+                    value.Value <- Some attempt
+                    until.Value <- Some u
+            delete = fun () -> value.Value <- None
+        },
+        value,
+        until
+
+
+    /// A browser that holds no attempt.
+    let noEnrolment () =
+        let cookie, _, _ = memoryEnrolmentCookie None
+        cookie
+
+
+    /// The stub env with a fresh session port over its own stub directory and outbox.
+    let envWithStubMail () =
+        let outbox = StubMail.make ()
+        let port, _, directory = makePortWith outbox
 
         directory,
+        outbox,
 
         { makeEnv
               (formularyAlwaysOk Formulary.empty)
@@ -1138,6 +1714,11 @@ module SessionStubTests =
         }
 
 
+    let envWithStub () =
+        let directory, _, env = envWithStubMail ()
+        directory, env
+
+
     /// Runs the whole hop for `choice`: present, the stub IdentityProvider, the callback.
     /// Returns the redirect the callback answered with.
     let openVia
@@ -1145,6 +1726,7 @@ module SessionStubTests =
         env
         (cookie: SessionCookie)
         (stateCookie: LaunchStateCookie)
+        (enrolment: EnrolmentCookie)
         launch
         key
         choice
@@ -1173,7 +1755,7 @@ module SessionStubTests =
                             Error = None
                         }
 
-                return! CompositionRoot.processCallback env cookie stateCookie cb
+                return! CompositionRoot.processCallback env cookie stateCookie enrolment cb
             | other -> return failtest $"expected RedirectTo, got {other}"
         }
 
@@ -1315,7 +1897,7 @@ module SessionStubTests =
                     let _, env = envWithStub ()
                     let cookie, _ = memoryCookie None
                     let stateCookie, _ = memoryStateCookie None
-                    let api = CompositionRoot.compose settings env cookie stateCookie
+                    let api = CompositionRoot.compose settings env cookie stateCookie (noEnrolment ())
                     let! answer = api.getSettings ()
                     answer |> Expect.equal "same value" settings
                 }
@@ -1360,7 +1942,15 @@ module SessionStubTests =
                     let stateCookie, _ = memoryStateCookie None
 
                     let! redirect =
-                        openVia directory env cookie stateCookie (mintFor "n-1" "stub-patient") keyA "prescriber"
+                        openVia
+                            directory
+                            env
+                            cookie
+                            stateCookie
+                            (noEnrolment ())
+                            (mintFor "n-1" "stub-patient")
+                            keyA
+                            "prescriber"
 
                     redirect |> Expect.equal "to the app" "/#/session"
                     held.Value |> Expect.isSome "cookie holds the id"
@@ -1379,7 +1969,15 @@ module SessionStubTests =
                     let stateCookie, _ = memoryStateCookie None
 
                     let! redirect =
-                        openVia directory env cookie stateCookie (mintFor "n-1" "stub-patient") keyA "unknown"
+                        openVia
+                            directory
+                            env
+                            cookie
+                            stateCookie
+                            (noEnrolment ())
+                            (mintFor "n-1" "stub-patient")
+                            keyA
+                            "unknown"
 
                     redirect |> Expect.equal "refused" "/#/session?refused=no-role"
                     held.Value |> Expect.isNone "no cookie"
@@ -1405,6 +2003,7 @@ module SessionStubTests =
                             env
                             cookie
                             noCookie
+                            (noEnrolment ())
                             {
                                 State = state
                                 StateCookie = None
@@ -1443,17 +2042,28 @@ module SessionStubTests =
                             Error = None
                         }
 
-                    let! _ = CompositionRoot.processCallback env cookie stateCookie cb1
+                    let! _ = CompositionRoot.processCallback env cookie stateCookie (noEnrolment ()) cb1
                     let first = held.Value.Value
 
                     // the same login launches again in another tab: the first Session is replaced
                     let stateCookie2, _ = memoryStateCookie None
-                    let! _ = openVia directory env cookie stateCookie2 (mintFor "n-2" "stub-patient") keyB "prescriber"
+
+                    let! _ =
+                        openVia
+                            directory
+                            env
+                            cookie
+                            stateCookie2
+                            (noEnrolment ())
+                            (mintFor "n-2" "stub-patient")
+                            keyB
+                            "prescriber"
+
                     let second = held.Value.Value
                     second |> Expect.notEqual "a newer session" first
 
                     // the first tab reloads its callback
-                    let! redirect = CompositionRoot.processCallback env cookie stateCookie cb1
+                    let! redirect = CompositionRoot.processCallback env cookie stateCookie (noEnrolment ()) cb1
                     redirect |> Expect.equal "to the app" "/#/session"
                     held.Value |> Expect.equal "the newer cookie stays" (Some second)
                 }
@@ -1461,7 +2071,7 @@ module SessionStubTests =
                 testAsync "GetSession: no cookie is None" {
                     let _, env = envWithStub ()
                     let cookie, _ = memoryCookie None
-                    let! response = CompositionRoot.processSession env cookie SessionCommand.GetSession
+                    let! response = CompositionRoot.processSession env cookie (noEnrolment ()) SessionCommand.GetSession
                     response |> Expect.equal "none" (SessionResponse.SessionResp None)
                 }
 
@@ -1469,11 +2079,21 @@ module SessionStubTests =
                     let directory, env = envWithStub ()
                     let cookie, held = memoryCookie None
                     let stateCookie, _ = memoryStateCookie None
-                    let! _ = openVia directory env cookie stateCookie (mintFor "n-1" "stub-patient") keyA "prescriber"
+
+                    let! _ =
+                        openVia
+                            directory
+                            env
+                            cookie
+                            stateCookie
+                            (noEnrolment ())
+                            (mintFor "n-1" "stub-patient")
+                            keyA
+                            "prescriber"
 
                     let later, _ = memoryCookie held.Value
 
-                    match! CompositionRoot.processSession env later SessionCommand.GetSession with
+                    match! CompositionRoot.processSession env later (noEnrolment ()) SessionCommand.GetSession with
                     | SessionResponse.SessionResp(Some session) ->
                         session.User
                         |> Option.map _.DisplayName
@@ -1486,16 +2106,39 @@ module SessionStubTests =
                     let directory, env = envWithStub ()
                     let cookie, held = memoryCookie None
                     let stateCookie, _ = memoryStateCookie None
-                    let! _ = openVia directory env cookie stateCookie (mintFor "n-1" "stub-patient") keyA "prescriber"
+
+                    let! _ =
+                        openVia
+                            directory
+                            env
+                            cookie
+                            stateCookie
+                            (noEnrolment ())
+                            (mintFor "n-1" "stub-patient")
+                            keyA
+                            "prescriber"
+
                     let first = held.Value.Value
 
                     let stateCookie2, _ = memoryStateCookie None
                     let other, _ = memoryCookie None
-                    let! _ = openVia directory env other stateCookie2 (mintFor "n-2" "stub-patient") keyB "prescriber"
+
+                    let! _ =
+                        openVia
+                            directory
+                            env
+                            other
+                            stateCookie2
+                            (noEnrolment ())
+                            (mintFor "n-2" "stub-patient")
+                            keyB
+                            "prescriber"
 
                     // the first browser still holds its cookie
                     let firstBrowser, heldFirst = memoryCookie (Some first)
-                    let! told = CompositionRoot.processSession env firstBrowser SessionCommand.GetSession
+
+                    let! told =
+                        CompositionRoot.processSession env firstBrowser (noEnrolment ()) SessionCommand.GetSession
 
                     told
                     |> Expect.equal "told" (SessionResponse.SessionEnded SessionEnding.SupersededByLaunch)
@@ -1503,25 +2146,28 @@ module SessionStubTests =
                     heldFirst.Value |> Expect.equal "cookie kept until acknowledged" (Some first)
 
                     // the answer was lost: the browser asks again and is told again
-                    let! second = CompositionRoot.processSession env firstBrowser SessionCommand.GetSession
+                    let! second =
+                        CompositionRoot.processSession env firstBrowser (noEnrolment ()) SessionCommand.GetSession
 
                     second
                     |> Expect.equal "told again" (SessionResponse.SessionEnded SessionEnding.SupersededByLaunch)
 
                     // the client acknowledges with a close: cookie deleted, ending dropped
-                    let! closed = CompositionRoot.processSession env firstBrowser SessionCommand.CloseSession
+                    let! closed =
+                        CompositionRoot.processSession env firstBrowser (noEnrolment ()) SessionCommand.CloseSession
+
                     closed |> Expect.equal "closed" SessionResponse.SessionClosed
                     heldFirst.Value |> Expect.isNone "cookie deleted"
 
                     let stale, _ = memoryCookie (Some first)
-                    let! third = CompositionRoot.processSession env stale SessionCommand.GetSession
+                    let! third = CompositionRoot.processSession env stale (noEnrolment ()) SessionCommand.GetSession
                     third |> Expect.equal "nothing left to tell" (SessionResponse.SessionResp None)
                 }
 
                 testAsync "GetSession: a cookie for an unknown session is None" {
                     let _, env = envWithStub ()
                     let cookie, _ = memoryCookie (Some "stale")
-                    let! response = CompositionRoot.processSession env cookie SessionCommand.GetSession
+                    let! response = CompositionRoot.processSession env cookie (noEnrolment ()) SessionCommand.GetSession
                     response |> Expect.equal "none" (SessionResponse.SessionResp None)
                 }
 
@@ -1529,9 +2175,23 @@ module SessionStubTests =
                     let directory, env = envWithStub ()
                     let cookie, held = memoryCookie None
                     let stateCookie, _ = memoryStateCookie None
-                    let! _ = openVia directory env cookie stateCookie (mintFor "n-1" "stub-patient") keyA "prescriber"
+
+                    let! _ =
+                        openVia
+                            directory
+                            env
+                            cookie
+                            stateCookie
+                            (noEnrolment ())
+                            (mintFor "n-1" "stub-patient")
+                            keyA
+                            "prescriber"
+
                     let id = held.Value.Value
-                    let! response = CompositionRoot.processSession env cookie SessionCommand.CloseSession
+
+                    let! response =
+                        CompositionRoot.processSession env cookie (noEnrolment ()) SessionCommand.CloseSession
+
                     response |> Expect.equal "closed" SessionResponse.SessionClosed
                     held.Value |> Expect.isNone "cookie deleted"
                     let! found = env.session.find id
@@ -1541,7 +2201,10 @@ module SessionStubTests =
                 testAsync "CloseSession without a cookie still deletes (idempotent)" {
                     let _, env = envWithStub ()
                     let cookie, held = memoryCookie None
-                    let! response = CompositionRoot.processSession env cookie SessionCommand.CloseSession
+
+                    let! response =
+                        CompositionRoot.processSession env cookie (noEnrolment ()) SessionCommand.CloseSession
+
                     response |> Expect.equal "closed" SessionResponse.SessionClosed
                     held.Value |> Expect.isNone "still none"
                 }
@@ -1560,7 +2223,7 @@ module SessionStubTests =
                     let cookie, held = memoryCookie (Some "session-1")
 
                     let! result =
-                        CompositionRoot.processSession env cookie SessionCommand.CloseSession
+                        CompositionRoot.processSession env cookie (noEnrolment ()) SessionCommand.CloseSession
                         |> Async.Catch
 
                     match result with
@@ -1584,6 +2247,7 @@ module SessionStubTests =
                             env
                             cookie
                             stateCookie
+                            (noEnrolment ())
                             {
                                 State = "st"
                                 StateCookie = None
@@ -1594,8 +2258,182 @@ module SessionStubTests =
                     redirect |> Expect.equal "invalid" "/#/session?refused=invalid"
                     held.Value |> Expect.equal "cookie untouched" (Some "any")
 
-                    let! response = CompositionRoot.processSession env cookie SessionCommand.GetSession
+                    let! response = CompositionRoot.processSession env cookie (noEnrolment ()) SessionCommand.GetSession
                     response |> Expect.equal "nothing" (SessionResponse.SessionResp None)
+                }
+            ]
+
+
+    /// The code the newest confirmation mail in the outbox carries.
+    let mailedCode (outbox: StubMail.Outbox) =
+        let body =
+            (outbox.sent () |> List.find (fun m -> m.Subject.Contains "confirmation code")).Body
+
+        let i = body.IndexOf "code is " + 8
+        body.Substring(i, 6)
+
+
+    let enrolmentCompositionTests =
+        testList
+            "processCallback and processSession while enrolling (UC-2)"
+            [
+                testAsync
+                    "no-pin: the callback sets the enrolment cookie, GetSession tells the pending enrolment, SupplyPin opens and swaps the cookies" {
+                    let directory, outbox, env = envWithStubMail ()
+                    let cookie, held = memoryCookie None
+                    let stateCookie, _ = memoryStateCookie None
+                    let enrolment, attempt, until = memoryEnrolmentCookie None
+
+                    let! redirect =
+                        openVia directory env cookie stateCookie enrolment (mintFor "n-1" "stub-patient") keyA "no-pin"
+
+                    redirect |> Expect.equal "to the app" "/#/session"
+                    held.Value |> Expect.isNone "no session cookie"
+                    attempt.Value |> Expect.isSome "enrolment cookie"
+
+                    until.Value
+                    |> Expect.equal "until the code expires" (Some(t0 + Hop.codeLifetime))
+
+                    let! pending = CompositionRoot.processSession env cookie enrolment SessionCommand.GetSession
+
+                    pending
+                    |> Expect.equal
+                        "pending"
+                        (SessionResponse.EnrolmentPending
+                            {
+                                DisplayName = "Stub Prescriber (no PIN)"
+                                MailHint = "n***@stub.example"
+                            })
+
+                    let! wrong =
+                        CompositionRoot.processSession env cookie enrolment (SessionCommand.SupplyPin("000000", "2468"))
+
+                    wrong
+                    |> Expect.equal "wrong code" (SessionResponse.PinRefused(PinRefusal.WrongCode 2))
+
+                    attempt.Value |> Expect.isSome "cookie kept"
+
+                    let! opened =
+                        CompositionRoot.processSession
+                            env
+                            cookie
+                            enrolment
+                            (SessionCommand.SupplyPin(mailedCode outbox, "2468"))
+
+                    match opened with
+                    | SessionResponse.SessionResp(Some session) ->
+                        session.User |> Option.map _.UserId |> Expect.equal "user" (Some "no-pin")
+                    | other -> failtest $"expected SessionResp, got {other}"
+
+                    held.Value |> Expect.isSome "session cookie set"
+                    attempt.Value |> Expect.isNone "enrolment cookie deleted"
+                    outbox.sent () |> List.length |> Expect.equal "two mails" 2
+
+                    let! found = CompositionRoot.processSession env cookie enrolment SessionCommand.GetSession
+
+                    match found with
+                    | SessionResponse.SessionResp(Some _) -> ()
+                    | other -> failtest $"expected the Session, got {other}"
+                }
+
+                testAsync "a void code deletes the enrolment cookie; a gone attempt at GetSession does too" {
+                    let directory, _, env = envWithStubMail ()
+                    let cookie, _ = memoryCookie None
+                    let stateCookie, _ = memoryStateCookie None
+                    let enrolment, attempt, _ = memoryEnrolmentCookie None
+
+                    let! _ =
+                        openVia directory env cookie stateCookie enrolment (mintFor "n-1" "stub-patient") keyA "no-pin"
+
+                    for _ in 1..2 do
+                        let! _ =
+                            CompositionRoot.processSession
+                                env
+                                cookie
+                                enrolment
+                                (SessionCommand.SupplyPin("000000", "2468"))
+
+                        ()
+
+                    let! void' =
+                        CompositionRoot.processSession env cookie enrolment (SessionCommand.SupplyPin("000000", "2468"))
+
+                    void' |> Expect.equal "void" (SessionResponse.PinRefused PinRefusal.CodeVoid)
+                    attempt.Value |> Expect.isNone "cookie deleted"
+
+                    let stale, attemptRef, _ = memoryEnrolmentCookie (Some "gone")
+                    let! nothing = CompositionRoot.processSession env cookie stale SessionCommand.GetSession
+                    nothing |> Expect.equal "nothing" (SessionResponse.SessionResp None)
+                    attemptRef.Value |> Expect.isNone "stale cookie deleted"
+                }
+
+                testAsync
+                    "SupplyPin without an enrolment cookie is expired; CloseSession while enrolling drops the attempt" {
+                    let directory, _, env = envWithStubMail ()
+                    let cookie, _ = memoryCookie None
+                    let stateCookie, _ = memoryStateCookie None
+
+                    let! expired =
+                        CompositionRoot.processSession
+                            env
+                            cookie
+                            (noEnrolment ())
+                            (SessionCommand.SupplyPin("123456", "2468"))
+
+                    expired
+                    |> Expect.equal "expired" (SessionResponse.PinRefused PinRefusal.AttemptExpired)
+
+                    let enrolment, attempt, _ = memoryEnrolmentCookie None
+
+                    let! _ =
+                        openVia directory env cookie stateCookie enrolment (mintFor "n-1" "stub-patient") keyA "no-pin"
+
+                    let held = attempt.Value
+                    let! closed = CompositionRoot.processSession env cookie enrolment SessionCommand.CloseSession
+                    closed |> Expect.equal "closed" SessionResponse.SessionClosed
+                    attempt.Value |> Expect.isNone "cookie deleted"
+                    let stale, _, _ = memoryEnrolmentCookie held
+                    let! nothing = CompositionRoot.processSession env cookie stale SessionCommand.GetSession
+                    nothing |> Expect.equal "the attempt is gone" (SessionResponse.SessionResp None)
+                }
+
+                testAsync "the Session wins over a stale enrolment cookie" {
+                    let directory, _, env = envWithStubMail ()
+                    let cookie, _ = memoryCookie None
+                    let stateCookie, _ = memoryStateCookie None
+                    let enrolment, _, _ = memoryEnrolmentCookie (Some "stale")
+
+                    let! _ =
+                        openVia
+                            directory
+                            env
+                            cookie
+                            stateCookie
+                            enrolment
+                            (mintFor "n-1" "stub-patient")
+                            keyA
+                            "prescriber"
+
+                    let! found = CompositionRoot.processSession env cookie enrolment SessionCommand.GetSession
+
+                    match found with
+                    | SessionResponse.SessionResp(Some _) -> ()
+                    | other -> failtest $"expected the Session, got {other}"
+                }
+
+                testAsync "the disabled port refuses to enrol" {
+                    let cookie, _ = memoryCookie None
+                    let enrolment, attempt, _ = memoryEnrolmentCookie (Some "any")
+
+                    let env = { snd (envWithStub ()) with session = Adapters.sessionDisabled }
+
+                    let! refused =
+                        CompositionRoot.processSession env cookie enrolment (SessionCommand.SupplyPin("123456", "2468"))
+
+                    refused
+                    |> Expect.equal "expired" (SessionResponse.PinRefused PinRefusal.AttemptExpired)
+
+                    attempt.Value |> Expect.isNone "cookie deleted"
                 }
             ]
 
@@ -1609,6 +2447,7 @@ module SessionStubTests =
                 HopTests.tests
                 stubLaunchTests
                 compositionTests
+                enrolmentCompositionTests
             ]
 
 

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -1561,6 +1561,70 @@ module SessionStubTests =
                         |> Expect.equal "expired" (SupplyPinResult.Refused PinRefusal.AttemptExpired)
                     }
 
+                    test
+                        "the registry is asked again at the supply: the Role is re-taken, another active Patient sets the PIN but opens nothing (Rule 6)" {
+                        let f = enrolFixture ()
+                        let state, attempt = suspendVia f seeded launch1 keyA "no-pin"
+                        let code = mailedCode f
+
+                        let moved identity =
+                            f.d.registry.standing identity
+                            |> Option.map (fun s -> { s with ActivePatientId = Some "other-patient" })
+
+                        let state, result =
+                            Hop.supplyPin
+                                t0
+                                f.ids
+                                salts
+                                codeMac
+                                moved
+                                StubPatientData.port.read
+                                f.outbox.port.send
+                                attempt
+                                code
+                                "2468"
+                                state
+
+                        result
+                        |> Expect.equal "no Session" (SupplyPinResult.Refused PinRefusal.WrongActivePatient)
+
+                        state.Sessions |> Map.isEmpty |> Expect.isTrue "nothing opened"
+
+                        state.Credentials["no-pin"]
+                        |> Credential.pinSet
+                        |> Expect.isTrue "the PIN is set (Rule 37)"
+
+                        state.Codes |> Map.isEmpty |> Expect.isTrue "code dropped"
+                        f.outbox.sent () |> List.length |> Expect.equal "told" 2
+
+                        let state, attempt = suspendVia f seeded launch1 keyA "no-pin"
+
+                        let reader identity =
+                            f.d.registry.standing identity
+                            |> Option.map (fun s -> { s with User = { s.User with Role = UserRole.Reader } })
+
+                        let _, result =
+                            Hop.supplyPin
+                                t0
+                                f.ids
+                                salts
+                                codeMac
+                                reader
+                                StubPatientData.port.read
+                                f.outbox.port.send
+                                attempt
+                                (mailedCode f)
+                                "2468"
+                                state
+
+                        match result with
+                        | SupplyPinResult.Opened(_, session) ->
+                            session.User
+                            |> Option.map _.Role
+                            |> Expect.equal "the fresh Role" (Some UserRole.Reader)
+                        | other -> failtest $"expected Opened, got {other}"
+                    }
+
                     test "the PIN-set mail falls back on the code's address when the registry cannot answer" {
                         let f = enrolFixture ()
                         let state, attempt = suspendVia f seeded launch1 keyA "no-pin"
@@ -2419,6 +2483,41 @@ module SessionStubTests =
                     match found with
                     | SessionResponse.SessionResp(Some _) -> ()
                     | other -> failtest $"expected the Session, got {other}"
+                }
+
+                testAsync "an enrolling callback replaces the Session this browser still held" {
+                    let directory, _, env = envWithStubMail ()
+                    let cookie, held = memoryCookie None
+                    let stateCookie, _ = memoryStateCookie None
+                    let enrolment, attempt, _ = memoryEnrolmentCookie None
+
+                    let! _ =
+                        openVia
+                            directory
+                            env
+                            cookie
+                            stateCookie
+                            enrolment
+                            (mintFor "n-1" "stub-patient")
+                            keyA
+                            "prescriber"
+
+                    let old = held.Value
+                    old |> Expect.isSome "a Session"
+
+                    let! _ =
+                        openVia directory env cookie stateCookie enrolment (mintFor "n-2" "stub-patient") keyB "no-pin"
+
+                    held.Value |> Expect.isNone "session cookie gone"
+                    attempt.Value |> Expect.isSome "enrolment cookie"
+                    let! pending = CompositionRoot.processSession env cookie enrolment SessionCommand.GetSession
+
+                    match pending with
+                    | SessionResponse.EnrolmentPending _ -> ()
+                    | other -> failtest $"expected EnrolmentPending, got {other}"
+
+                    let! gone = env.session.find old.Value
+                    gone |> Expect.equal "the old Session is closed" SessionLookup.NotFound
                 }
 
                 testAsync "the disabled port refuses to enrol" {

--- a/tests/Informedica.GenPRES.Shared.Tests/SessionGatePolicyTests.fs
+++ b/tests/Informedica.GenPRES.Shared.Tests/SessionGatePolicyTests.fs
@@ -80,6 +80,12 @@ module SessionGatePolicyTests =
                                 "Unreachable", Session.Unreachable(launch, key, 3)
                                 "Refused", Session.Refused(LaunchRefusal.NoRole, None)
                                 "Ended", Session.Ended SessionEnding.SupersededByLaunch
+                                "Enrolling",
+                                Session.Enrolling
+                                    {
+                                        DisplayName = "Stub Prescriber (no PIN)"
+                                        MailHint = "n***@stub.example"
+                                    }
                             ] do
                             test name {
                                 gateFor english session |> Expect.isSome "gate"

--- a/tests/Informedica.GenPRES.Shared.Tests/SessionMachineTests.fs
+++ b/tests/Informedica.GenPRES.Shared.Tests/SessionMachineTests.fs
@@ -319,6 +319,20 @@ module SessionMachineTests =
                         (Session.Ended SessionEnding.SupersededByLaunch, [ SessionEffect.CallCloseSession ])
                 }
 
+                test "Resumed with a pending enrolment is Enrolling, and a new launch presents (UC-2)" {
+                    let pending: EnrolmentPending =
+                        {
+                            DisplayName = "Stub Prescriber (no PIN)"
+                            MailHint = "n***@stub.example"
+                        }
+
+                    transition (SessionMsg.Resumed(Ok(ResumeResult.Enrolling pending))) Session.Resuming
+                    |> Expect.equal "enrolling" (Session.Enrolling pending, [])
+
+                    transition (SessionMsg.Present(launchB, keyB)) (Session.Enrolling pending)
+                    |> Expect.equal "presents" (Session.present launchB keyB)
+                }
+
                 test "from Ended the anonymous open carries nothing over, and a new launch presents" {
                     let ended = Session.Ended SessionEnding.SupersededByLaunch
 


### PR DESCRIPTION
## Summary

Plan [615](https://github.com/informedica/GenPRES/blob/master/docs/implementation-plans/615-enrolment-with-server-stubs.md) step 2: the launch suspends into enrolment instead of refusing, and continues when the PIN is supplied (UC-2, Rules 7, 25, 27, 28, 37, 40). The client shows the pending enrolment as a gate; the form is step 3.

- **Suspend.** At 5.4 a Prescriber whose credential has no PIN gets a `PendingCode` per credential (six digits from the CSPRNG, stored as a mac under the host key, fifteen minutes, one live code per person) and an `Enrolment` per launch that keeps that browser's public key. The code is mailed to the address the registry gave on this request; a second launch while the code stands gets its own attempt and no second mail (ext 2a). The callback answers `Enrolling (attempt, redirect, until)`; the edge sets `genpres_enrolment` (HttpOnly, Strict, `Path=/`, `Max-Age` what remains of the code) and redirects to `#/session`. A callback reload while the attempt stands is answered with it again (Rule 45); once it is gone, a relaunch is asked for.
- **Supply.** `SupplyPin` works on the attempt in the cookie only. Wrong codes count across the attempts of one code and the third voids it (`CodeVoid`, terminal); a PIN outside four to six digits spends no try (`PinFormat`); an expired or unknown attempt is `AttemptExpired`. The right code sets the PIN with a zero wrong-count, drops the code and every attempt bound to it, mails "PIN was set" to the registry's fresh address (falling back on the code's), and opens the Session through the existing one-act open on the supplying attempt's key.
- **Wire.** `EnrolmentPending { DisplayName; MailHint }`, `PinRefusal`, `SessionCommand.SupplyPin`, `SessionResponse.EnrolmentPending | PinRefused`. `GetSession` answers the Session first, then a standing attempt, and deletes the cookie of a gone one. `CloseSession` drops both cookies and the attempt. The disabled production port refuses to enrol.
- **Client, minimal.** `Session.Enrolling`, `ResumeResult.Enrolling`; the gate shows the existing enrolment text with no actions; the title bar shows nobody.
- **Script-first.** `Server/Scripts/Enrolment.fsx` (29 tests) is the draft; the source mirrors it.

The diff is large for the same reason as #617: the hop tests grow a mail port and a code source, and 31 server and 2 shared tests are added.

## Checks

- `dotnet run Build`, 204 server tests (31 new), 431 shared tests (2 new), Fable compile, Fantomas clean.
- Chrome, `GENPRES_PROD=0 dotnet run`, fresh context: `no-pin` on `/stub/launch` runs the hop and lands on the gate; `GetSession` answers `EnrolmentPending` with the hint `n***@stub.example`; `/stub/mail` shows the confirmation code; `SupplyPin` with a wrong code answers `WrongCode 2`, with a short PIN `PinFormat`, with the code and `2468` the opened Session; a reload shows **Stub Prescriber (no PIN)** as Prescriber, and the outbox holds both mails. A second fresh context launching `no-pin` opens directly: the PIN persists for the host.

## AI-assisted contribution

Drafted in the script by Claude Code, reviewed and migrated by the maintainer; verified by the tests and the browser walk above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZWjibQUW8uqCVbfV4vDTf
