### PR TITLE
feat(server): keep the record and lock the credential (#622)

### DIFF
--- a/src/Informedica.GenPRES.Client/SessionGatePolicy.fs
+++ b/src/Informedica.GenPRES.Client/SessionGatePolicy.fs
@@ -73,6 +73,7 @@ let english (term: Terms) =
     | Terms.``Session Role Reader`` -> "Reader"
     | Terms.``Session Gate Ended`` -> "Your session was ended"
     | Terms.``Session Ending Superseded`` -> "Another launch of yours opened a newer session, and this one was closed."
+    | Terms.``Session Ending Pin Limit`` -> "The PIN was entered wrong three times, and signing is locked for a while."
     | Terms.``Session Gate Enrolment`` -> "Set a PIN to continue"
     | Terms.``Session Gate Enrolment Text`` ->
         "Welcome, {0}. A confirmation code was mailed to {1}. Enter it together with the PIN of your choice: four to six digits."
@@ -243,6 +244,7 @@ let gateFor (tr: Terms -> string) (session: Session) : Gate option =
                         [
                             match ending with
                             | SessionEnding.SupersededByLaunch -> tr Terms.``Session Ending Superseded``
+                            | SessionEnding.WrongPinLimit -> tr Terms.``Session Ending Pin Limit``
                             tr Terms.``Session Relaunch``
                         ]
                 Busy = false

--- a/src/Informedica.GenPRES.Server/Scripts/Signing.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/Signing.fsx
@@ -1,0 +1,456 @@
+// UC-3 prescribe and sign against server-hosted stubs (plan 622), PR 1: the record and the
+// head a Session opens with, and the lock on a credential. No change in behaviour yet.
+//
+// Script-first draft (script-only policy) of:
+//   - the wire: `OrderPlanHead`, `SignedOrderPlan`, `SessionEnding.WrongPinLimit`
+//     → `Shared/Types.fs`;
+//   - `Credential.LockedUntil`, `wrongPinLimit`, `lockBase`, `lockFor`, `isLocked`, `verify`
+//     (Rules 23, 28, as the model's `UserCredential.verify`) → `Adapters.fs`;
+//   - `Hop`: `State.Records`, `SessionRecord.OpenedWith`, `headOf`, and `openWith` reading the
+//     head at open (Rule 19) → `Adapters.fs`.
+//
+// The plan's naming: the integration design's TreatmentPlan is the code's `OrderPlan`; a
+// signed version of it is a `SignedOrderPlan`.
+//
+// Only what changes is re-stated; `callback` and `supplyPin` keep calling `openWith`
+// unchanged. Run: `dotnet fsi Signing.fsx` from this directory (build first).
+
+#I __SOURCE_DIRECTORY__
+#r "nuget: Expecto, 10.2.3"
+
+#load "load.fsx"
+
+open System
+open Shared.Types
+open Shared.Models
+open ServerApi
+
+
+// ---------------------------------------------------------------------------------------------
+// Wire (→ Shared/Types.fs)
+// ---------------------------------------------------------------------------------------------
+
+/// What identifies a signed version of an order plan (Concept 9): its id, its place in the
+/// patient's record (`No` orders the record: a clock cannot say which of two landed first,
+/// Rule 20), who signed it and when. Enough for Rule 21's notice: whose, and when.
+type OrderPlanHead =
+    {
+        Id: string
+        No: int
+        By: UserContext
+        SignedAt: DateTime
+    }
+
+
+/// A signed version of an order plan, as the record holds it (the integration design's
+/// TreatmentPlan): the head, the patient, the version it was signed over (`Base`, `None` for
+/// the first), the orders as shown at the signature and the patient data the User saw
+/// (Rule 44).
+type SignedOrderPlan =
+    {
+        Head: OrderPlanHead
+        PatientId: string
+        Base: string option
+        Scenarios: OrderScenario[]
+        Patient: Patient
+    }
+
+
+/// Why a Session ended other than by the User closing it (Rule 11). The server says it once,
+/// at the next request, and the client shows it. Idle and absolute lifetime (Rule 10) come
+/// with their own plan.
+[<RequireQualifiedAccess>]
+type SessionEnding =
+    | SupersededByLaunch
+    // Rule 28: the third wrong PIN at a signature
+    | WrongPinLimit
+
+
+// ---------------------------------------------------------------------------------------------
+// The credential with its lock (→ ServerApi.Adapters.fs, replacing `Credential`)
+// ---------------------------------------------------------------------------------------------
+
+/// Concept 7, the UserCredential as the Database keeps it: the PIN hash, the wrong-count of
+/// Rule 28 (counted across Sessions, zeroed when the PIN is set or entered right), and the
+/// lock on signing, a moment rather than a state: the delay passes on its own.
+type Credential =
+    {
+        PinHash: PinHash option
+        WrongCount: int
+        LockedUntil: DateTime option
+    }
+
+
+module Credential =
+
+    let empty =
+        {
+            PinHash = None
+            WrongCount = 0
+            LockedUntil = None
+        }
+
+
+    /// Rule 24: whether a PIN is set.
+    let pinSet (credential: Credential) = credential.PinHash.IsSome
+
+
+    /// A credential with this PIN, a count of zero and no lock (Rules 28, 37: setting the PIN
+    /// resets both).
+    let withPin (newSalt: int -> byte[]) (pin: string) : Credential =
+        {
+            PinHash = Some(PinHash.make newSalt pin)
+            WrongCount = 0
+            LockedUntil = None
+        }
+
+
+    /// Wrong PINs before the Session ends and signing locks (Rule 28).
+    let wrongPinLimit = 3
+
+    /// The first lock (plan 622: one minute; the model counts in ticks).
+    let lockBase = TimeSpan.FromMinutes 1.0
+
+
+    /// Rule 28: the delay after `count` wrong entries. The entry that reaches the limit locks
+    /// for `lockBase`; each one after it doubles that.
+    let lockFor (count: int) = lockBase * float (pown 2 (max 0 (count - wrongPinLimit)))
+
+
+    /// Rule 28: whether signing is locked at this moment.
+    let isLocked (now: DateTime) (credential: Credential) =
+        match credential.LockedUntil with
+        | Some until -> now < until
+        | None -> false
+
+
+    /// Rules 23, 28: whether the PIN is accepted, and the credential as it stands after the
+    /// entry. A right PIN while unlocked zeroes the count and clears the lock; a right PIN
+    /// while locked is refused and counts nothing; a wrong PIN adds one and, at the limit or
+    /// beyond it, locks for `lockFor` from now, so a wrong entry while locked pushes the
+    /// delay out and doubles it.
+    let verify (now: DateTime) (pin: string) (credential: Credential) : bool * Credential =
+        let locked = isLocked now credential
+
+        let right =
+            match credential.PinHash with
+            | Some hash -> PinHash.verify pin hash
+            | None -> false
+
+        if right && not locked then
+            true,
+            { credential with
+                WrongCount = 0
+                LockedUntil = None
+            }
+        elif right then
+            false, credential
+        else
+            let count = credential.WrongCount + 1
+
+            let until =
+                if count >= wrongPinLimit then
+                    Some(now + lockFor count)
+                else
+                    None
+
+            false,
+            { credential with
+                WrongCount = count
+                LockedUntil = until
+            }
+
+
+    /// Rule 28: the wrong entries left before the limit.
+    let attemptsLeft (credential: Credential) = max 0 (wrongPinLimit - credential.WrongCount)
+
+
+// ---------------------------------------------------------------------------------------------
+// The record and the head at open (→ ServerApi.Adapters.fs, `Hop`)
+// ---------------------------------------------------------------------------------------------
+
+module Hop =
+
+    /// A Session as the store holds it: what the client learns, the login it belongs to
+    /// (Rule 8: a User has at most one open Session), and the head of the record it opened
+    /// with (Rule 19; `None` from nothing), which a Submission is checked against (Rule 20).
+    type SessionRecord =
+        {
+            Session: SessionOpened
+            Login: string option
+            OpenedWith: string option
+        }
+
+
+    /// The state of PR 1: only the fields this script changes; `Launches`, `Endings`, `Codes`
+    /// and `Enrolments` stay as `ServerApi.Hop.State` has them.
+    type State =
+        {
+            Sessions: Map<string, SessionRecord>
+            Endings: Map<string, SessionEnding * DateTime>
+            Credentials: Map<string, Credential>
+            // UC-3: the signed versions per patient, newest first
+            Records: Map<string, SignedOrderPlan list>
+        }
+
+
+    let emptyState =
+        {
+            Sessions = Map.empty
+            Endings = Map.empty
+            Credentials = Map.empty
+            Records = Map.empty
+        }
+
+
+    let initialState (credentials: Map<string, Credential>) =
+        { emptyState with Credentials = credentials }
+
+
+    /// Rule 19: the most recent signed version of a patient's record, if any.
+    let headOf (patientId: string) (state: State) =
+        state.Records |> Map.tryFind patientId |> Option.bind List.tryHead
+
+
+    /// Step 5.7, one act (Rule 40). The Session is written from the head of the record
+    /// (Rule 19), the login's other Sessions are closed and marked (Rule 8). Public here so
+    /// the script can test it; private in `Adapters.fs`, reached through `callback` and
+    /// `supplyPin`.
+    let openWith
+        (now: DateTime)
+        (newId: unit -> string)
+        (patientData: string -> Patient option)
+        (patientId: string)
+        (key: PublicKey)
+        (user: UserContext)
+        (state: State)
+        =
+        let id = newId ()
+
+        let session =
+            {
+                User = Some user
+                PatientContext =
+                    Some
+                        {
+                            PatientId = patientId
+                            Patient = patientData patientId |> Option.defaultValue Patient.empty
+                        }
+                OpenedToken = Some(OpenedToken $"opened-{id}")
+                KeyThumbprint = Some(PublicKey.thumbprint key)
+            }
+
+        let login = Some user.UserId
+
+        let superseded =
+            state.Sessions
+            |> Map.filter (fun sid s -> sid <> id && s.Login = login)
+            |> Map.toList
+            |> List.map fst
+
+        { state with
+            Sessions =
+                superseded
+                |> List.fold (fun m sid -> Map.remove sid m) state.Sessions
+                |> Map.add
+                    id
+                    {
+                        Session = session
+                        Login = login
+                        OpenedWith = headOf patientId state |> Option.map _.Head.Id
+                    }
+            Endings =
+                superseded
+                |> List.fold (fun m sid -> Map.add sid (SessionEnding.SupersededByLaunch, now) m) state.Endings
+        },
+        (id, session)
+
+
+// ---------------------------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------------------------
+
+open Expecto
+open Expecto.Flip
+
+
+let t0 = DateTime(2026, 9, 11, 12, 0, 0, DateTimeKind.Utc)
+let minutes (n: float) = TimeSpan.FromMinutes n
+let salts (n: int) = Array.init n byte
+let withPin = Credential.withPin salts "1234"
+
+let prescriber =
+    {
+        UserId = "prescriber"
+        DisplayName = "Stub Prescriber"
+        Role = UserRole.Prescriber
+    }
+
+let other =
+    { prescriber with
+        UserId = "prescriber-b"
+        DisplayName = "Stub Prescriber B"
+    }
+
+
+let signedBy (user: UserContext) no (at: DateTime) : SignedOrderPlan =
+    {
+        Head =
+            {
+                Id = $"plan-{no}"
+                No = no
+                By = user
+                SignedAt = at
+            }
+        PatientId = "stub-patient"
+        Base = (if no > 1 then Some $"plan-{no - 1}" else None)
+        Scenarios = [||]
+        Patient = Patient.empty
+    }
+
+
+let counter prefix =
+    let n = ref 0
+
+    fun () ->
+        n.Value <- n.Value + 1
+        $"{prefix}-{n.Value}"
+
+
+/// Wrong entries in a row, from a credential, each a minute after the last.
+let wrong (n: int) (start: DateTime) (credential: Credential) =
+    [ 1..n ]
+    |> List.fold (fun (c, at) _ -> Credential.verify at "0000" c |> snd, at + minutes 1.0) (credential, start)
+
+
+let credentialTests =
+    testList
+        "Credential"
+        [
+            test "empty and withPin carry no lock, and withPin zeroes the count (Rules 28, 37)" {
+                Credential.empty.LockedUntil |> Expect.isNone "empty"
+                withPin.LockedUntil |> Expect.isNone "set"
+                withPin.WrongCount |> Expect.equal "zero" 0
+                withPin |> Credential.pinSet |> Expect.isTrue "set"
+
+                let locked, _ = wrong 4 t0 withPin
+                let reset = Credential.withPin salts "2468"
+                reset.WrongCount |> Expect.equal "a new PIN zeroes the count" 0
+                reset.LockedUntil |> Expect.isNone "and clears the lock"
+                locked.WrongCount |> Expect.equal "(the old one stood at four)" 4
+            }
+
+            test "the delay is one minute at the limit and doubles with each further entry (Rule 28)" {
+                Credential.lockFor 0 |> Expect.equal "below the limit: the base" (minutes 1.0)
+                Credential.lockFor 3 |> Expect.equal "at the limit" (minutes 1.0)
+                Credential.lockFor 4 |> Expect.equal "one past" (minutes 2.0)
+                Credential.lockFor 5 |> Expect.equal "two past" (minutes 4.0)
+            }
+
+            test "a right PIN is accepted, zeroes the count and clears the lock" {
+                let twoWrong, at = wrong 2 t0 withPin
+                twoWrong.WrongCount |> Expect.equal "two" 2
+                twoWrong.LockedUntil |> Expect.isNone "not locked yet"
+                twoWrong |> Credential.attemptsLeft |> Expect.equal "one left" 1
+
+                let ok, after = Credential.verify at "1234" twoWrong
+                ok |> Expect.isTrue "accepted"
+                after.WrongCount |> Expect.equal "zeroed" 0
+                after.LockedUntil |> Expect.isNone "no lock"
+            }
+
+            test "the third wrong PIN locks for a minute; a right PIN inside it is refused and counts nothing" {
+                let limit, at = wrong 3 t0 withPin
+                limit.WrongCount |> Expect.equal "three" 3
+                limit.LockedUntil |> Expect.equal "locked from the third entry" (Some(at - minutes 1.0 + minutes 1.0))
+                limit |> Credential.isLocked (at - minutes 0.5) |> Expect.isTrue "locked inside the minute"
+                limit |> Credential.attemptsLeft |> Expect.equal "none left" 0
+
+                let ok, same = Credential.verify (at - minutes 0.5) "1234" limit
+                ok |> Expect.isFalse "refused while locked"
+                same |> Expect.equal "unchanged" limit
+
+                let ok, after = Credential.verify at "1234" limit
+                ok |> Expect.isTrue "accepted once the minute passed"
+                after.WrongCount |> Expect.equal "zeroed" 0
+            }
+
+            test "a wrong PIN while locked counts, and pushes the delay out and doubles it" {
+                let limit, at = wrong 3 t0 withPin
+                let inside = at - minutes 0.5
+
+                let ok, fourth = Credential.verify inside "0000" limit
+                ok |> Expect.isFalse "refused"
+                fourth.WrongCount |> Expect.equal "four" 4
+                fourth.LockedUntil |> Expect.equal "two minutes from this entry" (Some(inside + minutes 2.0))
+
+                let _, fifth = Credential.verify inside "0000" fourth
+                fifth.LockedUntil |> Expect.equal "four minutes" (Some(inside + minutes 4.0))
+            }
+
+            test "a credential without a PIN accepts nothing and counts the entry" {
+                let ok, after = Credential.verify t0 "1234" Credential.empty
+                ok |> Expect.isFalse "no PIN"
+                after.WrongCount |> Expect.equal "counted" 1
+            }
+
+            test "the stub seed carries no lock" {
+                for KeyValue(login, c) in StubCredentials.seed salts do
+                    // the seed is the source's Credential; the shape here adds the lock
+                    c.WrongCount |> Expect.equal $"{login} count" 0
+            }
+        ]
+
+
+let openTests =
+    let ids = counter "session"
+    let openAs user patientId state = Hop.openWith t0 ids (fun _ -> Some Patient.empty) patientId (PublicKey "key-a") user state
+
+    testList
+        "the head at open"
+        [
+            test "from nothing: no head, and the Session says so (Rule 19)" {
+                Hop.headOf "stub-patient" Hop.emptyState |> Expect.isNone "empty record"
+
+                let state, (id, session) = openAs prescriber "stub-patient" Hop.emptyState
+                state.Sessions[id].OpenedWith |> Expect.isNone "opened from nothing"
+                session.OpenedToken |> Expect.equal "the token, as before" (Some(OpenedToken $"opened-{id}"))
+            }
+
+            test "from a record: the newest version is the head, and the Session opened with it" {
+                let state =
+                    { Hop.emptyState with
+                        Records =
+                            Map.ofList
+                                [
+                                    "stub-patient", [ signedBy other 2 (t0 + minutes 1.0); signedBy prescriber 1 t0 ]
+                                    "another", [ signedBy prescriber 1 t0 ]
+                                ]
+                    }
+
+                (Hop.headOf "stub-patient" state |> Option.map _.Head.Id)
+                |> Expect.equal "newest first" (Some "plan-2")
+
+                let state, (id, _) = openAs prescriber "stub-patient" state
+                state.Sessions[id].OpenedWith |> Expect.equal "the head at open" (Some "plan-2")
+
+                let state, (id2, _) = openAs other "another" state
+                state.Sessions[id2].OpenedWith |> Expect.equal "per patient" (Some "plan-1")
+            }
+
+            test "a second open of the same login still supersedes the first (Rule 8)" {
+                let state, (a, _) = openAs prescriber "stub-patient" Hop.emptyState
+                let state, (b, _) = openAs prescriber "stub-patient" state
+                state.Sessions |> Map.containsKey a |> Expect.isFalse "a gone"
+                state.Sessions |> Map.containsKey b |> Expect.isTrue "b open"
+
+                state.Endings |> Map.tryFind a |> Option.map fst
+                |> Expect.equal "marked" (Some SessionEnding.SupersededByLaunch)
+            }
+        ]
+
+
+let tests = testList "Signing PR 1" [ credentialTests; openTests ]
+
+
+runTestsWithCLIArgs [] [||] tests

--- a/src/Informedica.GenPRES.Server/Scripts/Signing.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/Signing.fsx
@@ -112,9 +112,18 @@ module Credential =
     let lockBase = TimeSpan.FromMinutes 1.0
 
 
+    /// The longest lock. The model's delay only grows and decays with time; the decay is not
+    /// built, so the stub caps the delay instead (review on #624: an unbounded doubling
+    /// overflows the arithmetic long before it overflows anyone's patience).
+    let lockMax = TimeSpan.FromHours 24.0
+
+
     /// Rule 28: the delay after `count` wrong entries. The entry that reaches the limit locks
-    /// for `lockBase`; each one after it doubles that.
-    let lockFor (count: int) = lockBase * float (pown 2 (max 0 (count - wrongPinLimit)))
+    /// for `lockBase`; each one after it doubles that, up to `lockMax`.
+    let lockFor (count: int) =
+        // 2^11 minutes is already past a day; the bound keeps `pown` in range
+        let doublings = min 11 (max 0 (count - wrongPinLimit))
+        min lockMax (lockBase * float (pown 2 doublings))
 
 
     /// Rule 28: whether signing is locked at this moment.
@@ -345,6 +354,12 @@ let credentialTests =
                 Credential.lockFor 3 |> Expect.equal "at the limit" (minutes 1.0)
                 Credential.lockFor 4 |> Expect.equal "one past" (minutes 2.0)
                 Credential.lockFor 5 |> Expect.equal "two past" (minutes 4.0)
+                Credential.lockFor 13 |> Expect.equal "ten past: just under the cap" (minutes 1024.0)
+                Credential.lockFor 14 |> Expect.equal "capped at a day" Credential.lockMax
+                Credential.lockFor Int32.MaxValue |> Expect.equal "no overflow" Credential.lockMax
+
+                let _, c = Credential.verify t0 "0000" { withPin with WrongCount = Int32.MaxValue - 1 }
+                c.LockedUntil |> Expect.equal "a day from now" (Some(t0 + Credential.lockMax))
             }
 
             test "a right PIN is accepted, zeroes the count and clears the lock" {

--- a/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
@@ -273,10 +273,18 @@ module Credential =
     let lockBase = TimeSpan.FromMinutes 1.0
 
 
+    /// The longest lock. The model's delay only grows and decays with time; the decay is not
+    /// built, so the stub caps the delay instead (review on #624: an unbounded doubling
+    /// overflows the arithmetic long before it overflows anyone's patience).
+    let lockMax = TimeSpan.FromHours 24.0
+
+
     /// Rule 28: the delay after `count` wrong entries. The entry that reaches the limit locks
-    /// for `lockBase`; each one after it doubles that.
+    /// for `lockBase`; each one after it doubles that, up to `lockMax`.
     let lockFor (count: int) =
-        lockBase * float (pown 2 (max 0 (count - wrongPinLimit)))
+        // 2^11 minutes is already past a day; the bound keeps `pown` in range
+        let doublings = min 11 (max 0 (count - wrongPinLimit))
+        min lockMax (lockBase * float (pown 2 doublings))
 
 
     /// Rule 28: whether signing is locked at this moment.

--- a/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
@@ -237,6 +237,8 @@ type Credential =
     {
         PinHash: PinHash option
         WrongCount: int
+        // Rule 28: signing is locked until this moment; a delay, not a state
+        LockedUntil: DateTime option
     }
 
 
@@ -246,6 +248,7 @@ module Credential =
         {
             PinHash = None
             WrongCount = 0
+            LockedUntil = None
         }
 
 
@@ -253,12 +256,76 @@ module Credential =
     let pinSet (credential: Credential) = credential.PinHash.IsSome
 
 
-    /// A credential with this PIN and a count of zero (Rule 28: setting the PIN resets it).
+    /// A credential with this PIN, a count of zero and no lock (Rules 28, 37: setting the PIN
+    /// resets both).
     let withPin (newSalt: int -> byte[]) (pin: string) : Credential =
         {
             PinHash = Some(PinHash.make newSalt pin)
             WrongCount = 0
+            LockedUntil = None
         }
+
+
+    /// Wrong PINs before the Session ends and signing locks (Rule 28).
+    let wrongPinLimit = 3
+
+    /// The first lock (plan 622: one minute; the model counts in ticks).
+    let lockBase = TimeSpan.FromMinutes 1.0
+
+
+    /// Rule 28: the delay after `count` wrong entries. The entry that reaches the limit locks
+    /// for `lockBase`; each one after it doubles that.
+    let lockFor (count: int) =
+        lockBase * float (pown 2 (max 0 (count - wrongPinLimit)))
+
+
+    /// Rule 28: whether signing is locked at this moment.
+    let isLocked (now: DateTime) (credential: Credential) =
+        match credential.LockedUntil with
+        | Some until -> now < until
+        | None -> false
+
+
+    /// Rules 23, 28: whether the PIN is accepted, and the credential as it stands after the
+    /// entry. A right PIN while unlocked zeroes the count and clears the lock; a right PIN
+    /// while locked is refused and counts nothing; a wrong PIN adds one and, at the limit or
+    /// beyond it, locks for `lockFor` from now, so a wrong entry while locked pushes the
+    /// delay out and doubles it.
+    let verify (now: DateTime) (pin: string) (credential: Credential) : bool * Credential =
+        let locked = isLocked now credential
+
+        let right =
+            match credential.PinHash with
+            | Some hash -> PinHash.verify pin hash
+            | None -> false
+
+        if right && not locked then
+            true,
+            { credential with
+                WrongCount = 0
+                LockedUntil = None
+            }
+        elif right then
+            false, credential
+        else
+            let count = credential.WrongCount + 1
+
+            let until =
+                if count >= wrongPinLimit then
+                    Some(now + lockFor count)
+                else
+                    None
+
+            false,
+            { credential with
+                WrongCount = count
+                LockedUntil = until
+            }
+
+
+    /// Rule 28: the wrong entries left before the limit.
+    let attemptsLeft (credential: Credential) =
+        max 0 (wrongPinLimit - credential.WrongCount)
 
 
 module Pin =
@@ -319,12 +386,14 @@ module Hop =
         $"/#/session?refused={refusalWord refusal}"
 
 
-    /// A Session as the store holds it: what the client learns, plus the login it belongs to
-    /// (Rule 8: a User has at most one open Session).
+    /// A Session as the store holds it: what the client learns, the login it belongs to
+    /// (Rule 8: a User has at most one open Session), and the head of the record it opened
+    /// with (Rule 19; `None` from nothing), which a Submission is checked against (Rule 20).
     type SessionRecord =
         {
             Session: SessionOpened
             Login: string option
+            OpenedWith: string option
         }
 
 
@@ -375,6 +444,8 @@ module Hop =
             Codes: Map<string, PendingCode>
             // UC-2: the suspended launches by attempt
             Enrolments: Map<string, Enrolment>
+            // UC-3: the signed versions of each patient's order plan, newest first
+            Records: Map<string, SignedOrderPlan list>
         }
 
 
