### PR TITLE
docs: describe the stubbed enrolment as built

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -97,13 +97,42 @@ What each identity choice ends in:
 | `prescriber` | a Prescriber whose active patient is the launched one | an open Session as Prescriber | main path |
 | `reader` | a Reader; no PIN needed | an open Session as Reader | ext 5c |
 | `prescriber-other-patient` | a Prescriber with another patient active in MainEHR | the gate: wrong patient, relaunch | ext 5b |
-| `no-pin` | a Prescriber without a PIN | the gate: enrolment needed (UC-2 is not built; a relaunch is offered) | ext 5d |
+| `no-pin` | a Prescriber without a PIN | the enrolment form: a confirmation code by mail, then a PIN (UC-2, below) | ext 5d |
 | `unknown` | a login the UserRegistry does not know | the gate: no role, with "continue without launch" | ext 5a |
 | `none` | nobody signed on at the browser | the gate: no browser identity, relaunch only | ext 3c |
 
 A refusal arrives as `#/session?refused=<word>` with the words `expired`, `spent`, `invalid`,
 `no-identity`, `no-role`, `wrong-patient` and `enrolment`; the client erases the parameter and
 shows the gate for it.
+
+#### Enrolment: the first launch of a Prescriber without a PIN
+
+A Prescriber has to set a PIN before prescribing
+([uc-02](docs/scenarios/integration/uc-02-enrolment.md), Rules 24, 25, 37). The demo stands in
+for the MailService too ([plan 615](docs/implementation-plans/615-enrolment-with-server-stubs.md)):
+
+1. Launch with the identity `no-pin`. The hop runs as above, but instead of opening a Session
+   the server mails a six-digit confirmation code and the browser lands on the gate **Set a PIN
+   to continue**, which greets the user and says where the code went (`n***@stub.example`).
+2. Open `http://localhost:5173/stub/mail` in another tab: the stub MailService's outbox, newest
+   mail first. Copy the code from "GenPRES: your confirmation code".
+3. Enter the code, a PIN of four to six digits, and the PIN again, and press **Set PIN**. The
+   Session opens as **Stub Prescriber (no PIN)**, and the outbox shows a second mail, "GenPRES:
+   your PIN was set".
+4. Launch `no-pin` again, in this or another browser: the Session opens directly. The PIN lives
+   as long as the server runs. The seeded Prescribers (`prescriber`,
+   `prescriber-other-patient`) start with the PIN `1234`.
+
+Things worth trying here:
+
+- **A wrong code**: the form stays, with the tries left. The third wrong code voids it; a fresh
+  launch mails a fresh one.
+- **A second launch while the code stands** (another tab or browser, `no-pin` again): no second
+  mail; either browser can enter the code, and the Session opens in the one that did.
+- **Waiting**: the code lives fifteen minutes; after that the form is gone at the next reload
+  and a fresh launch mails a new code.
+- **Leaving**: **Close session** is not offered while enrolling; a relaunch replaces the
+  attempt, and closing the tab abandons it.
 
 #### Things worth trying
 
@@ -123,8 +152,9 @@ shows the gate for it.
 - **Production**: `GENPRES_PROD=1 GENPRES_PASSWORD=<16+ chars> dotnet run`; `/stub/launch`
   and `/authorize` are 404, `/callback` redirects to `refused=invalid`.
 
-The stand-ins keep everything in memory: launches by nonce, sessions, endings, one-time codes.
-A restart forgets all of it and the browser's session cookie no longer finds a Session.
+The stand-ins keep everything in memory: launches by nonce, sessions, endings, one-time codes,
+credentials and confirmation codes, the outbox. A restart forgets all of it: the browser's
+session cookie no longer finds a Session, and `no-pin` has to enrol again.
 
 #### Cookies and the development proxy
 
