### PR TITLE
feat(client): the enrolment form on the session gate

### DIFF
--- a/src/Informedica.GenPRES.Client/App.fs
+++ b/src/Informedica.GenPRES.Client/App.fs
@@ -631,6 +631,24 @@ module private Elmish =
                 | Choice2Of2 ex -> return SessionMsg(SessionMsg.CloseFailed ex.Message)
             }
             |> Cmd.fromAsync
+        | SessionEffect.CallSupplyPin(code, pin) ->
+            async {
+                try
+                    match! serverApi.processSession (Api.SessionCommand.SupplyPin(code, pin)) with
+                    | Api.SessionResponse.SessionResp(Some session) ->
+                        return SessionMsg(SessionMsg.PinAnswered(Ok(PinOutcome.Opened session)))
+                    | Api.SessionResponse.PinRefused refusal ->
+                        return SessionMsg(SessionMsg.PinAnswered(Ok(PinOutcome.Refused refusal)))
+                    // never an answer to SupplyPin: the attempt is gone, whatever happened
+                    | Api.SessionResponse.SessionResp None
+                    | Api.SessionResponse.SessionClosed
+                    | Api.SessionResponse.SessionEnded _
+                    | Api.SessionResponse.EnrolmentPending _ ->
+                        return SessionMsg(SessionMsg.PinAnswered(Ok(PinOutcome.Refused PinRefusal.AttemptExpired)))
+                with ex ->
+                    return SessionMsg(SessionMsg.PinAnswered(Error ex.Message))
+            }
+            |> Cmd.fromAsync
         | SessionEffect.GoTo url -> Cmd.ofEffect (fun _ -> Browser.Dom.window.location.assign url)
         | SessionEffect.SetPatient patient -> Cmd.ofMsg (UpdatePatient patient)
         | SessionEffect.KeepKey thumbprint ->
@@ -945,6 +963,15 @@ module private Elmish =
 
                     { state with
                         SnackbarMsg = "De sessie kon niet worden gesloten. Probeer het opnieuw."
+                        SnackbarOpen = true
+                        SnackbarSeverity = "error"
+                    }
+                // the same for a PIN that never reached the server: the form comes back as it was
+                | SessionMsg.PinAnswered(Error reason), Session.SupplyingPin _ ->
+                    Logging.error "could not send the PIN to the server" reason
+
+                    { state with
+                        SnackbarMsg = "De pincode kon niet worden verstuurd. Probeer het opnieuw."
                         SnackbarOpen = true
                         SnackbarSeverity = "error"
                     }
@@ -1381,6 +1408,9 @@ type private ConcreteAppEnv
 
         member _.OpenAnonymously() =
             SessionMsg SessionMsg.OpenAnonymous |> dispatch
+
+        member _.SupplyPin code pin =
+            SessionMsg(SessionMsg.SupplyPin(code, pin)) |> dispatch
 
     interface AppEnv.IAuthentication with
         member _.IsAuthenticated = state.IsAuthenticated

--- a/src/Informedica.GenPRES.Client/AppEnv.fs
+++ b/src/Informedica.GenPRES.Client/AppEnv.fs
@@ -80,6 +80,8 @@ type ISession =
     abstract Retry: unit -> unit
     // ext 5a: a fresh anonymous open that carries nothing over
     abstract OpenAnonymously: unit -> unit
+    // UC-2: the confirmation code and the chosen PIN, from the gate's form
+    abstract SupplyPin: string -> string -> unit
 
 
 /// Authentication state and commands

--- a/src/Informedica.GenPRES.Client/Components/TitleBar.fs
+++ b/src/Informedica.GenPRES.Client/Components/TitleBar.fs
@@ -253,7 +253,9 @@ module TitleBar =
             | Session.Refused _
             | Session.Unreachable _
             | Session.Ended _
-            | Session.Enrolling _ -> None
+            | Session.Enrolling _
+            | Session.SupplyingPin _
+            | Session.EnrolmentFailed _ -> None
             |> Option.defaultValue null
 
         JSX.jsx

--- a/src/Informedica.GenPRES.Client/SessionGatePolicy.fs
+++ b/src/Informedica.GenPRES.Client/SessionGatePolicy.fs
@@ -18,13 +18,27 @@ type Action =
     | ContinueWithoutLaunch
 
 
-/// One gate: a title, a body, whether work is in progress, and the actions.
+/// The enrolment form (UC-2): the labels of its three fields and its button, and what the
+/// server said about the last submission, if anything.
+type EnrolmentForm =
+    {
+        Code: string
+        Pin: string
+        Repeat: string
+        Submit: string
+        Error: string option
+    }
+
+
+/// One gate: a title, a body, whether work is in progress, the actions, and the form when the
+/// launch waits on a PIN.
 type Gate =
     {
         Title: string
         Body: string
         Busy: bool
         Actions: Action list
+        Form: EnrolmentForm option
     }
 
 
@@ -51,8 +65,7 @@ let english (term: Terms) =
         "You have no role in GenPRES. You can continue without a launch: no patient is carried over."
     | Terms.``Session Refusal Wrong Patient`` ->
         "The patient active in MainEHR is not the patient of this launch. Activate the right patient and open GenPRES again from MainEHR."
-    | Terms.``Session Refusal Enrolment`` ->
-        "A PIN has to be set before prescribing. Enrolment is not available yet. Open GenPRES again from MainEHR."
+    | Terms.``Session Refusal Enrolment`` -> "A PIN has to be set before prescribing. Open GenPRES again from MainEHR."
     | Terms.``Session Try Again`` -> "Try again"
     | Terms.``Session Continue Without Launch`` -> "Continue without launch"
     | Terms.``Session Close`` -> "Close session"