@@ -386,6 +457,7 @@ module Hop =
             Credentials = Map.empty
             Codes = Map.empty
             Enrolments = Map.empty
+            Records = Map.empty
         }
 
 
@@ -403,6 +475,11 @@ module Hop =
 
     let credentialOf (userId: string) (state: State) =
         state.Credentials |> Map.tryFind userId |> Option.defaultValue Credential.empty
+
+
+    /// Rule 19: the most recent signed version of a patient's record, if any.
+    let headOf (patientId: string) (state: State) =
+        state.Records |> Map.tryFind patientId |> Option.bind List.tryHead
 
 
     let private dropExpired (now: DateTime) (state: State) =
@@ -454,8 +531,8 @@ module Hop =
 
 
     /// Step 5.7, one act (Rule 40), from whatever carried the launch this far: a LaunchRecord
-    /// at the callback, an Enrolment once the PIN is set. The Session is written, the login's
-    /// other Sessions are closed and marked (Rule 8).
+    /// at the callback, an Enrolment once the PIN is set. The Session is written from the head
+    /// of the record (Rule 19), the login's other Sessions are closed and marked (Rule 8).
     let private openWith
         (now: DateTime)
         (newId: unit -> string)
@@ -497,6 +574,7 @@ module Hop =
                     {
                         Session = session
                         Login = login
+                        OpenedWith = headOf patientId state |> Option.map _.Head.Id
                     }
             Endings =
                 superseded