@@ -133,6 +163,7 @@ A restart forgets all of it and the browser's session cookie no longer finds a S
 | `genpres_session` | the callback, on an open | HttpOnly, Strict, `Path=/`, Secure over HTTPS | names the Session (Rule 12) |
 | `genpres_launch_state.<state>` | the answer to `PresentLaunch` | HttpOnly, Lax, `Path=/callback`, `Max-Age` 2 min | proves the callback comes from the browser that started the hop; one per hop so two tabs can launch at once |
 | `genpres_stub_identity` | the stub launch page | HttpOnly, Lax, `Path=/`, `Max-Age` 2 min | carries the identity choice and the PatientId to the stub IdentityProvider; demo only |
+| `genpres_enrolment` | the callback, when the launch suspends into enrolment | HttpOnly, Strict, `Path=/`, `Max-Age` what remains of the code's fifteen minutes | names the enrolment attempt this browser made; the form's `SupplyPin` works on it and nothing else (UC-2) |
 
 `vite.config.js` proxies `/api`, `/stub`, `/authorize` and `/callback` to the server on port
 8085, so in development the browser talks to one origin (`localhost:5173`) and the cookies,

--- a/docs/implementation-plans/409-client-launch-sequence.md
+++ b/docs/implementation-plans/409-client-launch-sequence.md
@@ -468,11 +468,12 @@ are listed per step with the reason.
 ### Still open
 
 - Step 7, the signed request (`Keys.sign`, the DPoP proof, the OpenedToken inside it).