@@ -60,6 +73,19 @@ let english (term: Terms) =
     | Terms.``Session Role Reader`` -> "Reader"
     | Terms.``Session Gate Ended`` -> "Your session was ended"
     | Terms.``Session Ending Superseded`` -> "Another launch of yours opened a newer session, and this one was closed."
+    | Terms.``Session Gate Enrolment`` -> "Set a PIN to continue"
+    | Terms.``Session Gate Enrolment Text`` ->
+        "Welcome, {0}. A confirmation code was mailed to {1}. Enter it together with the PIN of your choice: four to six digits."
+    | Terms.``Session Enrolment Code`` -> "Confirmation code"
+    | Terms.``Session Enrolment Pin`` -> "PIN"
+    | Terms.``Session Enrolment Pin Repeat`` -> "Repeat the PIN"
+    | Terms.``Session Enrolment Submit`` -> "Set PIN"
+    | Terms.``Session Enrolment Code Format`` -> "The confirmation code has six digits."
+    | Terms.``Session Enrolment Pin Format`` -> "The PIN has four to six digits."
+    | Terms.``Session Enrolment Pins Differ`` -> "The two PINs differ."
+    | Terms.``Session Enrolment Wrong Code`` -> "The code is not right. {0} tries left."
+    | Terms.``Session Enrolment Code Void`` -> "The code is void after three wrong tries."
+    | Terms.``Session Enrolment Expired`` -> "The enrolment has expired."
     | _ -> $"{term}"
 
 
@@ -100,6 +126,38 @@ let refusalBody (tr: Terms -> string) refusal =
     | LaunchRefusal.EnrolmentRequired -> [ tr Terms.``Session Refusal Enrolment`` ]
 
 
+/// Digits only, of a given length range: what the form checks before the server does.
+let digits (min: int) (max: int) (s: string) =
+    not (isNull s)
+    && s.Length >= min
+    && s.Length <= max
+    && s |> Seq.forall (fun c -> c >= '0' && c <= '9')
+
+
+/// The form's own check before a submission (UC-2): the code has six digits, the PIN four to
+/// six, and the repeat agrees. The first thing wrong, as a translated sentence; None when the
+/// submission can go.
+let formError (tr: Terms -> string) (code: string) (pin: string) (repeat: string) : string option =
+    if not (digits 6 6 code) then
+        Some(tr Terms.``Session Enrolment Code Format``)
+    elif not (digits 4 6 pin) then
+        Some(tr Terms.``Session Enrolment Pin Format``)
+    elif pin <> repeat then
+        Some(tr Terms.``Session Enrolment Pins Differ``)
+    else
+        None
+
+
+/// What the server said about a submission that left the form open.
+let refusalSentence (tr: Terms -> string) (refusal: PinRefusal) =
+    match refusal with
+    | PinRefusal.WrongCode left -> tr Terms.``Session Enrolment Wrong Code`` |> fill [ $"%i{left}" ]
+    | PinRefusal.PinFormat -> tr Terms.``Session Enrolment Pin Format``
+    | PinRefusal.CodeVoid -> tr Terms.``Session Enrolment Code Void``
+    | PinRefusal.AttemptExpired -> tr Terms.``Session Enrolment Expired``
+    | PinRefusal.WrongActivePatient -> tr Terms.``Session Refusal Wrong Patient``
+
+
 /// Whether the gate is over the app: false while the app is usable (anonymous, open, closing).
 let isGated (session: Session) =
     match session with
@@ -111,7 +169,9 @@ let isGated (session: Session) =
     | Session.Unreachable _
     | Session.Refused _
     | Session.Ended _
-    | Session.Enrolling _ -> true
+    | Session.Enrolling _
+    | Session.SupplyingPin _
+    | Session.EnrolmentFailed _ -> true
 
 
 /// The gate for a session phase, or None when the app is usable (anonymous, open, closing).
@@ -126,6 +186,7 @@ let gateFor (tr: Terms -> string) (session: Session) : Gate option =
                     |> fill [ $"%i{attempt}"; $"%i{Session.maxAttempts}" ]
                 Busy = true
                 Actions = []
+                Form = None
             }
     | Session.Resuming ->
         Some
@@ -134,6 +195,7 @@ let gateFor (tr: Terms -> string) (session: Session) : Gate option =
                 Body = tr Terms.``Session Gate Resuming Text``
                 Busy = true
                 Actions = []
+                Form = None
             }
     | Session.Unreachable(_, _, attempts) ->
         Some
@@ -147,6 +209,7 @@ let gateFor (tr: Terms -> string) (session: Session) : Gate option =
                         ]
                 Busy = false
                 Actions = [ Action.Retry ]
+                Form = None
             }
     | Session.Refused(refusal, retry) ->
         Some
@@ -169,6 +232,7 @@ let gateFor (tr: Terms -> string) (session: Session) : Gate option =
                         | _, Some _ -> Action.Retry
                         | _ -> ()
                     ]
+                Form = None
             }
     | Session.Ended ending ->
         Some
@@ -183,16 +247,53 @@ let gateFor (tr: Terms -> string) (session: Session) : Gate option =
                         ]
                 Busy = false
                 Actions = [ Action.ContinueWithoutLaunch ]
+                Form = None
             }