--- a/src/Informedica.GenPRES.Shared/Localization.fs
+++ b/src/Informedica.GenPRES.Shared/Localization.fs
@@ -161,6 +161,8 @@ type Terms =
     // the gate after the server ended the Session (Rule 11)
     | ``Session Gate Ended``
     | ``Session Ending Superseded``
+    // Rule 28 (UC-3, plan 622): the Session ended at the third wrong PIN
+    | ``Session Ending Pin Limit``
     // the enrolment form (UC-2, plan 615): title, body with {0} the name and {1} the hinted
     // mail address, the three field labels, the button, and one sentence per refusal
     | ``Session Gate Enrolment``

--- a/src/Informedica.GenPRES.Shared/Scripts/Localization.fsx
+++ b/src/Informedica.GenPRES.Shared/Scripts/Localization.fsx
@@ -54,6 +54,8 @@ type SessionTerms =
     // the gate after the server ended the Session (Rule 11, plan 605 PR 4)
     | ``Session Gate Ended``
     | ``Session Ending Superseded``
+    // Rule 28 (UC-3, plan 622 PR 1): the Session ended at the third wrong PIN
+    | ``Session Ending Pin Limit``
     // the enrolment form (UC-2, plan 615 PR 3): title, body with {0} the name and {1} the
     // hinted mail address, the three field labels, the button, and one sentence per refusal
     | ``Session Gate Enrolment``