-- UC-2 enrolment; WorkPlan carry-over (#518); decision D1 (#599).
+- WorkPlan carry-over (#518); decision D1 (#599).
 - The scope switch (#580), which retires the `IsProd` stop-gap.
 - On a launch URL the gate hides the language switcher; the language itself follows the
   server default since #601.
 
 Closed since this list was written: the identity hop (`RedirectTo`, the callback, the `state`
 cookie), the Rule 8 and 11 endings, and the sealed Launch, all against server-hosted stubs
-([plan 605](605-launch-with-server-stubs.md)).
+([plan 605](605-launch-with-server-stubs.md)); UC-2 enrolment against a stub MailService and an
+in-memory credential store ([plan 615](615-enrolment-with-server-stubs.md)).

--- a/docs/implementation-plans/615-enrolment-with-server-stubs.md
+++ b/docs/implementation-plans/615-enrolment-with-server-stubs.md
@@ -192,3 +192,40 @@ the client, migration by the maintainer after review.
 - `prescriber` and `reader` open as before; `unknown` never reaches the PIN question.
 - With `GENPRES_PROD=1` and a valid password: `/stub/mail` is 404 and `SupplyPin` is refused.
 - `dotnet run ServerTests`, the Fable compile and Fantomas stay green after every step.
+
+## As built
+
+Every step landed as one PR from a fork branch against `master`, script-first for the server
+and Shared code (`Server/Scripts/Enrolment.fsx`, `Shared/Scripts/Localization.fsx`), reviewed
+and migrated by the maintainer, client edits direct.
+
+| Step | PR | Landed |
+|------|----|--------|
+| plan | [#616](https://github.com/informedica/GenPRES/pull/616) | this document; review split the code from the attempt (below), made the third wrong code terminal, and gave the attempt no lifetime of its own |
+| 1 | [#617](https://github.com/informedica/GenPRES/pull/617) | `PinHash`, `Credential`, the credential store in the hop state seeded per stub login, `UserStanding.MailAddress` for `PinSet`, `Mail`/`MailPort`, `StubMail` with `/stub/mail`; no change in behaviour |
+| 2 | [#619](https://github.com/informedica/GenPRES/pull/619) | `PendingCode` per person and `Enrolment` per launch, the suspended callback, `supplyPin` as one act with the two mails, `EnrolmentPending`/`PinRefusal`/`SupplyPin` on the wire, the `genpres_enrolment` cookie, the composition root over both cookies, `Session.Enrolling` on the client without the form |
+| 3 | [#620](https://github.com/informedica/GenPRES/pull/620) | the form on the gate, `SupplyingPin` and `EnrolmentFailed`, `formError`, twelve `Terms` with sheet rows |
+| 4 | this PR | uc-02 as-built note, uc-01 and plan 409 updated, `DEVELOPMENT.md` enrolment walkthrough, this table |
+
+### Deviations from the text above
+
+- **`PinRefusal.WrongActivePatient`.** Review on #619: the supply asks the registry again and
+  takes its answer whole, the Role re-taken and the Session opened only if the launch's Patient
+  is still the active one (Rule 6); otherwise the PIN is set and told and the answer is a fifth,
+  terminal refusal. When the registry cannot answer, the launch continues on what it had, as
+  uc-02's last bullet says. The stub registry answers nothing for both an unknown and an
+  unreachable login; the real port will tell them apart.
+- **An enrolling callback closes the browser's Session.** Review on #619: a Session this browser
+  still held would otherwise hide the enrolment at the next `GetSession`; the callback closes it
+  and deletes its cookie, as an open replaces the cookie.
+- **`findEnrolment` and `dropEnrolment`** on the port, next to `supplyPin`: what `GetSession`
+  asks while an attempt stands, and what `CloseSession` does with one.
+- **Two more client states.** `SupplyingPin` (the request in flight, sent once at a time) and
+  `EnrolmentFailed` (the terminal answers, with their own sentence and a relaunch), so the gate
+  can say why the enrolment ended instead of the generic refusal.
+- **Twelve terms, not about eight.** One per field and button, one per refusal, plus the title
+  and body; and the existing enrolment refusal no longer says enrolment is unavailable.
+- **The form's fields** are cleared when the launch leaves the enrolment, and a server refusal
+  is hidden once the User edits a field (review on #620).
+- **Step 3's browser checks** covered the wrong code and the local checks; the void and expired
+  endings are covered by the machine and gate tests.

--- a/docs/scenarios/integration/uc-01-launch.md
+++ b/docs/scenarios/integration/uc-01-launch.md
@@ -299,15 +299,16 @@ Where the code departs from the text above, on purpose:
   Launch's PatientId and an empty patient (ext 6a); a data outage does not block prescribing.
 - **The key pair's thumbprint** is stored in the SessionRecord at 5.7, ready for step 7.
 
-Not built: step 7 (the signed request and the OpenedToken check), the PIN detour (UC-2; a
-Prescriber without a PIN is refused with `enrolment`), the audit (Rule 46), the newest
-TreatmentPlan of 5.6, and the absolute lifetime and idle endings of Rule 10.
+The PIN detour of 5.4 is built too: a Prescriber without a PIN suspends into
+[uc-02](uc-02-enrolment.md) and continues once the PIN is set (its as-built note is there).
+
+Not built: step 7 (the signed request and the OpenedToken check), the audit (Rule 46), the
+newest TreatmentPlan of 5.6, and the absolute lifetime and idle endings of Rule 10.
 
 ## Left out
 
-- **The PIN detour.** By design a Prescriber with no PIN is not refused: the launch suspends
-  into UC-2 and continues at 5.5 once the PIN is set. Until UC-2 is built, the code refuses
-  with `enrolment` and the Client asks for a relaunch (see [As built](#as-built-against-stubs)).
+- **The PIN detour.** A Prescriber with no PIN is not refused: the launch suspends into UC-2
+  and continues at 5.5 once the PIN is set.
 - **The audit.** Every launch, honored or refused, is appended to the audit (Rule 46).
 - **Everything after the launch**: prescribing and signing, and the ten other use cases.
 - **The confirmation code.** UC-2 and UC-6 mail a code to set or replace a PIN. It is not the

--- a/docs/scenarios/integration/uc-02-enrolment.md
+++ b/docs/scenarios/integration/uc-02-enrolment.md
@@ -81,6 +81,50 @@ between. Rule 27 wants a fresh answer on the request that sends each mail.
   PIN is set and the notice falls back on the address this launch already had, which the
   audit records.
 
+## As built against stubs
+
+The sequence above runs in the demo server since
+[plan 615](../../implementation-plans/615-enrolment-with-server-stubs.md), on the stand-ins of
+[uc-01](uc-01-launch.md#as-built-against-stubs) plus one more: the MailService is an outbox in
+memory with a page, `/stub/mail`, where the tester reads what a User would read in their mail.
+The credential (Concept 7) lives in the same in-memory state as the Sessions: a PBKDF2-SHA256
+hash under a salt of its own, and the wrong-count of Rule 28. The walkthrough is in
+[DEVELOPMENT.md](../../../DEVELOPMENT.md#enrolment-the-first-launch-of-a-prescriber-without-a-pin).
+
+Where the code departs from the text above, on purpose:
+
+- **Two records, not one.** The confirmation code belongs to the credential (one live code per
+  person, Rule 37) and the launch to the browser: `StartReset` writes a pending code keyed by
+  the person, and an enrolment attempt keyed by the launch, holding the public key of the
+  browser that made it. A second launch while the code stands gets an attempt of its own, bound
+  to the same code, and mails nothing (ext 2a); whichever browser supplies the code opens the
+  Session on its own key; setting the PIN drops the code and every attempt bound to it.
+- **`PinRequired` is a cookie and a GetSession.** The redirect of 4.2 unloads the Client, so
+  the suspension cannot be answered in a response body: the callback sets a `genpres_enrolment`
+  cookie naming the attempt and sends the browser to `#/session`, and `GetSession` answers
+  `EnrolmentPending` while the attempt stands. `SupplyPin` works on the attempt in that cookie,
+  never on one the Client names.
+- **The code as a mac.** Six digits from the CSPRNG, kept as an HMAC under the server's key;
+  the mail carries the digits, the state never does.
+- **The wait is bounded.** A code lives fifteen minutes, a mail round trip, and takes its
+  attempts along; the model's `AwaitingPinChoice` is never collected. A launch near the end of
+  the window gets a short-lived attempt, and the cookie's `Max-Age` is what remains.
+- **Ext 2b is three tries.** The third wrong code voids the code for every attempt bound to it,
+  a terminal answer; a fresh launch mails a fresh one. A PIN outside four to six digits (V8 names
+  no format; the assumption of plan 615) spends no try.
+- **The registry is asked again at the supply**, as the diagram shows for the address (Rule
+  27), and its answer is taken whole: the Role as it stands now, and the Session opens only if
+  the launch's Patient is still the active one (Rule 6); otherwise the PIN is set and told, no
+  Session opens, and the Client asks for a relaunch. When the registry cannot answer, the code
+  settles the PIN and the notice goes to the address the code went to (the last bullet above).
+- **A Session this browser still held** is closed by the enrolling callback, as an open would
+  replace it; left in place, its cookie would hide the enrolment.
+- **The Client's form** does the cheap checks first (six digits, four to six digits, the repeat
+  agrees) and shows the server's answer as the field's error until the User edits it.
+
+Not built: the audit (Rule 46), and the wrong-PIN limit at signing (Rule 28's count is kept and
+reset, nothing reads it yet).
+
 ---
 
 Drawn from UC-2 in [`Integration.fsx`](Integration.fsx). The full trace of all eleven use


### PR DESCRIPTION
## Summary

Plan [615](https://github.com/informedica/GenPRES/issues/615) step 4, documentation only.

- **uc-02** gets "As built against stubs": the stand-ins (the outbox at `/stub/mail`, the credential in the hop state) and the deliberate departures from the page: two records (the code per person, the attempt per launch with its browser's key), `PinRequired` as a cookie plus `GetSession`, the code as a mac, the fifteen-minute bound, three tries, the registry asked again at the supply with its answer taken whole, the browser's old Session closed, the form's own checks. Not built: the audit and the wrong-PIN limit at signing.
- **uc-01** drops the PIN detour from "not built" and points at uc-02; **plan 409** "Still open" drops UC-2.
- **DEVELOPMENT.md** "Simulating the launch sequence" gains the enrolment path: `no-pin`, the outbox, the form, the relaunch that opens directly, the seeded PIN `1234`, things worth trying, and the `genpres_enrolment` cookie in the table.
- **Plan 615** gets its as-built table (#616, #617, #619, #620, this PR) and the deviations, each with the review that caused it.

Markdownlint: no new findings on the five files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZWjibQUW8uqCVbfV4vDTf