-    // UC-2, until the form lands (plan 615, step 3): the launch waits on a PIN and the gate
-    // says what the refusal said, a relaunch
-    | Session.Enrolling _ ->
+    // UC-2: the launch waits on a PIN; the form asks for the mailed code and the PIN twice
+    | Session.Enrolling(pending, refusal) ->
+        Some
+            {
+                Title = tr Terms.``Session Gate Enrolment``
+                Body =
+                    tr Terms.``Session Gate Enrolment Text``
+                    |> fill [ pending.DisplayName; pending.MailHint ]
+                Busy = false
+                Actions = []
+                Form =
+                    Some
+                        {
+                            Code = tr Terms.``Session Enrolment Code``
+                            Pin = tr Terms.``Session Enrolment Pin``
+                            Repeat = tr Terms.``Session Enrolment Pin Repeat``
+                            Submit = tr Terms.``Session Enrolment Submit``
+                            Error = refusal |> Option.map (refusalSentence tr)
+                        }
+            }
+    | Session.SupplyingPin pending ->
+        Some
+            {
+                Title = tr Terms.``Session Gate Enrolment``
+                Body =
+                    tr Terms.``Session Gate Enrolment Text``
+                    |> fill [ pending.DisplayName; pending.MailHint ]
+                Busy = true
+                Actions = []
+                Form = None
+            }
+    // the enrolment ended without a Session: the code void or expired, or the Patient moved
+    | Session.EnrolmentFailed refusal ->
         Some
             {
                 Title = tr Terms.``Session Gate Refused``
-                Body = sentences [ tr Terms.``Session Refusal Enrolment`` ]
+                Body =
+                    sentences
+                        [
+                            refusalSentence tr refusal
+                            tr Terms.``Session Relaunch``
+                        ]
                 Busy = false
                 Actions = []
+                Form = None
             }
     | Session.Anonymous
     | Session.Open _

--- a/src/Informedica.GenPRES.Client/SessionMachine.fs
+++ b/src/Informedica.GenPRES.Client/SessionMachine.fs
@@ -35,8 +35,13 @@ type Session =
     // anonymously or relaunches
     | Ended of SessionEnding
     // no Session yet: the launch waits on a PIN (UC-2); the browser holds the attempt in a
-    // cookie, and the form to supply the code and the PIN follows (plan 615, step 3)
-    | Enrolling of EnrolmentPending
+    // cookie, the gate shows the form, and the last refusal of the form if any
+    | Enrolling of EnrolmentPending * refusal: PinRefusal option
+    // SupplyPin in flight
+    | SupplyingPin of EnrolmentPending
+    // no Session: the enrolment ended without a PIN (the code void or expired) or, the PIN
+    // set, with another Patient active (Rule 6); a relaunch is the only way on
+    | EnrolmentFailed of PinRefusal
 
 
 /// What GetSession answered at a resume.
@@ -46,6 +51,13 @@ type ResumeResult =
     | NotFound
     | Ended of SessionEnding
     | Enrolling of EnrolmentPending
+
+
+/// What SupplyPin answered.
+[<RequireQualifiedAccess>]
+type PinOutcome =
+    | Opened of SessionOpened
+    | Refused of PinRefusal
 
 
 [<RequireQualifiedAccess>]
@@ -58,6 +70,10 @@ type SessionMsg =
     | Retry
     | Resume
     | Resumed of Result<ResumeResult, string>
+    // UC-2: the confirmation code and the chosen PIN, from the gate's form
+    | SupplyPin of code: string * pin: string
+    // Error = transport failure
+    | PinAnswered of Result<PinOutcome, string>
     // from #/session?refused={reason}, launch step 4.5
     | RefusedAtCallback of LaunchRefusal
     | OpenAnonymous
@@ -72,6 +88,7 @@ type SessionEffect =
     | CallPresentLaunch of Launch * PublicKey
     | CallGetSession
     | CallCloseSession
+    | CallSupplyPin of code: string * pin: string
     // window.location.assign, for RedirectTo
     | GoTo of url: string
     // interpreted as UpdatePatient, so everything derived from the patient reloads
@@ -151,13 +168,31 @@ module Session =
         // the close acknowledges the ending: the server deletes the cookie and drops the mark
         | SessionMsg.Resumed(Ok(ResumeResult.Ended ending)), Session.Resuming ->
             Session.Ended ending, [ SessionEffect.CallCloseSession ]
-        // the launch waits on a PIN (UC-2): the gate says so, the form follows in step 3
-        | SessionMsg.Resumed(Ok(ResumeResult.Enrolling pending)), Session.Resuming -> Session.Enrolling pending, []
+        // the launch waits on a PIN (UC-2): the gate shows the form
+        | SessionMsg.Resumed(Ok(ResumeResult.Enrolling pending)), Session.Resuming ->
+            Session.Enrolling(pending, None), []
         | SessionMsg.Resumed _, Session.Resuming -> Session.Anonymous, []
         | SessionMsg.Resumed _, _ -> state, []
 
         // the Launch was consumed server-side; nothing is left to retry with
         | SessionMsg.RefusedAtCallback refusal, _ -> Session.Refused(refusal, None), []
+
+        // UC-2: the form is sent once at a time; the answer lands only on the request in flight
+        | SessionMsg.SupplyPin(code, pin), Session.Enrolling(pending, _) ->
+            Session.SupplyingPin pending, [ SessionEffect.CallSupplyPin(code, pin) ]
+        | SessionMsg.SupplyPin _, _ -> state, []
+        | SessionMsg.PinAnswered(Ok(PinOutcome.Opened session)), Session.SupplyingPin _ -> opened session
+        // the form stays open with what went wrong (ext 2b, a try left; a PIN out of format)
+        | SessionMsg.PinAnswered(Ok(PinOutcome.Refused(PinRefusal.WrongCode _ as refusal))),
+          Session.SupplyingPin pending
+        | SessionMsg.PinAnswered(Ok(PinOutcome.Refused(PinRefusal.PinFormat as refusal))), Session.SupplyingPin pending ->
+            Session.Enrolling(pending, Some refusal), []
+        // terminal: the code is void or expired, or the Patient moved (Rule 6); relaunch
+        | SessionMsg.PinAnswered(Ok(PinOutcome.Refused refusal)), Session.SupplyingPin _ ->
+            Session.EnrolmentFailed refusal, []
+        // the request never got there: the attempt stands, the form comes back as it was
+        | SessionMsg.PinAnswered(Error _), Session.SupplyingPin pending -> Session.Enrolling(pending, None), []
+        | SessionMsg.PinAnswered _, _ -> state, []
 
         // an anonymous open carries nothing over (Rule 7)
         | SessionMsg.OpenAnonymous, Session.Refused _