@@ -100,6 +102,7 @@ let english term =
     | ``Session Gate Ended`` -> "Your session was ended"
     | ``Session Ending Superseded`` ->
         "Another launch of yours opened a newer session, and this one was closed."
+    | ``Session Ending Pin Limit`` -> "The PIN was entered wrong three times, and signing is locked for a while."
     | ``Session Gate Enrolment`` -> "Set a PIN to continue"
     | ``Session Gate Enrolment Text`` ->
         "Welcome, {0}. A confirmation code was mailed to {1}. Enter it together with the PIN of your choice: four to six digits."
@@ -146,6 +149,7 @@ let dutch term =
     | ``Session Gate Ended`` -> "Uw sessie is beëindigd"
     | ``Session Ending Superseded`` ->
         "Een andere start van u heeft een nieuwere sessie geopend; deze sessie is gesloten."
+    | ``Session Ending Pin Limit`` -> "De pincode is drie keer verkeerd ingevoerd; ondertekenen is een tijdje geblokkeerd."
     | ``Session Gate Enrolment`` -> "Stel een pincode in om verder te gaan"
     | ``Session Gate Enrolment Text`` ->
         "Welkom, {0}. Er is een bevestigingscode gemaild naar {1}. Voer die in samen met de pincode van uw keuze: vier tot zes cijfers."

--- a/src/Informedica.GenPRES.Shared/Types.fs
+++ b/src/Informedica.GenPRES.Shared/Types.fs
@@ -645,10 +645,39 @@ module Types =
 
 
     /// Why a Session ended other than by the User closing it (Rule 11). The server says it
-    /// once, at the next request, and the client shows it. One case now; idle and absolute
-    /// lifetime (Rule 10) come with their own plan.
+    /// once, at the next request, and the client shows it. Idle and absolute lifetime
+    /// (Rule 10) come with their own plan.
     [<RequireQualifiedAccess>]
-    type SessionEnding = SupersededByLaunch
+    type SessionEnding =
+        | SupersededByLaunch
+        // Rule 28: the third wrong PIN at a signature (UC-3)
+        | WrongPinLimit
+
+
+    /// What identifies a signed version of an order plan (Concept 9): its id, its place in
+    /// the patient's record (`No` orders the record: a clock cannot say which of two landed
+    /// first, Rule 20), who signed it and when. Enough for Rule 21's notice: whose, and when.
+    type OrderPlanHead =
+        {
+            Id: string
+            No: int
+            By: UserContext
+            SignedAt: DateTime
+        }
+
+
+    /// A signed version of an order plan, as the record holds it (the integration design's
+    /// TreatmentPlan): the head, the patient, the version it was signed over (`Base`, `None`
+    /// for the first), the orders as shown at the signature and the patient data the User
+    /// saw (Rule 44).
+    type SignedOrderPlan =
+        {
+            Head: OrderPlanHead
+            PatientId: string
+            Base: string option
+            Scenarios: OrderScenario[]
+            Patient: Patient
+        }
 
 
     /// What the client learns when its launch is waiting on a PIN (UC-2): whom to greet and

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -1074,6 +1074,19 @@ module SessionStubTests =
                         Credential.lockFor 3 |> Expect.equal "at the limit" (minutes 1.0)
                         Credential.lockFor 4 |> Expect.equal "one past" (minutes 2.0)
                         Credential.lockFor 5 |> Expect.equal "two past" (minutes 4.0)