--- a/src/Informedica.GenPRES.Client/Views/SessionGate.fs
+++ b/src/Informedica.GenPRES.Client/Views/SessionGate.fs
@@ -7,12 +7,14 @@ namespace Views
 /// same way, no Session opens (Rule 7); the gate says why and what the User can do: retry
 /// (ext 3a, and a missing browser identity answered before the identity hop, ext 3c),
 /// continue without a launch (no Role, ext 5a), or relaunch from MainEHR (everything else).
-/// The gate cannot be dismissed: the edge from MainEHR is one-way, so the Client cannot
-/// relaunch by itself.
+/// While the launch waits on a PIN (UC-2) the gate is the enrolment form: the mailed
+/// confirmation code and the chosen PIN, twice. The gate cannot be dismissed: the edge from
+/// MainEHR is one-way, so the Client cannot relaunch by itself.
 /// </summary>
 module SessionGate =
 
     open Fable.Core
+    open Fable.Core.JsInterop
     open Feliz
     open Shared
     open SessionGatePolicy
@@ -36,10 +38,130 @@ module SessionGate =
                     Body = ""
                     Busy = false
                     Actions = []
+                    Form = None
                 }
 
         let onRetry = fun _ -> session.Retry()
         let onContinue = fun _ -> session.OpenAnonymously()
+
+        // the form's fields live here until they are sent; a local check runs first, the
+        // server's answer comes back through the session as the form's Error
+        let code, setCode = React.useState ""
+        let pin, setPin = React.useState ""
+        let repeat, setRepeat = React.useState ""
+        let localError, setLocalError = React.useState<string option> None
+
+        let onCode (e: Browser.Types.Event) =
+            setCode (e.target?value: string)
+            setLocalError None
+
+        let onPin (e: Browser.Types.Event) =
+            setPin (e.target?value: string)
+            setLocalError None
+
+        let onRepeat (e: Browser.Types.Event) =
+            setRepeat (e.target?value: string)
+            setLocalError None
+
+        let submit () =
+            match formError tr code pin repeat with
+            | Some error -> setLocalError (Some error)
+            | None -> session.SupplyPin code pin
+
+        let onSubmit = fun _ -> submit ()
+
+        let onKeyDown (e: Browser.Types.KeyboardEvent) =
+            if e.key = "Enter" then
+                submit ()
+
+        let form =
+            match gate.Form with
+            | None -> null
+            | Some form ->
+                let error = localError |> Option.orElse form.Error
+                let hasError = error.IsSome
+                let helper = error |> Option.defaultValue ""
+
+                JSX.jsx
+                    $"""
+                <Box component="form" noValidate={true} autoComplete="off" sx={ {| marginTop = 2 |} }>
+                    <TextField
+                        id="session-enrolment-code"
+                        name="code"
+                        autoFocus={true}
+                        margin="dense"
+                        label={form.Code}
+                        fullWidth={true}
+                        variant="outlined"
+                        value={code}
+                        onChange={onCode}
+                        onKeyDown={onKeyDown}
+                        error={hasError}
+                        slotProps={ {|
+                                        htmlInput =
+                                            {|
+                                                inputMode = "numeric"
+                                                autoComplete = "one-time-code"
+                                                maxLength = 6
+                                            |}
+                                    |} }
+                    />
+                    <TextField
+                        id="session-enrolment-pin"
+                        name="pin"
+                        margin="dense"
+                        label={form.Pin}
+                        type="password"
+                        fullWidth={true}
+                        variant="outlined"
+                        value={pin}
+                        onChange={onPin}
+                        onKeyDown={onKeyDown}
+                        error={hasError}
+                        slotProps={ {|
+                                        htmlInput =
+                                            {|
+                                                inputMode = "numeric"
+                                                autoComplete = "new-password"
+                                                maxLength = 6
+                                            |}
+                                    |} }
+                    />
+                    <TextField
+                        id="session-enrolment-repeat"
+                        name="repeat"
+                        margin="dense"
+                        label={form.Repeat}
+                        type="password"
+                        fullWidth={true}
+                        variant="outlined"
+                        value={repeat}
+                        onChange={onRepeat}
+                        onKeyDown={onKeyDown}
+                        error={hasError}
+                        helperText={helper}
+                        slotProps={ {|
+                                        htmlInput =
+                                            {|
+                                                inputMode = "numeric"
+                                                autoComplete = "new-password"
+                                                maxLength = 6
+                                            |}
+                                    |} }
+                    />
+                </Box>
+                """
+
+        let submitButton =
+            match gate.Form with
+            | None -> null
+            | Some form ->
+                JSX.jsx
+                    $"""
+                <Button key="submit" variant="contained" color="primary" onClick={onSubmit}>
+                    {form.Submit}
+                </Button>
+                """
 
         let progress =
             if gate.Busy then