+
+                        Credential.lockFor 13
+                        |> Expect.equal "ten past: just under the cap" (minutes 1024.0)
+
+                        Credential.lockFor 14 |> Expect.equal "capped at a day" Credential.lockMax
+
+                        Credential.lockFor Int32.MaxValue
+                        |> Expect.equal "no overflow" Credential.lockMax
+
+                        let _, c =
+                            Credential.verify t0 "0000" { withPin with WrongCount = Int32.MaxValue - 1 }
+
+                        c.LockedUntil |> Expect.equal "a day from now" (Some(t0 + Credential.lockMax))
                     }
 
                     test "a right PIN is accepted, zeroes the count and clears the lock" {

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -601,7 +601,56 @@ module SessionStubTests =
                             record.Session.KeyThumbprint
                             |> Expect.equal "thumbprint" (Some(PublicKey.thumbprint keyA))
 
+                            record.OpenedWith |> Expect.isNone "opened from nothing (Rule 19)"
                             state.Launches["n-1"].Outcome |> Expect.isSome "outcome appended"
+                        | other -> failtest $"expected Opened, got {other}"
+                    }
+
+                    test "prescriber over a record: the Session opens with the newest version as its head (Rule 19)" {
+                        let ids, d = fixture ()
+
+                        let signedAs userId no : SignedOrderPlan =
+                            {
+                                Head =
+                                    {
+                                        Id = $"plan-{no}"
+                                        No = no
+                                        By =
+                                            {
+                                                UserId = userId
+                                                DisplayName = userId
+                                                Role = UserRole.Prescriber
+                                            }
+                                        SignedAt = t0
+                                    }
+                                PatientId = "patient-1"
+                                Base = (if no > 1 then Some $"plan-{no - 1}" else None)
+                                Scenarios = [||]
+                                Patient = Shared.Models.Patient.empty
+                            }
+
+                        let record =
+                            { seeded with
+                                Records =
+                                    Map.ofList
+                                        [
+                                            "patient-1", [ signedAs "prescriber-b" 2; signedAs "prescriber" 1 ]
+                                            "patient-2", [ signedAs "prescriber" 1 ]
+                                        ]
+                            }
+
+                        Hop.headOf "patient-1" record
+                        |> Option.map _.Head.Id
+                        |> Expect.equal "newest first" (Some "plan-2")
+
+                        Hop.headOf "patient-3" record |> Expect.isNone "no record"
+
+                        let state, cb = hop ids d record launch1 keyA "prescriber"
+                        let state, result = run ids d state cb
+
+                        match result with
+                        | CallbackResult.Opened(id, _) ->
+                            state.Sessions[id].OpenedWith |> Expect.equal "the head at open" (Some "plan-2")
                         | other -> failtest $"expected Opened, got {other}"
                     }
 
@@ -970,17 +1019,36 @@ module SessionStubTests =
 
 
         let credentialTests =
+            let minutes (n: float) = TimeSpan.FromMinutes n
+            let withPin = Credential.withPin salts "1234"
+
+            /// Wrong entries in a row, each a minute after the last; the credential and the
+            /// time of the next entry.
+            let wrong (n: int) (start: DateTime) (credential: Credential) =
+                [ 1..n ]
+                |> List.fold
+                    (fun (c, at) _ -> Credential.verify at "0000" c |> snd, at + minutes 1.0)
+                    (credential, start)
+
             testList
                 "Credential"
                 [
                     test "an empty credential has no PIN set (Rule 24)" {
                         Credential.empty |> Credential.pinSet |> Expect.isFalse "no PIN"
+                        Credential.empty.LockedUntil |> Expect.isNone "no lock"
                     }
 
-                    test "withPin sets the PIN and a count of zero (Rule 28)" {
+                    test "withPin sets the PIN, a count of zero and no lock (Rules 28, 37)" {
                         let c = Credential.withPin salts "1234"
                         c |> Credential.pinSet |> Expect.isTrue "set"
                         c.WrongCount |> Expect.equal "zero" 0
+                        c.LockedUntil |> Expect.isNone "no lock"
+
+                        let locked, _ = wrong 4 t0 withPin
+                        locked.WrongCount |> Expect.equal "(four wrong entries)" 4
+                        let reset = Credential.withPin salts "2468"
+                        reset.WrongCount |> Expect.equal "a new PIN zeroes the count" 0
+                        reset.LockedUntil |> Expect.isNone "and clears the lock"
 
                         c.PinHash
                         |> Option.map (PinHash.verify "1234")
@@ -999,6 +1067,66 @@ module SessionStubTests =
 
                         seed["no-pin"] |> Credential.pinSet |> Expect.isFalse "no-pin unset"
                         seed |> Map.containsKey "reader" |> Expect.isFalse "a Reader has no credential"
+                    }
+
+                    test "the delay is one minute at the limit and doubles with each further entry (Rule 28)" {
+                        Credential.lockFor 0 |> Expect.equal "below the limit: the base" (minutes 1.0)
+                        Credential.lockFor 3 |> Expect.equal "at the limit" (minutes 1.0)
+                        Credential.lockFor 4 |> Expect.equal "one past" (minutes 2.0)
+                        Credential.lockFor 5 |> Expect.equal "two past" (minutes 4.0)
+                    }
+
+                    test "a right PIN is accepted, zeroes the count and clears the lock" {
+                        let twoWrong, at = wrong 2 t0 withPin
+                        twoWrong.WrongCount |> Expect.equal "two" 2
+                        twoWrong.LockedUntil |> Expect.isNone "not locked yet"
+                        twoWrong |> Credential.attemptsLeft |> Expect.equal "one left" 1
+
+                        let ok, after = Credential.verify at "1234" twoWrong
+                        ok |> Expect.isTrue "accepted"
+                        after.WrongCount |> Expect.equal "zeroed" 0
+                        after.LockedUntil |> Expect.isNone "no lock"
+                    }
+
+                    test "the third wrong PIN locks for a minute; a right PIN inside it is refused and counts nothing" {
+                        let limit, at = wrong 3 t0 withPin
+                        limit.WrongCount |> Expect.equal "three" 3
+                        limit.LockedUntil |> Expect.equal "a minute from the third entry" (Some at)
+
+                        limit
+                        |> Credential.isLocked (at - minutes 0.5)
+                        |> Expect.isTrue "locked inside the minute"
+
+                        limit |> Credential.attemptsLeft |> Expect.equal "none left" 0
+
+                        let ok, same = Credential.verify (at - minutes 0.5) "1234" limit
+                        ok |> Expect.isFalse "refused while locked"
+                        same |> Expect.equal "unchanged" limit
+
+                        let ok, after = Credential.verify at "1234" limit
+                        ok |> Expect.isTrue "accepted once the minute passed"
+                        after.WrongCount |> Expect.equal "zeroed" 0
+                    }
+
+                    test "a wrong PIN while locked counts, and pushes the delay out and doubles it" {
+                        let limit, at = wrong 3 t0 withPin
+                        let inside = at - minutes 0.5
+
+                        let ok, fourth = Credential.verify inside "0000" limit
+                        ok |> Expect.isFalse "refused"
+                        fourth.WrongCount |> Expect.equal "four" 4
+
+                        fourth.LockedUntil
+                        |> Expect.equal "two minutes from this entry" (Some(inside + minutes 2.0))
+
+                        let _, fifth = Credential.verify inside "0000" fourth
+                        fifth.LockedUntil |> Expect.equal "four minutes" (Some(inside + minutes 4.0))
+                    }
+
+                    test "a credential without a PIN accepts nothing and counts the entry" {
+                        let ok, after = Credential.verify t0 "1234" Credential.empty
+                        ok |> Expect.isFalse "no PIN"
+                        after.WrongCount |> Expect.equal "counted" 1
                     }
 
                     test "credentialOf answers the empty credential for a person the store does not know" {

--- a/tests/Informedica.GenPRES.Shared.Tests/SessionGatePolicyTests.fs
+++ b/tests/Informedica.GenPRES.Shared.Tests/SessionGatePolicyTests.fs
@@ -87,6 +87,7 @@ module SessionGatePolicyTests =
                                 "Unreachable", Session.Unreachable(launch, key, 3)
                                 "Refused", Session.Refused(LaunchRefusal.NoRole, None)
                                 "Ended", Session.Ended SessionEnding.SupersededByLaunch
+                                "Ended at the PIN limit", Session.Ended SessionEnding.WrongPinLimit
                                 "Enrolling", Session.Enrolling(pending, None)
                                 "SupplyingPin", Session.SupplyingPin pending
                                 "EnrolmentFailed", Session.EnrolmentFailed PinRefusal.CodeVoid
@@ -168,6 +169,9 @@ module SessionGatePolicyTests =
 
                     named.Body
                     |> Expect.equal "body terms" "<Session Ending Superseded> <Session Relaunch>"
+
+                    (namedGateOf (Session.Ended SessionEnding.WrongPinLimit)).Body
+                    |> Expect.equal "the PIN limit (Rule 28)" "<Session Ending Pin Limit> <Session Relaunch>"
                 }
 
                 test "Launching is busy, names the attempt, offers nothing" {
@@ -324,6 +328,7 @@ module SessionGatePolicyTests =
                             Terms.``Session Role Reader``
                             Terms.``Session Gate Ended``
                             Terms.``Session Ending Superseded``
+                            Terms.``Session Ending Pin Limit``
                         ] do
                         english term |> Expect.notEqual $"default for {term}" $"{term}"
 


### PR DESCRIPTION
## Summary

Plan [622](https://github.com/informedica/GenPRES/blob/master/docs/implementation-plans/622-signing-with-server-stubs.md) step 1: the record and the head a Session opens with, and the lock on a credential. **No change in behaviour**: no request reads the record yet, and no PIN is verified at a signature until step 3.

- **Shared**: `OrderPlanHead` and `SignedOrderPlan` (the integration design's TreatmentPlan, named after the code's `OrderPlan`); `SessionEnding.WrongPinLimit` (Rule 28); the term `Session Ending Pin Limit`.
- **Server**: `Credential` gains `LockedUntil`, with `wrongPinLimit` (3), `lockBase` (one minute), `lockFor` (doubling past the limit), `isLocked`, `verify` and `attemptsLeft` as the model's `UserCredential.verify` (Rules 23, 28): a right PIN while unlocked zeroes the count and clears the lock; a right PIN while locked is refused and counts nothing; a wrong PIN counts and, at the limit or beyond, locks from now. `Hop.State.Records`, the signed versions per patient, newest first; `SessionRecord.OpenedWith`, the head at open (Rule 19), read by `openWith` through `headOf`.
- **Client**: the gate's sentence for a Session ended at the PIN limit.
- **Tests**: the lock (one, two, four minutes; reset on a right entry; a right entry while locked counts nothing; a wrong one while locked doubles; `withPin` clears both), the head at open over a seeded record with two versions and two patients. Server 212, shared 438, Fable and Fantomas green.

Script-first: `Server/Scripts/Signing.fsx` (10 tests) and `Shared/Scripts/Localization.fsx` (17 tests), migrated after review.

## Localization

One row for the workbook (English, Dutch; the other languages empty):

```text
Session Ending Pin Limit	The PIN was entered wrong three times, and signing is locked for a while.	De pincode is drie keer verkeerd ingevoerd; ondertekenen is een tijdje geblokkeerd.
```

## AI-assisted contribution

- [x] Vibe coded: drafted by Claude Code in the two scripts, verified by their Expecto tests, then migrated and re-verified with the solution build, the server and shared test projects, the Fable compile and Fantomas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZWjibQUW8uqCVbfV4vDTf