@@ -83,15 +205,18 @@ module SessionGate =
         import Button from '@mui/material/Button';
         import Typography from '@mui/material/Typography';
         import CircularProgress from '@mui/material/CircularProgress';
+        import TextField from '@mui/material/TextField';
 
         <Card sx={ {| p = 4 |} } variant="outlined" role="alertdialog" aria-labelledby="session-gate-title">
             <CardHeader id="session-gate-title" title={gate.Title} />
             <CardContent>
                 <Typography variant="body2">{gate.Body}</Typography>
+                {form}
                 {progress}
             </CardContent>
             <CardActions>
                 {actions}
+                {submitButton}
             </CardActions>
         </Card>
         """

--- a/src/Informedica.GenPRES.Client/Views/SessionGate.fs
+++ b/src/Informedica.GenPRES.Client/Views/SessionGate.fs
@@ -50,18 +50,46 @@ module SessionGate =
         let pin, setPin = React.useState ""
         let repeat, setRepeat = React.useState ""
         let localError, setLocalError = React.useState<string option> None
+        // the server's answer is shown until the User edits a field; the next answer shows again
+        let edited, setEdited = React.useState false
+
+        let enrolling =
+            match session.Session with
+            | SessionMachine.Session.Enrolling _
+            | SessionMachine.Session.SupplyingPin _ -> true
+            | _ -> false
+
+        // the fields belong to one enrolment: they are cleared when the launch leaves it, so
+        // that a later enrolment in this page never shows or sends what an earlier one typed
+        React.useEffect (
+            (fun () ->
+                if not enrolling then
+                    setCode ""
+                    setPin ""
+                    setRepeat ""
+                    setLocalError None
+                    setEdited false
+            ),
+            [| box enrolling |]
+        )
+
+        // an answer arrived (the request in flight is over): show it, until the next edit
+        React.useEffect ((fun () -> setEdited false), [| box gate.Busy |])
 
         let onCode (e: Browser.Types.Event) =
             setCode (e.target?value: string)
             setLocalError None
+            setEdited true
 
         let onPin (e: Browser.Types.Event) =
             setPin (e.target?value: string)
             setLocalError None
+            setEdited true
 
         let onRepeat (e: Browser.Types.Event) =
             setRepeat (e.target?value: string)
             setLocalError None
+            setEdited true
 
         let submit () =
             match formError tr code pin repeat with
@@ -78,7 +106,7 @@ module SessionGate =
             match gate.Form with
             | None -> null
             | Some form ->
-                let error = localError |> Option.orElse form.Error
+                let error = localError |> Option.orElse (if edited then None else form.Error)
                 let hasError = error.IsSome
                 let helper = error |> Option.defaultValue ""
 

--- a/src/Informedica.GenPRES.Shared/Localization.fs
+++ b/src/Informedica.GenPRES.Shared/Localization.fs
@@ -161,6 +161,20 @@ type Terms =
     // the gate after the server ended the Session (Rule 11)
     | ``Session Gate Ended``
     | ``Session Ending Superseded``
+    // the enrolment form (UC-2, plan 615): title, body with {0} the name and {1} the hinted
+    // mail address, the three field labels, the button, and one sentence per refusal
+    | ``Session Gate Enrolment``
+    | ``Session Gate Enrolment Text``
+    | ``Session Enrolment Code``
+    | ``Session Enrolment Pin``
+    | ``Session Enrolment Pin Repeat``
+    | ``Session Enrolment Submit``
+    | ``Session Enrolment Code Format``
+    | ``Session Enrolment Pin Format``
+    | ``Session Enrolment Pins Differ``
+    | ``Session Enrolment Wrong Code``
+    | ``Session Enrolment Code Void``
+    | ``Session Enrolment Expired``
 
 
 module Localization =

--- a/src/Informedica.GenPRES.Shared/Scripts/Localization.fsx
+++ b/src/Informedica.GenPRES.Shared/Scripts/Localization.fsx
@@ -54,6 +54,20 @@ type SessionTerms =
     // the gate after the server ended the Session (Rule 11, plan 605 PR 4)
     | ``Session Gate Ended``
     | ``Session Ending Superseded``
+    // the enrolment form (UC-2, plan 615 PR 3): title, body with {0} the name and {1} the
+    // hinted mail address, the three field labels, the button, and one sentence per refusal
+    | ``Session Gate Enrolment``
+    | ``Session Gate Enrolment Text``
+    | ``Session Enrolment Code``
+    | ``Session Enrolment Pin``
+    | ``Session Enrolment Pin Repeat``
+    | ``Session Enrolment Submit``
+    | ``Session Enrolment Code Format``
+    | ``Session Enrolment Pin Format``
+    | ``Session Enrolment Pins Differ``
+    | ``Session Enrolment Wrong Code``
+    | ``Session Enrolment Code Void``
+    | ``Session Enrolment Expired``
 
 
 /// The English defaults: the strings the client shows today, verbatim.
@@ -77,8 +91,7 @@ let english term =
         "You have no role in GenPRES. You can continue without a launch: no patient is carried over."
     | ``Session Refusal Wrong Patient`` ->
         "The patient active in MainEHR is not the patient of this launch. Activate the right patient and open GenPRES again from MainEHR."
-    | ``Session Refusal Enrolment`` ->
-        "A PIN has to be set before prescribing. Enrolment is not available yet. Open GenPRES again from MainEHR."
+    | ``Session Refusal Enrolment`` -> "A PIN has to be set before prescribing. Open GenPRES again from MainEHR."
     | ``Session Try Again`` -> "Try again"
     | ``Session Continue Without Launch`` -> "Continue without launch"
     | ``Session Close`` -> "Close session"
@@ -87,6 +100,19 @@ let english term =
     | ``Session Gate Ended`` -> "Your session was ended"
     | ``Session Ending Superseded`` ->
         "Another launch of yours opened a newer session, and this one was closed."
+    | ``Session Gate Enrolment`` -> "Set a PIN to continue"
+    | ``Session Gate Enrolment Text`` ->
+        "Welcome, {0}. A confirmation code was mailed to {1}. Enter it together with the PIN of your choice: four to six digits."
+    | ``Session Enrolment Code`` -> "Confirmation code"
+    | ``Session Enrolment Pin`` -> "PIN"
+    | ``Session Enrolment Pin Repeat`` -> "Repeat the PIN"
+    | ``Session Enrolment Submit`` -> "Set PIN"
+    | ``Session Enrolment Code Format`` -> "The confirmation code has six digits."
+    | ``Session Enrolment Pin Format`` -> "The PIN has four to six digits."
+    | ``Session Enrolment Pins Differ`` -> "The two PINs differ."
+    | ``Session Enrolment Wrong Code`` -> "The code is not right. {0} tries left."
+    | ``Session Enrolment Code Void`` -> "The code is void after three wrong tries."
+    | ``Session Enrolment Expired`` -> "The enrolment has expired."
 
 
 /// Dutch, for the sheet; the other four languages stay empty and fall back to English.
@@ -111,7 +137,7 @@ let dutch term =
     | ``Session Refusal Wrong Patient`` ->
         "De patiënt die actief is in MainEHR is niet de patiënt van deze launch. Activeer de juiste patiënt en open GenPRES opnieuw vanuit MainEHR."
     | ``Session Refusal Enrolment`` ->
-        "Er moet een pincode worden ingesteld voordat u kunt voorschrijven. Inschrijven is nog niet beschikbaar. Open GenPRES opnieuw vanuit MainEHR."
+        "Er moet een pincode worden ingesteld voordat u kunt voorschrijven. Open GenPRES opnieuw vanuit MainEHR."
     | ``Session Try Again`` -> "Probeer opnieuw"
     | ``Session Continue Without Launch`` -> "Doorgaan zonder launch"
     | ``Session Close`` -> "Sessie sluiten"
@@ -120,6 +146,19 @@ let dutch term =
     | ``Session Gate Ended`` -> "Uw sessie is beëindigd"
     | ``Session Ending Superseded`` ->
         "Een andere start van u heeft een nieuwere sessie geopend; deze sessie is gesloten."
+    | ``Session Gate Enrolment`` -> "Stel een pincode in om verder te gaan"
+    | ``Session Gate Enrolment Text`` ->
+        "Welkom, {0}. Er is een bevestigingscode gemaild naar {1}. Voer die in samen met de pincode van uw keuze: vier tot zes cijfers."
+    | ``Session Enrolment Code`` -> "Bevestigingscode"
+    | ``Session Enrolment Pin`` -> "Pincode"
+    | ``Session Enrolment Pin Repeat`` -> "Herhaal de pincode"
+    | ``Session Enrolment Submit`` -> "Pincode instellen"
+    | ``Session Enrolment Code Format`` -> "De bevestigingscode bestaat uit zes cijfers."
+    | ``Session Enrolment Pin Format`` -> "De pincode bestaat uit vier tot zes cijfers."
+    | ``Session Enrolment Pins Differ`` -> "De twee pincodes verschillen."
+    | ``Session Enrolment Wrong Code`` -> "De code klopt niet. Nog {0} pogingen."
+    | ``Session Enrolment Code Void`` -> "De code is na drie verkeerde pogingen niet meer geldig."
+    | ``Session Enrolment Expired`` -> "De inschrijving is verlopen."
 
 
 let all =
@@ -248,7 +287,7 @@ let tests =
                 |> Expect.equal "distinct keys" all.Length
             }
 
-            test "placeholders appear only in the two attempt texts, in both languages" {
+            test "placeholders appear only in the attempt, enrolment and wrong-code texts, in both languages" {
                 let withPlaceholders =
                     all
                     |> Array.filter (fun t -> (english t).Contains "{0}" || (dutch t).Contains "{0}")
@@ -257,10 +296,17 @@ let tests =
                 withPlaceholders
                 |> Expect.equal
                     "placeholders"
-                    ([| ``Session Gate Opening Text``; ``Session Gate Unreachable Text`` |] |> Array.sort)
+                    ([|
+                        ``Session Gate Opening Text``
+                        ``Session Gate Unreachable Text``
+                        ``Session Gate Enrolment Text``
+                        ``Session Enrolment Wrong Code``
+                     |]
+                     |> Array.sort)
 
-                (english ``Session Gate Opening Text``).Contains "{1}" |> Expect.isTrue "{1} en"
-                (dutch ``Session Gate Opening Text``).Contains "{1}" |> Expect.isTrue "{1} nl"
+                for t in [ ``Session Gate Opening Text``; ``Session Gate Enrolment Text`` ] do
+                    (english t).Contains "{1}" |> Expect.isTrue $"{{1}} en {t}"
+                    (dutch t).Contains "{1}" |> Expect.isTrue $"{{1}} nl {t}"
             }
 
             test "fill replaces the placeholders" {

--- a/tests/Informedica.GenPRES.Shared.Tests/SessionGatePolicyTests.fs
+++ b/tests/Informedica.GenPRES.Shared.Tests/SessionGatePolicyTests.fs
@@ -40,6 +40,13 @@ module SessionGatePolicyTests =
         | None -> failtest $"expected a gate for {session}"
 
 
+    let pending: EnrolmentPending =
+        {
+            DisplayName = "Stub Prescriber (no PIN)"
+            MailHint = "n***@stub.example"
+        }
+
+
     let relaunchRefusals =
         [
             LaunchRefusal.LaunchExpired
@@ -80,18 +87,74 @@ module SessionGatePolicyTests =
                                 "Unreachable", Session.Unreachable(launch, key, 3)
                                 "Refused", Session.Refused(LaunchRefusal.NoRole, None)
                                 "Ended", Session.Ended SessionEnding.SupersededByLaunch
-                                "Enrolling",
-                                Session.Enrolling
-                                    {
-                                        DisplayName = "Stub Prescriber (no PIN)"
-                                        MailHint = "n***@stub.example"
-                                    }
+                                "Enrolling", Session.Enrolling(pending, None)
+                                "SupplyingPin", Session.SupplyingPin pending
+                                "EnrolmentFailed", Session.EnrolmentFailed PinRefusal.CodeVoid
                             ] do
                             test name {
                                 gateFor english session |> Expect.isSome "gate"
                                 isGated session |> Expect.isTrue "gated"
                             }
                     ]
+
+                test "Enrolling greets, says where the code went, and shows the form (UC-2)" {
+                    let gate = gateOf (Session.Enrolling(pending, None))
+                    gate.Busy |> Expect.isFalse "not busy"
+                    gate.Actions |> Expect.isEmpty "no actions besides the form"
+                    gate.Body |> Expect.stringContains "name" "Stub Prescriber (no PIN)"
+                    gate.Body |> Expect.stringContains "hint" "n***@stub.example"
+
+                    match gate.Form with
+                    | Some form ->
+                        form.Error |> Expect.isNone "nothing wrong yet"
+                        form.Submit |> Expect.equal "button" "Set PIN"
+                    | None -> failtest "expected the form"
+
+                    let named = namedGateOf (Session.Enrolling(pending, Some(PinRefusal.WrongCode 2)))
+                    named.Title |> Expect.equal "title term" "<Session Gate Enrolment>"
+
+                    named.Form
+                    |> Option.bind _.Error
+                    |> Expect.equal "the server's answer, as a term" (Some "<Session Enrolment Wrong Code>")
+
+                    (gateOf (Session.Enrolling(pending, Some(PinRefusal.WrongCode 2)))).Form
+                    |> Option.bind _.Error
+                    |> Expect.equal "filled" (Some "The code is not right. 2 tries left.")
+                }
+
+                test "SupplyingPin is busy without the form; EnrolmentFailed says why and asks for a relaunch" {
+                    let busy = gateOf (Session.SupplyingPin pending)
+                    busy.Busy |> Expect.isTrue "busy"
+                    busy.Form |> Expect.isNone "no form while in flight"
+
+                    let failed = gateOf (Session.EnrolmentFailed PinRefusal.CodeVoid)
+                    failed.Form |> Expect.isNone "no form"
+                    failed.Actions |> Expect.isEmpty "relaunch only"
+                    failed.Body |> Expect.stringContains "why" "three wrong tries"
+
+                    failed.Body
+                    |> Expect.stringContains "relaunch" "Open GenPRES again from MainEHR."
+
+                    (gateOf (Session.EnrolmentFailed PinRefusal.WrongActivePatient)).Body
+                    |> Expect.stringContains "patient" "not the patient of this launch"
+                }
+
+                test "the form's own check: six-digit code, four-to-six-digit PIN, repeat agrees" {
+                    formError english "123456" "2468" "2468" |> Expect.isNone "ok"
+
+                    formError english "12345" "2468" "2468"
+                    |> Expect.equal "code" (Some "The confirmation code has six digits.")
+
+                    formError english "12345a" "2468" "2468" |> Expect.isSome "code digits"
+
+                    formError english "123456" "123" "123"
+                    |> Expect.equal "pin" (Some "The PIN has four to six digits.")
+
+                    formError english "123456" "1234567" "1234567" |> Expect.isSome "pin long"
+
+                    formError english "123456" "2468" "2469"
+                    |> Expect.equal "repeat" (Some "The two PINs differ.")
+                }
 
                 test "Ended says why, asks for a relaunch, and offers the anonymous open (Rule 11)" {
                     let gate = gateOf (Session.Ended SessionEnding.SupersededByLaunch)

--- a/tests/Informedica.GenPRES.Shared.Tests/SessionMachineTests.fs
+++ b/tests/Informedica.GenPRES.Shared.Tests/SessionMachineTests.fs
@@ -327,10 +327,54 @@ module SessionMachineTests =
                         }
 
                     transition (SessionMsg.Resumed(Ok(ResumeResult.Enrolling pending))) Session.Resuming
-                    |> Expect.equal "enrolling" (Session.Enrolling pending, [])
+                    |> Expect.equal "enrolling" (Session.Enrolling(pending, None), [])
 
-                    transition (SessionMsg.Present(launchB, keyB)) (Session.Enrolling pending)
+                    transition (SessionMsg.Present(launchB, keyB)) (Session.Enrolling(pending, None))
                     |> Expect.equal "presents" (Session.present launchB keyB)
+                }
+
+                test "the form is sent once at a time, and the answer opens, keeps the form, or ends it (UC-2)" {
+                    let pending: EnrolmentPending =
+                        {
+                            DisplayName = "Stub Prescriber (no PIN)"
+                            MailHint = "n***@stub.example"
+                        }
+
+                    let enrolling = Session.Enrolling(pending, None)
+                    let supplying = Session.SupplyingPin pending
+
+                    transition (SessionMsg.SupplyPin("123456", "2468")) enrolling
+                    |> Expect.equal "sent" (supplying, [ SessionEffect.CallSupplyPin("123456", "2468") ])
+
+                    transition (SessionMsg.SupplyPin("123456", "2468")) supplying
+                    |> Expect.equal "not twice" (supplying, [])
+
+                    let session = sessionWith (Some "t") (Some patient)
+
+                    transition (SessionMsg.PinAnswered(Ok(PinOutcome.Opened session))) supplying
+                    |> Expect.equal "opened" (Session.opened session)
+
+                    transition (SessionMsg.PinAnswered(Ok(PinOutcome.Refused(PinRefusal.WrongCode 2)))) supplying
+                    |> Expect.equal "form kept" (Session.Enrolling(pending, Some(PinRefusal.WrongCode 2)), [])
+
+                    transition (SessionMsg.PinAnswered(Ok(PinOutcome.Refused PinRefusal.PinFormat))) supplying
+                    |> Expect.equal "form kept" (Session.Enrolling(pending, Some PinRefusal.PinFormat), [])
+
+                    for terminal in
+                        [
+                            PinRefusal.CodeVoid
+                            PinRefusal.AttemptExpired
+                            PinRefusal.WrongActivePatient
+                        ] do
+                        transition (SessionMsg.PinAnswered(Ok(PinOutcome.Refused terminal))) supplying
+                        |> Expect.equal $"{terminal}" (Session.EnrolmentFailed terminal, [])
+
+                    transition (SessionMsg.PinAnswered(Error "down")) supplying
+                    |> Expect.equal "form back" (enrolling, [])
+
+                    // an answer lands only on the request in flight
+                    transition (SessionMsg.PinAnswered(Ok(PinOutcome.Opened session))) enrolling
+                    |> Expect.equal "dropped" (enrolling, [])
                 }
 
                 test "from Ended the anonymous open carries nothing over, and a new launch presents" {


### PR DESCRIPTION
## Summary

Plan [615](https://github.com/informedica/GenPRES/blob/master/docs/implementation-plans/615-enrolment-with-server-stubs.md) step 3: while the launch waits on a PIN (UC-2) the gate is the enrolment form.

- **The form.** The mailed confirmation code, the chosen PIN and its repeat, on the gate. The form's own check runs first (six digits, four to six digits, the repeat agrees, `SessionGatePolicy.formError`); the server's answer comes back as the field error. A wrong code keeps the form with the tries left; a PIN out of format too. A void or expired code, or another Patient active at the supply (Rule 6), ends the enrolment (`Session.EnrolmentFailed`) with the reason and a relaunch.
- **The machine.** `Session.Enrolling` carries the last refusal; `SupplyingPin` is the request in flight, sent once at a time, and an answer lands only on it; `PinOutcome`, `SessionMsg.SupplyPin` / `PinAnswered`, `SessionEffect.CallSupplyPin`. A transport failure brings the form back as it was and shows a snackbar, as a failed close does.
- **Terms, script-first.** Twelve new cases drafted in `Shared/Scripts/Localization.fsx` with English defaults and Dutch translations (17 script tests), added to `Terms`; the existing enrolment refusal no longer says enrolment is unavailable. The sheet rows are below; until they are pasted the gate shows the English defaults.
- **Tests.** Shared: 437 (6 new: the machine's supply transitions, the gate's form, the busy and failed gates, the form check).

## Checks

- `dotnet run Build`, 206 server tests, 437 shared tests, Fable compile, Fantomas clean.
- Chrome, fresh context, `GENPRES_PROD=0 dotnet run`: `no-pin` lands on the gate "Set a PIN to continue" with the greeting and the hinted address; a mismatched repeat shows "The two PINs differ." without a round trip; a wrong code shows "The code is not right. 2 tries left."; the code from `/stub/mail` with the PIN opens the Session as **Stub Prescriber (no PIN)**, Prescriber.

## Sheet rows (Term, English, Dutch)

```
Session Refusal Enrolment	A PIN has to be set before prescribing. Open GenPRES again from MainEHR.	Er moet een pincode worden ingesteld voordat u kunt voorschrijven. Open GenPRES opnieuw vanuit MainEHR.
Session Gate Enrolment	Set a PIN to continue	Stel een pincode in om verder te gaan
Session Gate Enrolment Text	Welcome, {0}. A confirmation code was mailed to {1}. Enter it together with the PIN of your choice: four to six digits.	Welkom, {0}. Er is een bevestigingscode gemaild naar {1}. Voer die in samen met de pincode van uw keuze: vier tot zes cijfers.
Session Enrolment Code	Confirmation code	Bevestigingscode
Session Enrolment Pin	PIN	Pincode
Session Enrolment Pin Repeat	Repeat the PIN	Herhaal de pincode
Session Enrolment Submit	Set PIN	Pincode instellen
Session Enrolment Code Format	The confirmation code has six digits.	De bevestigingscode bestaat uit zes cijfers.
Session Enrolment Pin Format	The PIN has four to six digits.	De pincode bestaat uit vier tot zes cijfers.
Session Enrolment Pins Differ	The two PINs differ.	De twee pincodes verschillen.
Session Enrolment Wrong Code	The code is not right. {0} tries left.	De code klopt niet. Nog {0} pogingen.
Session Enrolment Code Void	The code is void after three wrong tries.	De code is na drie verkeerde pogingen niet meer geldig.
Session Enrolment Expired	The enrolment has expired.	De inschrijving is verlopen.
```

The first row replaces the existing one.

## AI-assisted contribution

The terms drafted in the script by Claude Code, reviewed and migrated by the maintainer; the client edits by Claude Code under the UI exception; verified by the tests and the browser walk above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZWjibQUW8uqCVbfV4vDTf
