### PR TITLE
feat(server): commit a signature (#622)

### DIFF
--- a/src/Informedica.GenPRES.Server/Scripts/Signing.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/Signing.fsx
@@ -1,20 +1,17 @@
-// UC-3 prescribe and sign against server-hosted stubs (plan 622), PR 2: the signing challenge
-// (uc-03 step 2; Rules 20, 33, 34, 43, 44), with Rule 44's data notice: changed or unreadable
-// patient data is told, never refused, and the User proceeds by returning the notice token.
+// UC-3 prescribe and sign against server-hosted stubs (plan 622), PR 3: the commit (uc-03
+// step 3; Rules 20, 23, 27, 28, 33, 34, 38, 42, 43, 45).
 //
 // Script-first draft (script-only policy) of:
-//   - the wire: `SigningRefusal`, `DataNotice`, `SigningResponse` → `Shared/Types.fs` (the
-//     port answers it, like `LaunchOutcome`); `SigningCommand.RequestSignChallenge`,
-//     `IServerApi.processSigning` → `Shared/Api.fs`;
-//   - the port: `SessionPort.challenge` → `Ports.fs`;
-//   - `Hop`: `Notice`, `Challenge`, `State.Notices` and `State.Challenges` (one each per
-//     Session, two minutes), `challenge` as the ladder of uc-03 step 2 → `Adapters.fs`;
-//     `sessionDisabled` refusing;
-//   - the composition root: `processSigning` over the session cookie → `CompositionRoot.fs`.
+//   - the wire: `Submission`, `SigningResponse.Submitted`, `SignedOrderPlan.Verified`
+//     → `Shared/Types.fs`; `SigningCommand.Submit` → `Shared/Api.fs`;
+//   - the port: `SessionPort.submit` → `Ports.fs`;
+//   - `Mails.pinLimit` (Rule 27) → `Adapters.fs`;
+//   - `Hop`: `State.Answered` (Rule 45, per Session and key), `commit` as the ladder of the
+//     model's `dbCommit`, the PIN last → `Adapters.fs`; `sessionDisabled` refusing;
+//   - the composition root: `Submit` over the session cookie → `CompositionRoot.fs`.
 //
-// PR 1 (merged, #624) put the record, the head at open and the credential lock in place; this
-// script re-states only what changes: a `State` of the fields the challenge reads, over the
-// source's `SessionRecord`. The Submission (step 3) is PR 3. Run: `dotnet fsi Signing.fsx`
+// PR 2 (merged, #626) issued the challenge; this script re-states only what changes: a `State`
+// of the fields the commit reads, over the source's records. Run: `dotnet fsi Signing.fsx`
 // from this directory (build first).
 
 #I __SOURCE_DIRECTORY__
@@ -32,177 +29,147 @@ open ServerApi
 // Wire (→ Shared/Types.fs, Shared/Api.fs)
 // ---------------------------------------------------------------------------------------------
 
-/// Why a signature did not proceed (uc-03 steps 2 and 3). The first seven end the signing and
-/// are told once; `PinWrong` and `Locked` keep the PIN dialog open; `PinLimit` ends the
-/// Session (Rule 28). Changed patient data is not a refusal but a `DataNotice` (Rule 44). The
-/// PIN cases arrive with the Submission (PR 3).
-[<RequireQualifiedAccess>]
-type SigningRefusal =
-    // no Session for the cookie, or none at all
-    | NoSession
-    // the Session has no Patient, or the plan names other patient data (Rule 33)
-    | NoPatient
-    // nobody to sign as, or the Role is not Prescriber (Concept 7, Rule 38)
-    | NotPrescriber
-    // Rule 20: the record moved on; whose version, and when
-    | Blocked of OrderPlanHead
-    // Rule 34: not the OpenedToken this Session holds
-    | StaleToken
-    // Rule 43: not the plan the challenge was issued over, or no challenge
-    | ChallengeMismatch
-    | ChallengeExpired
-    // Rule 28
-    | PinWrong of attemptsLeft: int
-    | PinLimit
-    | Locked of until: DateTime
-
-
-/// Rule 44: the patient data as it stands, told before a challenge is issued when it is not
-/// what the Session opened with. `Data = None`: the platform cannot be read, the data is
-/// unverified. The User proceeds by returning the token with the next request.
-type DataNotice =
+/// A signed version of an order plan, as the record holds it (the integration design's
+/// TreatmentPlan): the head, the patient, the version it was signed over (`Base`, `None` for
+/// the first), the orders as shown at the signature, the patient data the User saw and
+/// whether it was the platform's reading at the challenge (Rule 44).
+type SignedOrderPlan =
     {
-        Data: Patient option
-        Token: string
+        Head: OrderPlanHead
+        PatientId: string
+        Base: string option
+        Scenarios: OrderScenario[]
+        Patient: Patient
+        Verified: bool
     }
 
 
-/// The signing command family (uc-03 steps 2 and 3): always cookie-authenticated, like the
-/// session family. Room to grow: the Submission (PR 3).
+/// uc-03 step 3: the plan as shown, the OpenedToken the Session holds (Rule 34), the
+/// challenge it was issued (Rule 43), the PIN (Rule 23), and a key of the client's own so that
+/// the commit takes effect once (Rule 45). Never logged.
+type Submission =
+    {
+        Plan: OrderPlan
+        Opened: OpenedToken
+        Challenge: string
+        Pin: string
+        IdemKey: string
+    }
+
+
 [<RequireQualifiedAccess>]
 type SigningCommand =
-    // step 2: the plan as shown, the OpenedToken the Session holds (Rule 34), and the token of
-    // the data notice the User accepted, if one was told (Rule 44)
     | RequestSignChallenge of OrderPlan * OpenedToken * dataNotice: string option
+    // step 3: the signature
+    | Submit of Submission
 
 
 [<RequireQualifiedAccess>]
 type SigningResponse =
-    // the challenge over exactly this plan (Rule 43); comes back with the PIN
     | ChallengeIssued of challenge: string
-    // Rule 44: no challenge yet; the data as it stands, to show and to accept or not
     | DataNotice of DataNotice
+    // step 3: the version committed, and a fresh OpenedToken over it (Rule 34)
+    | Submitted of SignedOrderPlan * OpenedToken
     | Refused of SigningRefusal
 
 
 module SigningCommand =
 
-    /// For the log. Never the plan (long) or, later, the PIN.
+    /// For the log. Never the plan (long) or the PIN.
     let toString cmd =
         match cmd with
         | SigningCommand.RequestSignChallenge _ -> "RequestSignChallenge"
+        | SigningCommand.Submit _ -> "Submit"
 
 
 // ---------------------------------------------------------------------------------------------
-// Ports (→ ServerApi.Ports.fs)
+// Mail (→ ServerApi.Adapters.fs, `Mails`)
 // ---------------------------------------------------------------------------------------------
 
-type SessionPort =
-    {
-        present: Launch * PublicKey -> Async<LaunchResult>
-        callback: Callback -> Async<CallbackResult>
-        find: string -> Async<SessionLookup>
-        close: string -> Async<unit>
-        findEnrolment: string -> Async<EnrolmentPending option>
-        supplyPin: string -> string -> string -> Async<SupplyPinResult>
-        dropEnrolment: string -> Async<unit>
-        // UC-3 step 2: a challenge over the plan as shown, for the Session the cookie names
-        challenge: string -> OrderPlan * OpenedToken * string option -> Async<SigningResponse>
-    }
+module Mails =
+
+    /// Rule 27: the third wrong PIN ended a Session and locked signing.
+    let pinLimit (displayName: string) : string * string =
+        "GenPRES: signing is locked",
+        $"Hello {displayName},\n\nThe PIN was entered wrong three times at a signature just now. Your session was ended and signing is locked for a while. If that was not you, tell your administrator."
 
 
 // ---------------------------------------------------------------------------------------------
-// The challenge (→ ServerApi.Adapters.fs, `Hop`)
+// The commit (→ ServerApi.Adapters.fs, `Hop`)
 // ---------------------------------------------------------------------------------------------
 
 module Hop =
 
     type SessionRecord = ServerApi.Hop.SessionRecord
+    type Challenge = ServerApi.Hop.Challenge
 
 
-    /// A data notice as the store holds it (Rule 44): one per Session, the platform's reading
-    /// it was told over (`None`: unreadable), for two minutes.
-    type Notice =
-        {
-            Nonce: string
-            Data: Patient option
-            Expiry: DateTime
-        }
-
-
-    /// A signing challenge as the store holds it (Concept 17): one per Session, over exactly
-    /// the patient data and the orders shown (Rule 43), whether that data was the platform's
-    /// reading when it was issued (Rule 44), for two minutes.
-    type Challenge =
-        {
-            Nonce: string
-            Patient: Patient
-            Scenarios: OrderScenario[]
-            Verified: bool
-            Expiry: DateTime
-        }
-
-
-    /// The state of PR 2: the fields the challenge reads; the rest stays as
+    /// The state of PR 3: the fields the commit reads; the rest stays as
     /// `ServerApi.Hop.State` has it.
     type State =
         {
             Sessions: Map<string, SessionRecord>
+            Endings: Map<string, SessionEnding * DateTime>
+            Credentials: Map<string, Credential>
             Records: Map<string, SignedOrderPlan list>
-            // UC-3: the live data notice per Session
-            Notices: Map<string, Notice>
-            // UC-3: the live challenge per Session
             Challenges: Map<string, Challenge>
+            // UC-3, Rule 45: what a Submission was answered, by Session and by the client's key
+            Answered: Map<string * string, SigningResponse * DateTime>
         }
 
 
     let emptyState =
         {
             Sessions = Map.empty
+            Endings = Map.empty
+            Credentials = Map.empty
             Records = Map.empty
-            Notices = Map.empty
             Challenges = Map.empty
+            Answered = Map.empty
         }
 
 
-    /// How long a challenge lives: the launch's two minutes, the time to read the modal and
-    /// enter a PIN, so what is signed was checked against the platform moments ago (Rule 44).
-    let challengeLifetime = TimeSpan.FromMinutes 2.0
+    let challengeLifetime = ServerApi.Hop.challengeLifetime
 
 
-    /// Rule 19: the most recent signed version of a patient's record, if any.
+    let credentialOf (userId: string) (state: State) =
+        state.Credentials |> Map.tryFind userId |> Option.defaultValue Credential.empty
+
+
     let headOf (patientId: string) (state: State) =
         state.Records |> Map.tryFind patientId |> Option.bind List.tryHead
 
 
-    let private dropExpired (now: DateTime) (state: State) =
-        { state with
-            Notices = state.Notices |> Map.filter (fun _ n -> now <= n.Expiry)
-            Challenges = state.Challenges |> Map.filter (fun _ c -> now <= c.Expiry)
-        }
-
-
-    /// Rule 20: the head of the record, when it is not the version the Session opened with.
     let blockedBy (record: SessionRecord) (patientId: string) (state: State) =
         match headOf patientId state with
         | Some head when Some head.Head.Id <> record.OpenedWith -> Some head.Head
         | _ -> None
 
 
-    /// uc-03 step 2, in order: the Session with a User and a Patient; the Role Prescriber; the
-    /// OpenedToken this Session holds (Rule 34); the patient data re-read (Rule 44): when it is
-    /// not what the Session opened with and no notice over this reading was accepted, no
-    /// challenge yet but a `DataNotice`, replacing any earlier notice and dropping any earlier
-    /// challenge (it was over the data before the change); the plan over the data as
-    /// it stands (Rule 33); the record not moved on (Rule 20). Then a challenge over exactly
-    /// this plan (Rule 43), replacing the Session's earlier one and spending the notice. The
-    /// PIN is not involved: a refusal here costs no attempt (Rule 28).
-    let challenge
+    let private dropExpired (now: DateTime) (state: State) =
+        { state with
+            Challenges = state.Challenges |> Map.filter (fun _ c -> now <= c.Expiry)
+            Answered = state.Answered |> Map.filter (fun _ (_, at) -> now <= at + challengeLifetime)
+        }
+
+
+    /// uc-03 step 3, one act in the model's order (`dbCommit`): the Session with a User and a
+    /// Patient; the answer already given to this Session's key (Rule 45); the Role re-taken
+    /// from the registry (Rule 38, fails closed); the OpenedToken this Session holds (Rule 34);
+    /// the record not moved on (Rule 20); the challenge this Session was issued, over exactly
+    /// this plan (Rule 43); and last the PIN (Rules 23, 28), so that a Submission that was
+    /// never going to land costs no attempt. Then the version is appended, the challenge
+    /// spent, the OpenedToken re-minted over the new head, and the answer remembered under the
+    /// key, refusals too. Three wrong PINs end the Session (`WrongPinLimit`), lock signing and
+    /// mail the User (Rule 27); a wrong PIN while locked pushes the lock out; a right PIN while
+    /// locked is refused and counts nothing.
+    let commit
         (now: DateTime)
         (newId: unit -> string)
-        (patientData: string -> Patient option)
+        (standing: BrowserIdentity -> UserStanding option)
+        (send: Mail -> unit)
         (sid: string)
-        (plan: OrderPlan, opened: OpenedToken, notice: string option)
+        (submission: Submission)
         (state: State)
         : State * SigningResponse
         =
@@ -216,83 +183,110 @@ module Hop =
             | None, _ -> refuse SigningRefusal.NotPrescriber
             | Some _, None -> refuse SigningRefusal.NoPatient
             | Some user, Some patient ->
-                if user.Role <> UserRole.Prescriber then
-                    refuse SigningRefusal.NotPrescriber
-                elif record.Session.OpenedToken <> Some opened then
-                    refuse SigningRefusal.StaleToken
-                else
-                    let current = patientData patient.PatientId
+                match state.Answered |> Map.tryFind (sid, submission.IdemKey) with
+                | Some(answer, _) -> state, answer
+                | None ->
+                    // the answer is remembered from here on, under this Session and the key
+                    let remember (state: State) answer =
+                        { state with Answered = state.Answered |> Map.add (sid, submission.IdemKey) (answer, now) }, answer
 
-                    let accepted =
-                        notice
-                        |> Option.bind (fun token ->
-                            state.Notices
-                            |> Map.tryFind sid
-                            |> Option.filter (fun n -> n.Nonce = token && n.Data = current)
-                        )
+                    let refuse refusal =
+                        remember state (SigningResponse.Refused refusal)
 
-                    if current <> Some patient.Patient && accepted.IsNone then
-                        let nonce = newId ()
+                    let identity =
+                        {
+                            Login = record.Login |> Option.defaultValue user.UserId
+                            DisplayName = user.DisplayName
+                        }
 
-                        { state with
-                            Notices =
-                                state.Notices
-                                |> Map.add
-                                    sid
-                                    {
-                                        Nonce = nonce
-                                        Data = current
-                                        Expiry = now + challengeLifetime
-                                    }
-                            // a challenge over the data before the change must not be signed
-                            Challenges = state.Challenges |> Map.remove sid
-                        },
-                        SigningResponse.DataNotice { Data = current; Token = nonce }
-                    // unverified data: the plan stays over what the Session opened with
-                    elif plan.Patient <> (current |> Option.defaultValue patient.Patient) then
-                        refuse SigningRefusal.NoPatient
-                    else
-                        match blockedBy record patient.PatientId state with
-                        | Some head -> refuse (SigningRefusal.Blocked head)
-                        | None ->
-                            let nonce = newId ()
+                    match standing identity with
+                    | Some fresh when fresh.User.Role = UserRole.Prescriber ->
+                        if record.Session.OpenedToken <> Some submission.Opened then
+                            refuse SigningRefusal.StaleToken
+                        else
+                            match blockedBy record patient.PatientId state with
+                            | Some head -> refuse (SigningRefusal.Blocked head)
+                            | None ->
+                                match state.Challenges |> Map.tryFind sid with
+                                | None -> refuse SigningRefusal.ChallengeExpired
+                                | Some challenge when
+                                    challenge.Nonce <> submission.Challenge
+                                    || challenge.Patient <> submission.Plan.Patient
+                                    || challenge.Scenarios <> submission.Plan.Scenarios
+                                    ->
+                                    refuse SigningRefusal.ChallengeMismatch
+                                | Some challenge ->
+                                    let credential = credentialOf user.UserId state
+                                    let wasLocked = Credential.isLocked now credential
+                                    let right, credential = Credential.verify now submission.Pin credential
 
-                            { state with
-                                Notices = state.Notices |> Map.remove sid
-                                Challenges =
-                                    state.Challenges
-                                    |> Map.add
-                                        sid
-                                        {
-                                            Nonce = nonce
-                                            Patient = plan.Patient
-                                            Scenarios = plan.Scenarios
-                                            Verified = current.IsSome
-                                            Expiry = now + challengeLifetime
-                                        }
-                            },
-                            SigningResponse.ChallengeIssued nonce
+                                    let state =
+                                        { state with Credentials = state.Credentials |> Map.add user.UserId credential }
 
+                                    if right then
+                                        let id = newId ()
 
-    /// The port member, as `makeSessionPort` wires it: the pure step under the state lock.
-    let challengePort (now: unit -> DateTime) (newId: unit -> string) (patientData: PatientDataPort) (initial: State) =
-        let gate = obj ()
-        let mutable state = initial
+                                        let plan =
+                                            {
+                                                Head =
+                                                    {
+                                                        Id = id
+                                                        No = 1 + (state.Records |> Map.tryFind patient.PatientId |> Option.map List.length |> Option.defaultValue 0)
+                                                        By = user
+                                                        SignedAt = now
+                                                    }
+                                                PatientId = patient.PatientId
+                                                Base = record.OpenedWith
+                                                Scenarios = challenge.Scenarios
+                                                Patient = challenge.Patient
+                                                Verified = challenge.Verified
+                                            }
 
-        let update f =
-            lock gate (fun () ->
-                let next, result = f state
-                state <- next
-                result
-            )
+                                        let token = OpenedToken $"opened-{newId ()}"
 
-        (fun sid request -> async { return update (fun s -> challenge (now ()) newId patientData.read sid request s) }),
-        (fun () -> state)
+                                        let opened =
+                                            { record with
+                                                Session = { record.Session with OpenedToken = Some token }
+                                                OpenedWith = Some id
+                                            }
 
+                                        remember
+                                            { state with
+                                                Records =
+                                                    state.Records
+                                                    |> Map.change patient.PatientId (fun versions ->
+                                                        Some(plan :: (versions |> Option.defaultValue []))
+                                                    )
+                                                Challenges = state.Challenges |> Map.remove sid
+                                                Sessions = state.Sessions |> Map.add sid opened
+                                            }
+                                            (SigningResponse.Submitted(plan, token))
+                                    elif wasLocked then
+                                        // this Session did nothing wrong; the lock is the credential's
+                                        remember state (SigningResponse.Refused(SigningRefusal.Locked credential.LockedUntil.Value))
+                                    elif credential |> Credential.attemptsLeft = 0 then
+                                        // Rule 28: the limit is reached now; the Session ends (Rule 10)
+                                        let subject, body = Mails.pinLimit user.DisplayName
 
-/// What the production port answers until the scope switch: nothing is signed.
-let challengeDisabled: string -> OrderPlan * OpenedToken * string option -> Async<SigningResponse> =
-    fun _ _ -> async { return SigningResponse.Refused SigningRefusal.NoSession }
+                                        send
+                                            {
+                                                To = fresh.MailAddress
+                                                Subject = subject
+                                                Body = body
+                                            }
+
+                                        remember
+                                            { state with
+                                                Sessions = state.Sessions |> Map.remove sid
+                                                Endings = state.Endings |> Map.add sid (SessionEnding.WrongPinLimit, now)
+                                                Challenges = state.Challenges |> Map.remove sid
+                                            }
+                                            (SigningResponse.Refused SigningRefusal.PinLimit)
+                                    else
+                                        remember
+                                            state
+                                            (SigningResponse.Refused(SigningRefusal.PinWrong(credential |> Credential.attemptsLeft)))
+                    | _ -> refuse SigningRefusal.NotPrescriber
 
 
 // ---------------------------------------------------------------------------------------------
@@ -301,10 +295,9 @@ let challengeDisabled: string -> OrderPlan * OpenedToken * string option -> Asyn
 
 module CompositionRoot =
 
-    /// A signing command for the Session the cookie names. No cookie, no Session: refused
-    /// before the port is asked. Writes no cookie.
     let processSigning
         (challenge: string -> OrderPlan * OpenedToken * string option -> Async<SigningResponse>)
+        (submit: string -> Submission -> Async<SigningResponse>)
         (cookie: SessionCookie)
         (cmd: SigningCommand)
         =
@@ -314,6 +307,7 @@ module CompositionRoot =
             | Some id ->
                 match cmd with
                 | SigningCommand.RequestSignChallenge(plan, opened, notice) -> return! challenge id (plan, opened, notice)
+                | SigningCommand.Submit submission -> return! submit id submission
         }
 
 
@@ -328,6 +322,7 @@ open Expecto.Flip
 let t0 = DateTime(2026, 9, 11, 12, 0, 0, DateTimeKind.Utc)
 let minutes (n: float) = TimeSpan.FromMinutes n
 let seconds (n: float) = TimeSpan.FromSeconds n
+let salts (n: int) = Array.init n byte
 
 let prescriber =
     {
@@ -342,37 +337,28 @@ let other =
         DisplayName = "Stub Prescriber B"
     }
 
-let reader =
-    {
-        UserId = "reader"
-        DisplayName = "Stub Reader"
-        Role = UserRole.Reader
-    }
-
 let stubPatient = Patient.empty
 let otherData = { Patient.empty with Department = Some "ICU" }
 let token sid = OpenedToken $"opened-{sid}"
+let plan = OrderPlan.create stubPatient [||]
 
 
-/// A Session as the store holds it after an open.
-let session (sid: string) (user: UserContext option) (patient: (string * Patient) option) (openedWith: string option) =
+let session (sid: string) (user: UserContext) (patientId: string) (openedWith: string option) =
     sid,
     ({
         Session =
             {
-                User = user
+                User = Some user
                 PatientContext =
-                    patient
-                    |> Option.map (fun (pid, data) ->
+                    Some
                         {
-                            PatientId = pid
-                            Patient = data
+                            PatientId = patientId
+                            Patient = stubPatient
                         }
-                    )
                 OpenedToken = Some(token sid)
                 KeyThumbprint = Some "t"
             }
-        Login = user |> Option.map _.UserId
+        Login = Some user.UserId
         OpenedWith = openedWith
     }: Hop.SessionRecord)
 
@@ -390,14 +376,46 @@ let signedBy (user: UserContext) no (at: DateTime) : SignedOrderPlan =
         Base = (if no > 1 then Some $"plan-{no - 1}" else None)
         Scenarios = [||]
         Patient = stubPatient
+        Verified = true
     }
 
 
-let stateOf (sessions: (string * Hop.SessionRecord) list) (records: (string * SignedOrderPlan list) list) =
-    { Hop.emptyState with
-        Sessions = Map.ofList sessions
-        Records = Map.ofList records
+let challenged (sid: string) (at: DateTime) : string * Hop.Challenge =
+    sid,
+    {
+        Nonce = $"c-{sid}"
+        Patient = stubPatient
+        Scenarios = [||]
+        Verified = true
+        Expiry = at + Hop.challengeLifetime
     }
+
+
+/// The registry as the stub has it, for the logins the tests use.
+let registry (identity: BrowserIdentity) =
+    let standing role =
+        Some
+            {
+                User =
+                    {
+                        UserId = identity.Login
+                        DisplayName = identity.DisplayName
+                        Role = role
+                    }
+                ActivePatientId = Some "stub-patient"
+                MailAddress = $"{identity.Login}@stub.example"
+            }
+
+    match identity.Login with
+    | "prescriber"
+    | "prescriber-b" -> standing UserRole.Prescriber
+    | "demoted" -> standing UserRole.Reader
+    | _ -> None
+
+
+let outbox () =
+    let sent = ref []
+    (fun (m: Mail) -> sent.Value <- m :: sent.Value), sent
 
 
 let counter prefix =
@@ -408,255 +426,238 @@ let counter prefix =
         $"{prefix}-{n.Value}"
 
 
-let plan = OrderPlan.create stubPatient [||]
-
-/// The platform as the stub has it: every patient is `Patient.empty`, `no-data` has none.
-let platform pid =
-    if pid = "no-data" then None else Some stubPatient
-
-
-let ask now nonces state sid (plan, opened) =
-    Hop.challenge now nonces platform sid (plan, opened, None) state
+let stateOf sessions records challenges =
+    { Hop.emptyState with
+        Sessions = Map.ofList sessions
+        Credentials = StubCredentials.seed salts |> Map.map (fun _ c -> { PinHash = c.PinHash; WrongCount = 0; LockedUntil = None })
+        Records = Map.ofList records
+        Challenges = Map.ofList challenges
+    }
 
 
-let askWith notice now nonces state sid (plan, opened) =
-    Hop.challenge now nonces platform sid (plan, opened, Some notice) state
+let submission sid pin key : Submission =
+    {
+        Plan = plan
+        Opened = token sid
+        Challenge = $"c-{sid}"
+        Pin = pin
+        IdemKey = key
+    }
 
 
-let opened = session "s-1" (Some prescriber) (Some("stub-patient", stubPatient)) None
+let submitAt now ids (send: Mail -> unit) state sid (s: Submission) =
+    Hop.commit now ids registry send sid s state
 
 
-let ladderTests =
+let submit state sid s = submitAt t0 (counter "id") (fst (outbox ())) state sid s
+
+
+let opened = session "s-1" prescriber "stub-patient" None
+let ready = stateOf [ opened ] [] [ challenged "s-1" t0 ]
+
+
+let happyTests =
     testList
-        "Hop.challenge refuses"
+        "Hop.commit commits"
         [
-            test "no Session for the id" {
-                stateOf [] []
-                |> ask t0 (counter "n") <| "s-9" <| (plan, token "s-9")
-                |> snd
-                |> Expect.equal "no session" (SigningResponse.Refused SigningRefusal.NoSession)
+            test "the version: head, base, by and patient from the Session, the plan from the challenge, verified" {
+                let ids = counter "id"
+                let state, answer = submitAt t0 ids ignore ready "s-1" (submission "s-1" "1234" "k-1")
+
+                match answer with
+                | SigningResponse.Submitted(signed, fresh) ->
+                    signed.Head |> Expect.equal "head" { Id = "id-1"; No = 1; By = prescriber; SignedAt = t0 }
+                    signed.PatientId |> Expect.equal "the Session's patient" "stub-patient"
+                    signed.Base |> Expect.isNone "from nothing"
+                    signed.Verified |> Expect.isTrue "the challenge's reading"
+                    fresh |> Expect.equal "re-minted" (OpenedToken "opened-id-2")
+
+                    state.Records["stub-patient"] |> Expect.equal "appended, newest first" [ signed ]
+                    state.Challenges |> Expect.isEmpty "spent"
+                    state.Sessions["s-1"].OpenedWith |> Expect.equal "the new head" (Some "id-1")
+                    state.Sessions["s-1"].Session.OpenedToken |> Expect.equal "held" (Some fresh)
+                    state.Answered[("s-1", "k-1")] |> fst |> Expect.equal "remembered" answer
+                    (Hop.credentialOf "prescriber" state).WrongCount |> Expect.equal "count zero" 0
+                | other -> failtest $"expected Submitted, got {other}"
             }
 
-            test "the anonymous Session: nobody to sign as (Concept 7)" {
-                stateOf [ session "s-1" None None None ] []
-                |> ask t0 (counter "n") <| "s-1" <| (plan, token "s-1")
-                |> snd
-                |> Expect.equal "not a prescriber" (SigningResponse.Refused SigningRefusal.NotPrescriber)
+            test "a second version over the first: No 2, Base the first" {
+                let ids = counter "id"
+                let state, _ = submitAt t0 ids ignore ready "s-1" (submission "s-1" "1234" "k-1")
+                // a new challenge over the new baseline, the token as re-minted
+                let state = { state with Challenges = Map.ofList [ challenged "s-1" (t0 + minutes 1.0) ] }
+
+                let again =
+                    { submission "s-1" "1234" "k-2" with Opened = state.Sessions["s-1"].Session.OpenedToken.Value }
+
+                match submitAt (t0 + minutes 1.0) ids ignore state "s-1" again |> snd with
+                | SigningResponse.Submitted(signed, _) ->
+                    signed.Head.No |> Expect.equal "second" 2
+                    signed.Base |> Expect.equal "over the first" (Some "id-1")
+                | other -> failtest $"expected Submitted, got {other}"
             }
 
-            test "a Session without a Patient (ext 1a)" {
-                stateOf [ session "s-1" (Some prescriber) None None ] []
-                |> ask t0 (counter "n") <| "s-1" <| (plan, token "s-1")
-                |> snd
-                |> Expect.equal "no patient" (SigningResponse.Refused SigningRefusal.NoPatient)
+            test "the same key again: the same answer, nothing committed twice (Rule 45)" {
+                let ids = counter "id"
+                let state, first = submitAt t0 ids ignore ready "s-1" (submission "s-1" "1234" "k-1")
+                let state, again = submitAt (t0 + seconds 5.0) ids ignore state "s-1" (submission "s-1" "1234" "k-1")
+                again |> Expect.equal "the first answer" first
+                state.Records["stub-patient"] |> List.length |> Expect.equal "one version" 1
             }
 
-            test "a plan over other patient data than the Session's (Rule 33)" {
-                stateOf [ opened ] []
-                |> ask t0 (counter "n") <| "s-1" <| (OrderPlan.create otherData [||], token "s-1")
+            test "a remembered refusal is answered again without counting; another Session's key finds nothing" {
+                let state, first = submit ready "s-1" (submission "s-1" "0000" "k-1")
+                first |> Expect.equal "wrong" (SigningResponse.Refused(SigningRefusal.PinWrong 2))
+                let state, again = submit state "s-1" (submission "s-1" "0000" "k-1")
+                again |> Expect.equal "the same" first
+                (Hop.credentialOf "prescriber" state).WrongCount |> Expect.equal "counted once" 1
+
+                let s2 = session "s-2" other "stub-patient" None
+                let state = { state with Sessions = state.Sessions |> Map.add (fst s2) (snd s2) }
+
+                submit state "s-2" { submission "s-2" "1234" "k-1" with Challenge = "none" }
                 |> snd
-                |> Expect.equal "no patient" (SigningResponse.Refused SigningRefusal.NoPatient)
+                |> Expect.equal "their own ladder" (SigningResponse.Refused SigningRefusal.ChallengeExpired)
             }
 
-            test "a Reader (Rule 26), before the token is looked at" {
-                stateOf [ session "s-1" (Some reader) (Some("stub-patient", stubPatient)) None ] []
-                |> ask t0 (counter "n") <| "s-1" <| (plan, token "stale")
-                |> snd
-                |> Expect.equal "not a prescriber" (SigningResponse.Refused SigningRefusal.NotPrescriber)
-            }
+            test "the old token is stale once the commit re-minted it (Rule 34)" {
+                let ids = counter "id"
+                let state, _ = submitAt t0 ids ignore ready "s-1" (submission "s-1" "1234" "k-1")
+                let state = { state with Challenges = Map.ofList [ challenged "s-1" t0 ] }
 
-            test "not the OpenedToken this Session holds (Rule 34)" {
-                stateOf [ opened ] []
-                |> ask t0 (counter "n") <| "s-1" <| (plan, token "s-2")
+                submitAt t0 ids ignore state "s-1" (submission "s-1" "1234" "k-2")
                 |> snd
                 |> Expect.equal "stale" (SigningResponse.Refused SigningRefusal.StaleToken)
-            }
-
-            test "changed data is a notice, not a refusal: the data as it stands, and a token (Rule 44)" {
-                // opened with data the platform has since changed
-                let state, answer =
-                    stateOf [ session "s-1" (Some prescriber) (Some("stub-patient", otherData)) None ] []
-                    |> ask t0 (counter "n") <| "s-1" <| (OrderPlan.create otherData [||], token "s-1")
-
-                answer |> Expect.equal "told" (SigningResponse.DataNotice { Data = Some stubPatient; Token = "n-1" })
-                state.Challenges |> Expect.isEmpty "no challenge yet"
-
-                state.Notices["s-1"]
-                |> Expect.equal
-                    "stored"
-                    {
-                        Nonce = "n-1"
-                        Data = Some stubPatient
-                        Expiry = t0 + minutes 2.0
-                    }
-            }
-
-            test "a notice drops the Session's earlier challenge: it was over the data before the change" {
-                let nonces = counter "n"
-                let state, issued = stateOf [ opened ] [] |> ask t0 nonces <| "s-1" <| (plan, token "s-1")
-                issued |> Expect.equal "issued" (SigningResponse.ChallengeIssued "n-1")
-
-                // the platform's reading changes under the challenge
-                let changed = { state with Sessions = state.Sessions |> Map.add "s-1" (snd (session "s-1" (Some prescriber) (Some("stub-patient", otherData)) None)) }
-                let state, told = ask (t0 + seconds 30.0) nonces changed "s-1" (OrderPlan.create otherData [||], token "s-1")
-                told |> Expect.equal "told" (SigningResponse.DataNotice { Data = Some stubPatient; Token = "n-2" })
-                state.Challenges |> Expect.isEmpty "the earlier challenge is gone"
-            }
-
-            test "unreadable data is a notice without data" {
-                stateOf [ session "s-1" (Some prescriber) (Some("no-data", stubPatient)) None ] []
-                |> ask t0 (counter "n") <| "s-1" <| (plan, token "s-1")
-                |> snd
-                |> Expect.equal "unverified" (SigningResponse.DataNotice { Data = None; Token = "n-1" })
-            }
-
-            test "the notice comes before the block, the Role and the token before the notice" {
-                stateOf
-                    [ session "s-1" (Some prescriber) (Some("no-data", stubPatient)) None ]
-                    [ "no-data", [ signedBy other 1 t0 ] ]
-                |> ask t0 (counter "n") <| "s-1" <| (plan, token "s-1")
-                |> snd
-                |> Expect.equal "notice first" (SigningResponse.DataNotice { Data = None; Token = "n-1" })
-
-                stateOf [ session "s-1" (Some prescriber) (Some("no-data", stubPatient)) None ] []
-                |> ask t0 (counter "n") <| "s-1" <| (plan, token "stale")
-                |> snd
-                |> Expect.equal "token first" (SigningResponse.Refused SigningRefusal.StaleToken)
-            }
-
-            test "the record moved on (Rule 20): whose version, and when" {
-                let byOther = signedBy other 1 (t0 - minutes 5.0)
-
-                // opened from nothing, someone signed since
-                stateOf [ opened ] [ "stub-patient", [ byOther ] ]
-                |> ask t0 (counter "n") <| "s-1" <| (plan, token "s-1")
-                |> snd
-                |> Expect.equal "blocked" (SigningResponse.Refused(SigningRefusal.Blocked byOther.Head))
-
-                // opened with version 1, version 2 signed since
-                let v2 = signedBy other 2 (t0 - minutes 1.0)
-
-                stateOf
-                    [ session "s-1" (Some prescriber) (Some("stub-patient", stubPatient)) (Some "plan-1") ]
-                    [ "stub-patient", [ v2; signedBy prescriber 1 (t0 - minutes 5.0) ] ]
-                |> ask t0 (counter "n") <| "s-1" <| (plan, token "s-1")
-                |> snd
-                |> Expect.equal "blocked by v2" (SigningResponse.Refused(SigningRefusal.Blocked v2.Head))
-            }
-
-            test "a refusal stores no challenge" {
-                let state, _ = stateOf [ opened ] [] |> ask t0 (counter "n") <| "s-1" <| (plan, token "s-2")
-                state.Challenges |> Expect.isEmpty "nothing stored"
             }
         ]
 
 
-let issueTests =
+let refusalTests =
     testList
-        "Hop.challenge issues"
+        "Hop.commit refuses"
         [
-            test "over this exact plan, for this Session, for two minutes (Rules 43, 44)" {
-                let nonces = counter "n"
-                let state, answer = stateOf [ opened ] [] |> ask t0 nonces <| "s-1" <| (plan, token "s-1")
-                answer |> Expect.equal "issued" (SigningResponse.ChallengeIssued "n-1")
-
-                state.Challenges["s-1"]
-                |> Expect.equal
-                    "stored"
-                    {
-                        Nonce = "n-1"
-                        Patient = stubPatient
-                        Scenarios = [||]
-                        Verified = true
-                        Expiry = t0 + minutes 2.0
-                    }
+            test "no Session, and the anonymous Session" {
+                submit ready "s-9" (submission "s-9" "1234" "k")
+                |> snd
+                |> Expect.equal "no session" (SigningResponse.Refused SigningRefusal.NoSession)
             }
 
-            test "an accepted notice: the challenge over the data as it stands, unverified when unreadable (Rule 44)" {
-                let nonces = counter "n"
-                let changed = session "s-1" (Some prescriber) (Some("stub-patient", otherData)) None
-                let state, _ = stateOf [ changed ] [] |> ask t0 nonces <| "s-1" <| (OrderPlan.create otherData [||], token "s-1")
+            test "the Role withdrawn since the launch (Rule 38), and a registry that cannot answer" {
+                let demoted = session "s-1" { prescriber with UserId = "demoted" } "stub-patient" None
+                let state = stateOf [ demoted ] [] [ challenged "s-1" t0 ]
+                let state, answer = submit state "s-1" (submission "s-1" "1234" "k")
+                answer |> Expect.equal "not a prescriber" (SigningResponse.Refused SigningRefusal.NotPrescriber)
+                state.Records |> Expect.isEmpty "nothing committed"
 
-                // the plan must be over the data told, not the data the Session opened with
-                askWith "n-1" (t0 + seconds 5.0) nonces state "s-1" (OrderPlan.create otherData [||], token "s-1")
+                let unknown = session "s-1" { prescriber with UserId = "gone" } "stub-patient" None
+                stateOf [ unknown ] [] [ challenged "s-1" t0 ] |> submit <| "s-1" <| submission "s-1" "1234" "k"
                 |> snd
-                |> Expect.equal "not over the data told" (SigningResponse.Refused SigningRefusal.NoPatient)
-
-                let state, answer = askWith "n-1" (t0 + seconds 5.0) nonces state "s-1" (plan, token "s-1")
-                answer |> Expect.equal "issued" (SigningResponse.ChallengeIssued "n-2")
-                state.Challenges["s-1"].Verified |> Expect.isTrue "the platform's reading"
-                state.Challenges["s-1"].Patient |> Expect.equal "over the data told" stubPatient
-                state.Notices |> Expect.isEmpty "the notice is spent"
-
-                // unreadable: the plan stays over the data the Session opened with
-                let unreadable = session "s-2" (Some prescriber) (Some("no-data", stubPatient)) None
-                let state, _ = stateOf [ unreadable ] [] |> ask t0 nonces <| "s-2" <| (plan, token "s-2")
-                let state, answer = askWith "n-3" (t0 + seconds 5.0) nonces state "s-2" (plan, token "s-2")
-                answer |> Expect.equal "issued unverified" (SigningResponse.ChallengeIssued "n-4")
-                state.Challenges["s-2"].Verified |> Expect.isFalse "unverified"
+                |> Expect.equal "fails closed" (SigningResponse.Refused SigningRefusal.NotPrescriber)
             }
 
-            test "a wrong, spent or expired notice token is a fresh notice, never a refusal" {
-                let nonces = counter "n"
-                let changed = session "s-1" (Some prescriber) (Some("stub-patient", otherData)) None
-                let state, _ = stateOf [ changed ] [] |> ask t0 nonces <| "s-1" <| (plan, token "s-1")
+            test "a stale token, before the head is looked at" {
+                let state = stateOf [ opened ] [ "stub-patient", [ signedBy other 1 t0 ] ] [ challenged "s-1" t0 ]
 
-                askWith "n-9" (t0 + seconds 5.0) nonces state "s-1" (plan, token "s-1")
+                submit state "s-1" { submission "s-1" "1234" "k" with Opened = OpenedToken "old" }
                 |> snd
-                |> Expect.equal "wrong token: told again" (SigningResponse.DataNotice { Data = Some stubPatient; Token = "n-2" })
-
-                askWith "n-1" (t0 + minutes 3.0) nonces state "s-1" (plan, token "s-1")
-                |> snd
-                |> Expect.equal "expired: told again" (SigningResponse.DataNotice { Data = Some stubPatient; Token = "n-3" })
-
-                let state, _ = askWith "n-1" (t0 + seconds 5.0) nonces state "s-1" (plan, token "s-1")
-                askWith "n-1" (t0 + seconds 10.0) nonces state "s-1" (plan, token "s-1")
-                |> snd
-                |> Expect.equal "spent: told again" (SigningResponse.DataNotice { Data = Some stubPatient; Token = "n-5" })
+                |> Expect.equal "stale" (SigningResponse.Refused SigningRefusal.StaleToken)
             }
 
-            test "a notice over other data is told again when the reading changed once more" {
-                let nonces = counter "n"
-                let changed = session "s-1" (Some prescriber) (Some("stub-patient", otherData)) None
-                let state, _ = stateOf [ changed ] [] |> ask t0 nonces <| "s-1" <| (plan, token "s-1")
-                // the notice named the platform's reading; a notice naming another reading does not fit
-                let state = { state with Notices = state.Notices |> Map.add "s-1" { state.Notices["s-1"] with Data = None } }
+            test "the record moved on (Rule 20): blocked, and the PIN never looked at" {
+                let byOther = signedBy other 1 t0
+                let state = stateOf [ opened ] [ "stub-patient", [ byOther ] ] [ challenged "s-1" t0 ]
+                let state, answer = submit state "s-1" (submission "s-1" "0000" "k")
+                answer |> Expect.equal "blocked" (SigningResponse.Refused(SigningRefusal.Blocked byOther.Head))
+                (Hop.credentialOf "prescriber" state).WrongCount |> Expect.equal "not counted" 0
+                state.Challenges |> Map.containsKey "s-1" |> Expect.isTrue "the challenge stands"
+            }
 
-                askWith "n-1" (t0 + seconds 5.0) nonces state "s-1" (plan, token "s-1")
+            test "no challenge, an expired one, another nonce, another plan (Rule 43)" {
+                stateOf [ opened ] [] [] |> submit <| "s-1" <| submission "s-1" "1234" "k"
                 |> snd
-                |> Expect.equal "told again" (SigningResponse.DataNotice { Data = Some stubPatient; Token = "n-2" })
-            }
+                |> Expect.equal "none" (SigningResponse.Refused SigningRefusal.ChallengeExpired)
 
-            test "opened with the head: not blocked (Rule 20)" {
-                stateOf
-                    [ session "s-1" (Some prescriber) (Some("stub-patient", stubPatient)) (Some "plan-1") ]
-                    [ "stub-patient", [ signedBy other 1 (t0 - minutes 5.0) ] ]
-                |> ask t0 (counter "n") <| "s-1" <| (plan, token "s-1")
+                submitAt (t0 + minutes 3.0) (counter "id") ignore ready "s-1" (submission "s-1" "1234" "k")
                 |> snd
-                |> Expect.equal "issued" (SigningResponse.ChallengeIssued "n-1")
+                |> Expect.equal "expired" (SigningResponse.Refused SigningRefusal.ChallengeExpired)
+
+                submit ready "s-1" { submission "s-1" "1234" "k" with Challenge = "c-other" }
+                |> snd
+                |> Expect.equal "another nonce" (SigningResponse.Refused SigningRefusal.ChallengeMismatch)
+
+                let state, answer = submit ready "s-1" { submission "s-1" "0000" "k" with Plan = OrderPlan.create otherData [||] }
+                answer |> Expect.equal "another plan" (SigningResponse.Refused SigningRefusal.ChallengeMismatch)
+                (Hop.credentialOf "prescriber" state).WrongCount |> Expect.equal "the PIN never looked at" 0
+            }
+        ]
+
+
+let pinTests =
+    testList
+        "Hop.commit and the PIN (Rule 28)"
+        [
+            test "a wrong PIN counts and keeps the challenge; the next right one on the same challenge signs" {
+                let state, first = submit ready "s-1" (submission "s-1" "0000" "k-1")
+                first |> Expect.equal "two left" (SigningResponse.Refused(SigningRefusal.PinWrong 2))
+                state.Challenges |> Map.containsKey "s-1" |> Expect.isTrue "the challenge stands"
+
+                let state, second = submit state "s-1" (submission "s-1" "0000" "k-2")
+                second |> Expect.equal "one left" (SigningResponse.Refused(SigningRefusal.PinWrong 1))
+
+                match submit state "s-1" (submission "s-1" "1234" "k-3") |> snd with
+                | SigningResponse.Submitted _ -> ()
+                | other -> failtest $"expected Submitted, got {other}"
             }
 
-            test "a second request replaces the Session's challenge; another Session has its own" {
-                let nonces = counter "n"
-                let s2 = session "s-2" (Some other) (Some("stub-patient", stubPatient)) None
-                let state, _ = stateOf [ opened; s2 ] [] |> ask t0 nonces <| "s-1" <| (plan, token "s-1")
-                let state, again = ask (t0 + seconds 10.0) nonces state "s-1" (plan, token "s-1")
-                let state, theirs = ask (t0 + seconds 20.0) nonces state "s-2" (plan, token "s-2")
+            test "the third wrong PIN: the Session ends, signing locks, a mail goes out (Rules 10, 27, 28)" {
+                let send, sent = outbox ()
+                let state, _ = submitAt t0 (counter "id") send ready "s-1" (submission "s-1" "0000" "k-1")
+                let state, _ = submitAt (t0 + seconds 10.0) (counter "id") send state "s-1" (submission "s-1" "0000" "k-2")
+                let state, third = submitAt (t0 + seconds 20.0) (counter "id") send state "s-1" (submission "s-1" "0000" "k-3")
 
-                again |> Expect.equal "replaced" (SigningResponse.ChallengeIssued "n-2")
-                theirs |> Expect.equal "their own" (SigningResponse.ChallengeIssued "n-3")
-                state.Challenges |> Map.count |> Expect.equal "one per Session" 2
-                state.Challenges["s-1"].Nonce |> Expect.equal "the newest" "n-2"
+                third |> Expect.equal "the limit" (SigningResponse.Refused SigningRefusal.PinLimit)
+                state.Sessions |> Map.containsKey "s-1" |> Expect.isFalse "the Session is gone"
+
+                state.Endings |> Map.tryFind "s-1" |> Option.map fst
+                |> Expect.equal "marked" (Some SessionEnding.WrongPinLimit)
+
+                state.Challenges |> Expect.isEmpty "the challenge is gone"
+
+                let c = Hop.credentialOf "prescriber" state
+                c.WrongCount |> Expect.equal "three" 3
+                c.LockedUntil |> Expect.equal "a minute" (Some(t0 + seconds 20.0 + minutes 1.0))
+
+                sent.Value |> List.length |> Expect.equal "one mail" 1
+                sent.Value.Head.To |> Expect.equal "to the registry's address" "prescriber@stub.example"
+                sent.Value.Head.Subject |> Expect.equal "subject" "GenPRES: signing is locked"
             }
 
-            test "a challenge is gone after two minutes" {
-                let nonces = counter "n"
-                let s2 = session "s-2" (Some other) (Some("stub-patient", stubPatient)) None
-                let state, _ = stateOf [ opened; s2 ] [] |> ask t0 nonces <| "s-1" <| (plan, token "s-1")
-                let state, _ = ask (t0 + minutes 2.0) nonces state "s-2" (plan, token "s-2")
-                state.Challenges |> Map.containsKey "s-1" |> Expect.isTrue "still there at two minutes"
-                let state, _ = ask (t0 + minutes 2.0 + seconds 1.0) nonces state "s-2" (plan, token "s-2")
-                state.Challenges |> Map.containsKey "s-1" |> Expect.isFalse "gone after"
+            test "after a relaunch: a right PIN while locked is refused and counts nothing; a wrong one pushes the lock out" {
+                let send, _ = outbox ()
+                let locked, _ = [ "k-1"; "k-2"; "k-3" ] |> List.fold (fun (s, at) k -> submitAt at (counter "id") send s "s-1" (submission "s-1" "0000" k) |> fst, at + seconds 10.0) (ready, t0)
+                let until = (Hop.credentialOf "prescriber" locked).LockedUntil.Value
+
+                // the relaunch: a new Session, a new challenge; the lock is the credential's
+                let s2 = session "s-2" prescriber "stub-patient" None
+                let relaunched = { locked with Sessions = Map.ofList [ s2 ]; Challenges = Map.ofList [ challenged "s-2" until ] }
+
+                let state, answer = submitAt (until - seconds 30.0) (counter "id") send relaunched "s-2" (submission "s-2" "1234" "k-4")
+                answer |> Expect.equal "locked" (SigningResponse.Refused(SigningRefusal.Locked until))
+                (Hop.credentialOf "prescriber" state).WrongCount |> Expect.equal "not counted" 3
+                state.Sessions |> Map.containsKey "s-2" |> Expect.isTrue "this Session did nothing wrong"
+
+                let state, pushed = submitAt (until - seconds 30.0) (counter "id") send state "s-2" (submission "s-2" "0000" "k-5")
+                pushed |> Expect.equal "locked longer" (SigningResponse.Refused(SigningRefusal.Locked(until - seconds 30.0 + minutes 2.0)))
+                (Hop.credentialOf "prescriber" state).WrongCount |> Expect.equal "counted" 4
+                state.Sessions |> Map.containsKey "s-2" |> Expect.isTrue "still open"
+
+                // once the lock passed, the right PIN signs and zeroes the count
+                let later = until - seconds 30.0 + minutes 2.0
+                let state = { state with Challenges = Map.ofList [ challenged "s-2" later ] }
+
+                match submitAt later (counter "id") send state "s-2" (submission "s-2" "1234" "k-6") with
+                | state, SigningResponse.Submitted _ -> (Hop.credentialOf "prescriber" state).WrongCount |> Expect.equal "zeroed" 0
+                | _, other -> failtest $"expected Submitted, got {other}"
             }
         ]
 
@@ -674,45 +675,35 @@ let memoryCookie (initial: string option) =
 
 let compositionTests =
     testList
-        "processSigning"
+        "processSigning Submit"
         [
-            testAsync "without a cookie the port is never asked" {
+            testAsync "without a cookie: refused, the port never asked" {
                 let asked = ref false
-                let port _ _ = async { asked.Value <- true; return SigningResponse.ChallengeIssued "n" }
+                let submit _ _ = async { asked.Value <- true; return SigningResponse.Refused SigningRefusal.PinLimit }
                 let cookie, _ = memoryCookie None
-                let! answer = CompositionRoot.processSigning port cookie (SigningCommand.RequestSignChallenge(plan, token "s-1", None))
+                let! answer = CompositionRoot.processSigning (fun _ _ -> async { return SigningResponse.Refused SigningRefusal.NoSession }) submit cookie (SigningCommand.Submit(submission "s-1" "1234" "k"))
                 answer |> Expect.equal "refused" (SigningResponse.Refused SigningRefusal.NoSession)
                 asked.Value |> Expect.isFalse "not asked"
             }
 
-            testAsync "with a cookie the port is asked for that Session, and the cookie is untouched" {
-                let port, stateOf' = Hop.challengePort (fun () -> t0) (counter "n") StubPatientData.port (stateOf [ opened ] [])
+            testAsync "with a cookie: the port is asked for that Session, and the cookie stays whatever the answer" {
+                let asked = ref None
+                let submit sid (s: Submission) = async { asked.Value <- Some(sid, s.IdemKey); return SigningResponse.Refused SigningRefusal.PinLimit }
                 let cookie, held = memoryCookie (Some "s-1")
-                let! answer = CompositionRoot.processSigning port cookie (SigningCommand.RequestSignChallenge(plan, token "s-1", None))
-                answer |> Expect.equal "issued" (SigningResponse.ChallengeIssued "n-1")
+                let! answer = CompositionRoot.processSigning (fun _ _ -> async { return SigningResponse.Refused SigningRefusal.NoSession }) submit cookie (SigningCommand.Submit(submission "s-1" "1234" "k"))
+                answer |> Expect.equal "the port's answer" (SigningResponse.Refused SigningRefusal.PinLimit)
+                asked.Value |> Expect.equal "for the cookie's Session" (Some("s-1", "k"))
+                // the ending is told at the next GetSession and acknowledged by the close (Rule 11)
                 held.Value |> Expect.equal "cookie kept" (Some "s-1")
-                (stateOf' ()).Challenges |> Map.containsKey "s-1" |> Expect.isTrue "stored under the cookie's id"
-
-                let cookie, _ = memoryCookie (Some "s-9")
-                let! answer = CompositionRoot.processSigning port cookie (SigningCommand.RequestSignChallenge(plan, token "s-9", None))
-                answer |> Expect.equal "unknown id" (SigningResponse.Refused SigningRefusal.NoSession)
             }
 
-            testAsync "the production port refuses" {
-                let cookie, _ = memoryCookie (Some "s-1")
-                let! answer = CompositionRoot.processSigning challengeDisabled cookie (SigningCommand.RequestSignChallenge(plan, token "s-1", None))
-                answer |> Expect.equal "refused" (SigningResponse.Refused SigningRefusal.NoSession)
-            }
-
-            test "the log never sees the plan" {
-                SigningCommand.RequestSignChallenge(plan, token "s-1", None)
-                |> SigningCommand.toString
-                |> Expect.equal "name only" "RequestSignChallenge"
+            test "the log never sees the PIN" {
+                SigningCommand.Submit(submission "s-1" "1234" "k") |> SigningCommand.toString |> Expect.equal "name only" "Submit"
             }
         ]
 
 
-let tests = testList "Signing PR 2" [ ladderTests; issueTests; compositionTests ]
+let tests = testList "Signing PR 3" [ happyTests; refusalTests; pinTests; compositionTests ]
 
 
 runTestsWithCLIArgs [] [||] tests

--- a/src/Informedica.GenPRES.Server/Scripts/Signing.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/Signing.fsx
@@ -146,6 +146,11 @@ module Hop =
         | _ -> None
 
 
+    /// Concept 10: an order appears once in a plan.
+    let duplicateOrders (scenarios: OrderScenario[]) =
+        scenarios |> Array.countBy _.Order.Id |> Array.exists (fun (_, n) -> n > 1)
+
+
     let private dropExpired (now: DateTime) (state: State) =
         { state with
             Challenges = state.Challenges |> Map.filter (fun _ c -> now <= c.Expiry)
@@ -213,6 +218,7 @@ module Hop =
                                     challenge.Nonce <> submission.Challenge
                                     || challenge.Patient <> submission.Plan.Patient
                                     || challenge.Scenarios <> submission.Plan.Scenarios
+                                    || duplicateOrders submission.Plan.Scenarios
                                     ->
                                     refuse SigningRefusal.ChallengeMismatch
                                 | Some challenge ->
@@ -268,12 +274,17 @@ module Hop =
                                         // Rule 28: the limit is reached now; the Session ends (Rule 10)
                                         let subject, body = Mails.pinLimit user.DisplayName
 
-                                        send
-                                            {
-                                                To = fresh.MailAddress
-                                                Subject = subject
-                                                Body = body
-                                            }
+                                        // best effort (MailPort: fire and forget): the ending and the lock
+                                        // land whatever the mail does
+                                        try
+                                            send
+                                                {
+                                                    To = fresh.MailAddress
+                                                    Subject = subject
+                                                    Body = body
+                                                }
+                                        with _ ->
+                                            ()
 
                                         remember
                                             { state with
@@ -416,6 +427,38 @@ let registry (identity: BrowserIdentity) =
 let outbox () =
     let sent = ref []
     (fun (m: Mail) -> sent.Value <- m :: sent.Value), sent
+
+
+/// An OrderScenario with only its order id set, every other field a default (built by
+/// reflection: the order graph is too deep to write by hand), for the duplicate check.
+let scenarioWithOrder (id: string) : OrderScenario =
+    let rec defaultOf (t: Type) : obj =
+        if t = typeof<string> then box ""
+        elif t = typeof<bool> then box false
+        elif t = typeof<int> then box 0
+        elif t = typeof<decimal> then box 0m
+        elif t = typeof<float> then box 0.0
+        elif t = typeof<DateTime> then box t0
+        elif t.IsArray then box (Array.CreateInstance(t.GetElementType(), 0))
+        elif t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<option<_>> then null
+        elif Microsoft.FSharp.Reflection.FSharpType.IsRecord t then
+            Microsoft.FSharp.Reflection.FSharpValue.MakeRecord(
+                t,
+                Microsoft.FSharp.Reflection.FSharpType.GetRecordFields t
+                |> Array.map (fun f -> defaultOf f.PropertyType)
+            )
+        elif Microsoft.FSharp.Reflection.FSharpType.IsUnion t then
+            let case = (Microsoft.FSharp.Reflection.FSharpType.GetUnionCases t)[0]
+
+            Microsoft.FSharp.Reflection.FSharpValue.MakeUnion(
+                case,
+                case.GetFields() |> Array.map (fun f -> defaultOf f.PropertyType)
+            )
+        else
+            null
+
+    let scenario = defaultOf typeof<OrderScenario> :?> OrderScenario
+    { scenario with Order = { scenario.Order with Id = id } }
 
 
 let counter prefix =
@@ -572,6 +615,23 @@ let refusalTests =
                 state.Challenges |> Map.containsKey "s-1" |> Expect.isTrue "the challenge stands"
             }
 
+            test "the same order twice in the plan is a mismatch (Concept 10), the PIN never looked at" {
+                let twice = [| scenarioWithOrder "o-1"; scenarioWithOrder "o-1" |]
+                let planted = { snd (challenged "s-1" t0) with Scenarios = twice }
+                let state = stateOf [ opened ] [] [ "s-1", planted ]
+                let state, answer = submit state "s-1" { submission "s-1" "0000" "k" with Plan = OrderPlan.create stubPatient twice }
+                answer |> Expect.equal "mismatch" (SigningResponse.Refused SigningRefusal.ChallengeMismatch)
+                (Hop.credentialOf "prescriber" state).WrongCount |> Expect.equal "not counted" 0
+
+                let once = [| scenarioWithOrder "o-1"; scenarioWithOrder "o-2" |]
+                let planted = { planted with Scenarios = once }
+                let state = stateOf [ opened ] [] [ "s-1", planted ]
+
+                match submit state "s-1" { submission "s-1" "1234" "k" with Plan = OrderPlan.create stubPatient once } |> snd with
+                | SigningResponse.Submitted(signed, _) -> signed.Scenarios |> Expect.equal "two orders" once
+                | other -> failtest $"expected Submitted, got {other}"
+            }
+
             test "no challenge, an expired one, another nonce, another plan (Rule 43)" {
                 stateOf [ opened ] [] [] |> submit <| "s-1" <| submission "s-1" "1234" "k"
                 |> snd
@@ -630,6 +690,16 @@ let pinTests =
                 sent.Value |> List.length |> Expect.equal "one mail" 1
                 sent.Value.Head.To |> Expect.equal "to the registry's address" "prescriber@stub.example"
                 sent.Value.Head.Subject |> Expect.equal "subject" "GenPRES: signing is locked"
+            }
+
+            test "the mail failing stops neither the ending nor the lock" {
+                let broken (_: Mail) = raise (InvalidOperationException "smtp down")
+                let state, _ = submitAt t0 (counter "id") broken ready "s-1" (submission "s-1" "0000" "k-1")
+                let state, _ = submitAt t0 (counter "id") broken state "s-1" (submission "s-1" "0000" "k-2")
+                let state, third = submitAt t0 (counter "id") broken state "s-1" (submission "s-1" "0000" "k-3")
+                third |> Expect.equal "the limit" (SigningResponse.Refused SigningRefusal.PinLimit)
+                state.Sessions |> Map.containsKey "s-1" |> Expect.isFalse "ended"
+                (Hop.credentialOf "prescriber" state).LockedUntil |> Expect.isSome "locked"
             }
 
             test "after a relaunch: a right PIN while locked is refused and counts nothing; a wrong one pushes the lock out" {

--- a/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
@@ -369,6 +369,12 @@ module Mails =
         $"Hello {displayName},\n\nA PIN was set for your GenPRES account just now. If that was not you, tell your administrator."
 
 
+    /// Rule 27: the third wrong PIN ended a Session and locked signing.
+    let pinLimit (displayName: string) : string * string =
+        "GenPRES: signing is locked",
+        $"Hello {displayName},\n\nThe PIN was entered wrong three times at a signature just now. Your session was ended and signing is locked for a while. If that was not you, tell your administrator."
+
+
 /// Launch steps 4 and 5 over server-hosted stubs (plan 605): the LaunchRecord keyed by the
 /// nonce (4.2), the redirect to the IdentityProvider, the callback (4.5) with the step-5 ladder,
 /// the Rule 45 replay and the Rule 40 single act with the Rule 8 closes; the credential half of
@@ -481,6 +487,8 @@ module Hop =
             Notices: Map<string, Notice>
             // UC-3: the live challenge per Session
             Challenges: Map<string, Challenge>
+            // UC-3, Rule 45: what a Submission was answered, by Session and by the client's key
+            Answered: Map<string * string, SigningResponse * DateTime>
         }
 
 
@@ -495,6 +503,7 @@ module Hop =
             Records = Map.empty
             Notices = Map.empty
             Challenges = Map.empty
+            Answered = Map.empty
         }
 
 
@@ -533,6 +542,7 @@ module Hop =
             Enrolments = state.Enrolments |> Map.filter (fun _ e -> codes |> Map.containsKey e.UserId)
             Notices = state.Notices |> Map.filter (fun _ n -> now <= n.Expiry)
             Challenges = state.Challenges |> Map.filter (fun _ c -> now <= c.Expiry)
+            Answered = state.Answered |> Map.filter (fun _ (_, at) -> now <= at + challengeLifetime)
         }
 
 
@@ -1016,6 +1026,155 @@ module Hop =
                             SigningResponse.ChallengeIssued nonce
 
 
+    /// uc-03 step 3, one act in the model's order (`dbCommit`): the Session with a User and a
+    /// Patient; the answer already given to this Session's key (Rule 45); the Role re-taken
+    /// from the registry (Rule 38, fails closed); the OpenedToken this Session holds (Rule 34);
+    /// the record not moved on (Rule 20); the challenge this Session was issued, over exactly
+    /// this plan (Rule 43); and last the PIN (Rules 23, 28), so that a Submission that was
+    /// never going to land costs no attempt. Then the version is appended, the challenge
+    /// spent, the OpenedToken re-minted over the new head, and the answer remembered under the
+    /// key, refusals too. Three wrong PINs end the Session (`WrongPinLimit`), lock signing and
+    /// mail the User (Rule 27); a wrong PIN while locked pushes the lock out; a right PIN while
+    /// locked is refused and counts nothing.
+    let commit
+        (now: DateTime)
+        (newId: unit -> string)
+        (standing: BrowserIdentity -> UserStanding option)
+        (send: Mail -> unit)
+        (sid: string)
+        (submission: Submission)
+        (state: State)
+        : State * SigningResponse
+        =
+        let state = dropExpired now state
+        let refuse refusal = state, SigningResponse.Refused refusal
+
+        match state.Sessions |> Map.tryFind sid with
+        | None -> refuse SigningRefusal.NoSession
+        | Some record ->
+            match record.Session.User, record.Session.PatientContext with
+            | None, _ -> refuse SigningRefusal.NotPrescriber
+            | Some _, None -> refuse SigningRefusal.NoPatient
+            | Some user, Some patient ->
+                match state.Answered |> Map.tryFind (sid, submission.IdemKey) with
+                | Some(answer, _) -> state, answer
+                | None ->
+                    // the answer is remembered from here on, under this Session and the key
+                    let remember (state: State) answer =
+                        { state with Answered = state.Answered |> Map.add (sid, submission.IdemKey) (answer, now) },
+                        answer
+
+                    let refuse refusal =
+                        remember state (SigningResponse.Refused refusal)
+
+                    let identity =
+                        {
+                            Login = record.Login |> Option.defaultValue user.UserId
+                            DisplayName = user.DisplayName
+                        }
+
+                    match standing identity with
+                    | Some fresh when fresh.User.Role = UserRole.Prescriber ->
+                        if record.Session.OpenedToken <> Some submission.Opened then
+                            refuse SigningRefusal.StaleToken
+                        else
+                            match blockedBy record patient.PatientId state with
+                            | Some head -> refuse (SigningRefusal.Blocked head)
+                            | None ->
+                                match state.Challenges |> Map.tryFind sid with
+                                | None -> refuse SigningRefusal.ChallengeExpired
+                                | Some challenge when
+                                    challenge.Nonce <> submission.Challenge
+                                    || challenge.Patient <> submission.Plan.Patient
+                                    || challenge.Scenarios <> submission.Plan.Scenarios
+                                    ->
+                                    refuse SigningRefusal.ChallengeMismatch
+                                | Some challenge ->
+                                    let credential = credentialOf user.UserId state
+                                    let wasLocked = Credential.isLocked now credential
+                                    let right, credential = Credential.verify now submission.Pin credential
+
+                                    let state =
+                                        { state with Credentials = state.Credentials |> Map.add user.UserId credential }
+
+                                    if right then
+                                        let id = newId ()
+
+                                        let plan =
+                                            {
+                                                Head =
+                                                    {
+                                                        Id = id
+                                                        No =
+                                                            1
+                                                            + (state.Records
+                                                               |> Map.tryFind patient.PatientId
+                                                               |> Option.map List.length
+                                                               |> Option.defaultValue 0)
+                                                        By = user
+                                                        SignedAt = now
+                                                    }
+                                                PatientId = patient.PatientId
+                                                Base = record.OpenedWith
+                                                Scenarios = challenge.Scenarios
+                                                Patient = challenge.Patient
+                                                Verified = challenge.Verified
+                                            }
+
+                                        let token = OpenedToken $"opened-{newId ()}"
+
+                                        let opened =
+                                            { record with
+                                                Session = { record.Session with OpenedToken = Some token }
+                                                OpenedWith = Some id
+                                            }
+
+                                        remember
+                                            { state with
+                                                Records =
+                                                    state.Records
+                                                    |> Map.change
+                                                        patient.PatientId
+                                                        (fun versions ->
+                                                            Some(plan :: (versions |> Option.defaultValue []))
+                                                        )
+                                                Challenges = state.Challenges |> Map.remove sid
+                                                Sessions = state.Sessions |> Map.add sid opened
+                                            }
+                                            (SigningResponse.Submitted(plan, token))
+                                    elif wasLocked then
+                                        // this Session did nothing wrong; the lock is the credential's
+                                        remember
+                                            state
+                                            (SigningResponse.Refused(SigningRefusal.Locked credential.LockedUntil.Value))
+                                    elif credential |> Credential.attemptsLeft = 0 then
+                                        // Rule 28: the limit is reached now; the Session ends (Rule 10)
+                                        let subject, body = Mails.pinLimit user.DisplayName
+
+                                        send
+                                            {
+                                                To = fresh.MailAddress
+                                                Subject = subject
+                                                Body = body
+                                            }
+
+                                        remember
+                                            { state with
+                                                Sessions = state.Sessions |> Map.remove sid
+                                                Endings =
+                                                    state.Endings |> Map.add sid (SessionEnding.WrongPinLimit, now)
+                                                Challenges = state.Challenges |> Map.remove sid
+                                            }
+                                            (SigningResponse.Refused SigningRefusal.PinLimit)
+                                    else
+                                        remember
+                                            state
+                                            (SigningResponse.Refused(
+                                                SigningRefusal.PinWrong(credential |> Credential.attemptsLeft)
+                                            ))
+                    | _ -> refuse SigningRefusal.NotPrescriber
+
+
     /// Six digits from a random source (the CSPRNG in the host).
     let newCode (randomBelow: int -> int) () = (randomBelow 1_000_000).ToString "D6"
 
@@ -1098,6 +1257,11 @@ module Hop =
             challenge =
                 fun sid request ->
                     async { return update (fun s -> challenge (now ()) newId patientData.read sid request s) }
+            submit =
+                fun sid submission ->
+                    async {
+                        return update (fun s -> commit (now ()) newId registry.standing mail.send sid submission s)
+                    }
         }
 
 
@@ -1571,6 +1735,7 @@ module Adapters =
             supplyPin = fun _ _ _ -> async { return SupplyPinResult.Refused PinRefusal.AttemptExpired }
             dropEnrolment = fun _ -> async { return () }
             challenge = fun _ _ -> async { return SigningResponse.Refused SigningRefusal.NoSession }
+            submit = fun _ _ -> async { return SigningResponse.Refused SigningRefusal.NoSession }
         }
 
 

--- a/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
@@ -937,6 +937,11 @@ module Hop =
         | _ -> None
 
 
+    /// Concept 10: an order appears once in a plan.
+    let duplicateOrders (scenarios: OrderScenario[]) =
+        scenarios |> Array.countBy _.Order.Id |> Array.exists (fun (_, n) -> n > 1)
+
+
     /// uc-03 step 2, in order: the Session with a User and a Patient; the Role Prescriber; the
     /// OpenedToken this Session holds (Rule 34); the patient data re-read (Rule 44): when it is
     /// not what the Session opened with and no notice over this reading was accepted, no
@@ -1003,6 +1008,9 @@ module Hop =
                     // unverified data: the plan stays over what the Session opened with
                     elif plan.Patient <> (current |> Option.defaultValue patient.Patient) then
                         refuse SigningRefusal.NoPatient
+                    // Concept 10: no challenge over a plan that names an order twice
+                    elif duplicateOrders plan.Scenarios then
+                        refuse SigningRefusal.ChallengeMismatch
                     else
                         match blockedBy record patient.PatientId state with
                         | Some head -> refuse (SigningRefusal.Blocked head)
@@ -1087,6 +1095,7 @@ module Hop =
                                     challenge.Nonce <> submission.Challenge
                                     || challenge.Patient <> submission.Plan.Patient
                                     || challenge.Scenarios <> submission.Plan.Scenarios
+                                    || duplicateOrders submission.Plan.Scenarios
                                     ->
                                     refuse SigningRefusal.ChallengeMismatch
                                 | Some challenge ->
@@ -1151,12 +1160,17 @@ module Hop =
                                         // Rule 28: the limit is reached now; the Session ends (Rule 10)
                                         let subject, body = Mails.pinLimit user.DisplayName
 
-                                        send
-                                            {
-                                                To = fresh.MailAddress
-                                                Subject = subject
-                                                Body = body
-                                            }
+                                        // best effort (MailPort: fire and forget): the ending and the lock
+                                        // land whatever the mail does
+                                        try
+                                            send
+                                                {
+                                                    To = fresh.MailAddress
+                                                    Subject = subject
+                                                    Body = body
+                                                }
+                                        with _ ->
+                                            ()
 
                                         remember
                                             { state with

--- a/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
@@ -132,6 +132,7 @@ module CompositionRoot =
                 match cmd with
                 | SigningCommand.RequestSignChallenge(plan, opened, notice) ->
                     return! env.session.challenge id (plan, opened, notice)
+                | SigningCommand.Submit submission -> return! env.session.submit id submission
         }
 
 

--- a/src/Informedica.GenPRES.Server/ServerApi.Ports.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Ports.fs
@@ -172,6 +172,8 @@ type SessionPort =
         dropEnrolment: string -> Async<unit>
         // UC-3 step 2: a challenge over the plan as shown, for the Session the cookie names
         challenge: string -> OrderPlan * OpenedToken * string option -> Async<SigningResponse>
+        // UC-3 step 3: the signature, for the Session the cookie names
+        submit: string -> Submission -> Async<SigningResponse>
     }
 
 

--- a/src/Informedica.GenPRES.Shared/Api.fs
+++ b/src/Informedica.GenPRES.Shared/Api.fs
@@ -193,6 +193,8 @@ module Api =
         // step 2: the plan as shown, the OpenedToken the Session holds (Rule 34), and the
         // token of the data notice the User accepted, if one was told (Rule 44)
         | RequestSignChallenge of OrderPlan * OpenedToken * dataNotice: string option
+        // step 3: the signature
+        | Submit of Submission
 
 
     module LaunchCommand =
@@ -215,10 +217,11 @@ module Api =
 
     module SigningCommand =
 
-        /// For the log. Never the plan (long) or, later, the PIN.
+        /// For the log. Never the plan (long) or the PIN.
         let toString cmd =
             match cmd with
             | SigningCommand.RequestSignChallenge _ -> "RequestSignChallenge"
+            | SigningCommand.Submit _ -> "Submit"
 
 
     /// Defines how routes are generated on server and mapped from the client

--- a/src/Informedica.GenPRES.Shared/Types.fs
+++ b/src/Informedica.GenPRES.Shared/Types.fs
@@ -668,8 +668,8 @@ module Types =
 
     /// A signed version of an order plan, as the record holds it (the integration design's
     /// TreatmentPlan): the head, the patient, the version it was signed over (`Base`, `None`
-    /// for the first), the orders as shown at the signature and the patient data the User
-    /// saw (Rule 44).
+    /// for the first), the orders as shown at the signature, the patient data the User saw
+    /// and whether it was the platform's reading at the challenge (Rule 44).
     type SignedOrderPlan =
         {
             Head: OrderPlanHead
@@ -677,6 +677,7 @@ module Types =
             Base: string option
             Scenarios: OrderScenario[]
             Patient: Patient
+            Verified: bool
         }
 
 
@@ -746,6 +747,19 @@ module Types =
         }
 
 
+    /// uc-03 step 3: the plan as shown, the OpenedToken the Session holds (Rule 34), the
+    /// challenge it was issued (Rule 43), the PIN (Rule 23), and a key of the client's own so
+    /// that the commit takes effect once (Rule 45). Never logged.
+    type Submission =
+        {
+            Plan: OrderPlan
+            Opened: OpenedToken
+            Challenge: string
+            Pin: string
+            IdemKey: string
+        }
+
+
     /// The answer to a signing command. A payload like `LaunchOutcome`: the session port
     /// answers it, so it lives with the types, not the api.
     [<RequireQualifiedAccess>]
@@ -754,4 +768,6 @@ module Types =
         | ChallengeIssued of challenge: string
         // Rule 44: no challenge yet; the data as it stands, to show and to accept or not
         | DataNotice of DataNotice
+        // step 3: the version committed, and a fresh OpenedToken over it (Rule 34)
+        | Submitted of SignedOrderPlan * OpenedToken
         | Refused of SigningRefusal

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -70,6 +70,7 @@ module StubAdapters =
             supplyPin = fun _ _ _ -> async { return SupplyPinResult.Refused PinRefusal.AttemptExpired }
             dropEnrolment = fun _ -> async { return () }
             challenge = fun _ _ -> async { return SigningResponse.Refused SigningRefusal.NoSession }
+            submit = fun _ _ -> async { return SigningResponse.Refused SigningRefusal.NoSession }
         }
 
 
@@ -628,6 +629,7 @@ module SessionStubTests =
                                 Base = (if no > 1 then Some $"plan-{no - 1}" else None)
                                 Scenarios = [||]
                                 Patient = Shared.Models.Patient.empty
+                                Verified = true
                             }
 
                         let record =
@@ -1889,6 +1891,7 @@ module SessionStubTests =
                     Base = (if no > 1 then Some $"plan-{no - 1}" else None)
                     Scenarios = [||]
                     Patient = stubPatient
+                    Verified = true
                 }
 
             let stateOf sessions records =
@@ -2254,6 +2257,388 @@ module SessionStubTests =
                 ]
 
 
+        let commitTests =
+            let minutes (n: float) = TimeSpan.FromMinutes n
+            let seconds (n: float) = TimeSpan.FromSeconds n
+            let stubPatient = Shared.Models.Patient.empty
+            let otherData = { stubPatient with Department = Some "ICU" }
+            let token sid = OpenedToken $"opened-{sid}"
+            let plan = OrderPlan.create stubPatient [||]
+
+            let userOf id role : UserContext =
+                {
+                    UserId = id
+                    DisplayName = id
+                    Role = role
+                }
+
+            let prescriber = userOf "prescriber" UserRole.Prescriber
+            let other = userOf "prescriber-b" UserRole.Prescriber
+
+            let session sid (user: UserContext) patientId openedWith =
+                sid,
+                ({
+                    Session =
+                        {
+                            User = Some user
+                            PatientContext =
+                                Some
+                                    {
+                                        PatientId = patientId
+                                        Patient = stubPatient
+                                    }
+                            OpenedToken = Some(token sid)
+                            KeyThumbprint = Some "t"
+                        }
+                    Login = Some user.UserId
+                    OpenedWith = openedWith
+                }
+                : Hop.SessionRecord)
+
+            let signedBy (user: UserContext) no (at: DateTime) : SignedOrderPlan =
+                {
+                    Head =
+                        {
+                            Id = $"plan-{no}"
+                            No = no
+                            By = user
+                            SignedAt = at
+                        }
+                    PatientId = "stub-patient"
+                    Base = (if no > 1 then Some $"plan-{no - 1}" else None)
+                    Scenarios = [||]
+                    Patient = stubPatient
+                    Verified = true
+                }
+
+            let challenged sid (at: DateTime) : string * Hop.Challenge =
+                sid,
+                {
+                    Nonce = $"c-{sid}"
+                    Patient = stubPatient
+                    Scenarios = [||]
+                    Verified = true
+                    Expiry = at + Hop.challengeLifetime
+                }
+
+            /// The registry as the stub has it, for the logins these tests use; `demoted` is a
+            /// Prescriber whose Role was withdrawn since the launch.
+            let registry (identity: BrowserIdentity) =
+                let standing role =
+                    Some
+                        {
+                            User =
+                                {
+                                    UserId = identity.Login
+                                    DisplayName = identity.DisplayName
+                                    Role = role
+                                }
+                            ActivePatientId = Some "stub-patient"
+                            MailAddress = $"{identity.Login}@stub.example"
+                        }
+
+                match identity.Login with
+                | "prescriber"
+                | "prescriber-b" -> standing UserRole.Prescriber
+                | "demoted" -> standing UserRole.Reader
+                | _ -> None
+
+            let outbox () =
+                let sent = ref []
+                (fun (m: Mail) -> sent.Value <- m :: sent.Value), sent
+
+            let stateOf sessions records challenges =
+                { seeded with
+                    Sessions = Map.ofList sessions
+                    Records = Map.ofList records
+                    Challenges = Map.ofList challenges
+                }
+
+            let submission sid pin key : Submission =
+                {
+                    Plan = plan
+                    Opened = token sid
+                    Challenge = $"c-{sid}"
+                    Pin = pin
+                    IdemKey = key
+                }
+
+            let submitAt now ids send state sid (s: Submission) =
+                Hop.commit now ids registry send sid s state
+
+            let submit state sid s =
+                submitAt t0 (counter "id") ignore state sid s
+
+            let opened = session "s-1" prescriber "stub-patient" None
+            let ready = stateOf [ opened ] [] [ challenged "s-1" t0 ]
+
+            testList
+                "Hop.commit"
+                [
+                    test
+                        "commits the version: head, base, by and patient from the Session, the plan from the challenge (Rules 33, 34, 42, 45)" {
+                        let ids = counter "id"
+
+                        let state, answer =
+                            submitAt t0 ids ignore ready "s-1" (submission "s-1" "1234" "k-1")
+
+                        match answer with
+                        | SigningResponse.Submitted(signed, fresh) ->
+                            signed.Head
+                            |> Expect.equal
+                                "head"
+                                {
+                                    Id = "id-1"
+                                    No = 1
+                                    By = prescriber
+                                    SignedAt = t0
+                                }
+
+                            signed.PatientId |> Expect.equal "the Session's patient" "stub-patient"
+                            signed.Base |> Expect.isNone "from nothing"
+                            signed.Verified |> Expect.isTrue "the challenge's reading"
+                            fresh |> Expect.equal "re-minted" (OpenedToken "opened-id-2")
+                            state.Records["stub-patient"] |> Expect.equal "appended" [ signed ]
+                            state.Challenges |> Expect.isEmpty "spent"
+                            state.Sessions["s-1"].OpenedWith |> Expect.equal "the new head" (Some "id-1")
+                            state.Sessions["s-1"].Session.OpenedToken |> Expect.equal "held" (Some fresh)
+                            state.Answered[("s-1", "k-1")] |> fst |> Expect.equal "remembered" answer
+                        | other -> failtest $"expected Submitted, got {other}"
+
+                        // a second version over the first, on a new challenge and the re-minted token
+                        let state =
+                            { state with Challenges = Map.ofList [ challenged "s-1" (t0 + minutes 1.0) ] }
+
+                        let again =
+                            { submission "s-1" "1234" "k-2" with
+                                Opened = state.Sessions["s-1"].Session.OpenedToken.Value
+                            }
+
+                        match submitAt (t0 + minutes 1.0) ids ignore state "s-1" again |> snd with
+                        | SigningResponse.Submitted(signed, _) ->
+                            signed.Head.No |> Expect.equal "second" 2
+                            signed.Base |> Expect.equal "over the first" (Some "id-1")
+                        | other -> failtest $"expected Submitted, got {other}"
+
+                        // the old token is stale once re-minted (Rule 34)
+                        let state = { state with Challenges = Map.ofList [ challenged "s-1" t0 ] }
+
+                        submitAt t0 ids ignore state "s-1" (submission "s-1" "1234" "k-3")
+                        |> snd
+                        |> Expect.equal "stale" (SigningResponse.Refused SigningRefusal.StaleToken)
+                    }
+
+                    test
+                        "the same key again: the same answer, nothing twice; a refusal too, without counting; another Session's key finds nothing (Rule 45)" {
+                        let ids = counter "id"
+
+                        let state, first =
+                            submitAt t0 ids ignore ready "s-1" (submission "s-1" "1234" "k-1")
+
+                        let state, again =
+                            submitAt (t0 + seconds 5.0) ids ignore state "s-1" (submission "s-1" "1234" "k-1")
+
+                        again |> Expect.equal "the first answer" first
+                        state.Records["stub-patient"] |> List.length |> Expect.equal "one version" 1
+
+                        let state, wrong = submit ready "s-1" (submission "s-1" "0000" "k-1")
+
+                        wrong
+                        |> Expect.equal "wrong" (SigningResponse.Refused(SigningRefusal.PinWrong 2))
+
+                        let state, wrongAgain = submit state "s-1" (submission "s-1" "0000" "k-1")
+                        wrongAgain |> Expect.equal "the same" wrong
+
+                        (Hop.credentialOf "prescriber" state).WrongCount
+                        |> Expect.equal "counted once" 1
+
+                        let s2 = session "s-2" other "stub-patient" None
+                        let state = { state with Sessions = state.Sessions |> Map.add (fst s2) (snd s2) }
+
+                        submit state "s-2" { submission "s-2" "1234" "k-1" with Challenge = "none" }
+                        |> snd
+                        |> Expect.equal "their own ladder" (SigningResponse.Refused SigningRefusal.ChallengeExpired)
+                    }
+
+                    test
+                        "refuses: no Session; the Role withdrawn or the registry silent (Rule 38); a stale token; the block (Rule 20), with the PIN never looked at" {
+                        submit ready "s-9" (submission "s-9" "1234" "k")
+                        |> snd
+                        |> Expect.equal "no session" (SigningResponse.Refused SigningRefusal.NoSession)
+
+                        let demoted =
+                            session "s-1" (userOf "demoted" UserRole.Prescriber) "stub-patient" None
+
+                        let state, answer =
+                            submit (stateOf [ demoted ] [] [ challenged "s-1" t0 ]) "s-1" (submission "s-1" "1234" "k")
+
+                        answer
+                        |> Expect.equal "not a prescriber" (SigningResponse.Refused SigningRefusal.NotPrescriber)
+
+                        state.Records |> Expect.isEmpty "nothing committed"
+
+                        let unknown = session "s-1" (userOf "gone" UserRole.Prescriber) "stub-patient" None
+
+                        submit (stateOf [ unknown ] [] [ challenged "s-1" t0 ]) "s-1" (submission "s-1" "1234" "k")
+                        |> snd
+                        |> Expect.equal "fails closed" (SigningResponse.Refused SigningRefusal.NotPrescriber)
+
+                        let byOther = signedBy other 1 t0
+
+                        let moved =
+                            stateOf [ opened ] [ "stub-patient", [ byOther ] ] [ challenged "s-1" t0 ]
+
+                        submit moved "s-1" { submission "s-1" "1234" "k" with Opened = OpenedToken "old" }
+                        |> snd
+                        |> Expect.equal "stale before the head" (SigningResponse.Refused SigningRefusal.StaleToken)
+
+                        let state, answer = submit moved "s-1" (submission "s-1" "0000" "k")
+
+                        answer
+                        |> Expect.equal "blocked" (SigningResponse.Refused(SigningRefusal.Blocked byOther.Head))
+
+                        (Hop.credentialOf "prescriber" state).WrongCount |> Expect.equal "not counted" 0
+
+                        state.Challenges
+                        |> Map.containsKey "s-1"
+                        |> Expect.isTrue "the challenge stands"
+                    }
+
+                    test
+                        "refuses on the challenge: none, expired, another nonce, another plan (Rule 43), with the PIN never looked at" {
+                        submit (stateOf [ opened ] [] []) "s-1" (submission "s-1" "1234" "k")
+                        |> snd
+                        |> Expect.equal "none" (SigningResponse.Refused SigningRefusal.ChallengeExpired)
+
+                        submitAt (t0 + minutes 3.0) (counter "id") ignore ready "s-1" (submission "s-1" "1234" "k")
+                        |> snd
+                        |> Expect.equal "expired" (SigningResponse.Refused SigningRefusal.ChallengeExpired)
+
+                        submit ready "s-1" { submission "s-1" "1234" "k" with Challenge = "c-other" }
+                        |> snd
+                        |> Expect.equal "another nonce" (SigningResponse.Refused SigningRefusal.ChallengeMismatch)
+
+                        let state, answer =
+                            submit
+                                ready
+                                "s-1"
+                                { submission "s-1" "0000" "k" with Plan = OrderPlan.create otherData [||] }
+
+                        answer
+                        |> Expect.equal "another plan" (SigningResponse.Refused SigningRefusal.ChallengeMismatch)
+
+                        (Hop.credentialOf "prescriber" state).WrongCount |> Expect.equal "not counted" 0
+                    }
+
+                    test
+                        "a wrong PIN counts and keeps the challenge; the third ends the Session, locks and mails (Rules 10, 27, 28)" {
+                        let send, sent = outbox ()
+
+                        let state, first =
+                            submitAt t0 (counter "id") send ready "s-1" (submission "s-1" "0000" "k-1")
+
+                        first
+                        |> Expect.equal "two left" (SigningResponse.Refused(SigningRefusal.PinWrong 2))
+
+                        state.Challenges
+                        |> Map.containsKey "s-1"
+                        |> Expect.isTrue "the challenge stands"
+
+                        match
+                            submitAt t0 (counter "id") send state "s-1" (submission "s-1" "1234" "k-2")
+                            |> snd
+                        with
+                        | SigningResponse.Submitted _ -> ()
+                        | other -> failtest $"expected Submitted on the same challenge, got {other}"
+
+                        let state, second =
+                            submitAt (t0 + seconds 10.0) (counter "id") send state "s-1" (submission "s-1" "0000" "k-2")
+
+                        second
+                        |> Expect.equal "one left" (SigningResponse.Refused(SigningRefusal.PinWrong 1))
+
+                        let state, third =
+                            submitAt (t0 + seconds 20.0) (counter "id") send state "s-1" (submission "s-1" "0000" "k-3")
+
+                        third
+                        |> Expect.equal "the limit" (SigningResponse.Refused SigningRefusal.PinLimit)
+
+                        state.Sessions |> Map.containsKey "s-1" |> Expect.isFalse "the Session is gone"
+
+                        state.Endings
+                        |> Map.tryFind "s-1"
+                        |> Option.map fst
+                        |> Expect.equal "marked" (Some SessionEnding.WrongPinLimit)
+
+                        state.Challenges |> Expect.isEmpty "the challenge is gone"
+                        let c = Hop.credentialOf "prescriber" state
+                        c.WrongCount |> Expect.equal "three" 3
+                        c.LockedUntil |> Expect.equal "a minute" (Some(t0 + seconds 20.0 + minutes 1.0))
+                        sent.Value |> List.length |> Expect.equal "one mail" 1
+
+                        sent.Value.Head.To
+                        |> Expect.equal "to the registry's address" "prescriber@stub.example"
+
+                        sent.Value.Head.Subject |> Expect.equal "subject" "GenPRES: signing is locked"
+                    }
+
+                    test
+                        "after a relaunch: a right PIN while locked is refused without counting, a wrong one pushes the lock out, and after the lock it signs" {
+                        let send, _ = outbox ()
+
+                        let locked, _ =
+                            [ "k-1"; "k-2"; "k-3" ]
+                            |> List.fold
+                                (fun (s, at) k ->
+                                    submitAt at (counter "id") send s "s-1" (submission "s-1" "0000" k) |> fst,
+                                    at + seconds 10.0
+                                )
+                                (ready, t0)
+
+                        let until = (Hop.credentialOf "prescriber" locked).LockedUntil.Value
+                        let s2 = session "s-2" prescriber "stub-patient" None
+
+                        let relaunched =
+                            { locked with
+                                Sessions = Map.ofList [ s2 ]
+                                Challenges = Map.ofList [ challenged "s-2" until ]
+                            }
+
+                        let inside = until - seconds 30.0
+
+                        let state, answer =
+                            submitAt inside (counter "id") send relaunched "s-2" (submission "s-2" "1234" "k-4")
+
+                        answer
+                        |> Expect.equal "locked" (SigningResponse.Refused(SigningRefusal.Locked until))
+
+                        (Hop.credentialOf "prescriber" state).WrongCount |> Expect.equal "not counted" 3
+
+                        state.Sessions
+                        |> Map.containsKey "s-2"
+                        |> Expect.isTrue "this Session did nothing wrong"
+
+                        let state, pushed =
+                            submitAt inside (counter "id") send state "s-2" (submission "s-2" "0000" "k-5")
+
+                        pushed
+                        |> Expect.equal
+                            "locked longer"
+                            (SigningResponse.Refused(SigningRefusal.Locked(inside + minutes 2.0)))
+
+                        (Hop.credentialOf "prescriber" state).WrongCount |> Expect.equal "counted" 4
+
+                        let later = inside + minutes 2.0
+                        let state = { state with Challenges = Map.ofList [ challenged "s-2" later ] }
+
+                        match submitAt later (counter "id") send state "s-2" (submission "s-2" "1234" "k-6") with
+                        | state, SigningResponse.Submitted _ ->
+                            (Hop.credentialOf "prescriber" state).WrongCount |> Expect.equal "zeroed" 0
+                        | _, other -> failtest $"expected Submitted, got {other}"
+                    }
+                ]
+
+
         let tests =
             testList
                 "Hop"
@@ -2274,6 +2659,7 @@ module SessionStubTests =
                     supplyTests
                     dropTests
                     challengeTests
+                    commitTests
                 ]
 
 
@@ -3219,6 +3605,89 @@ module SessionStubTests =
                         | SigningResponse.ChallengeIssued nonce -> nonce |> Expect.isNotEmpty "issued"
                         | other -> failtest $"expected ChallengeIssued, got {other}"
                     | other -> failtest $"expected DataNotice, got {other}"
+                }
+
+                testAsync
+                    "Submit: the signature through the real hop; three wrong PINs end the Session and GetSession says so" {
+                    let directory, env = envWithStub ()
+                    let cookie, _ = memoryCookie None
+                    let stateCookie, _ = memoryStateCookie None
+
+                    let! _ =
+                        openVia
+                            directory
+                            env
+                            cookie
+                            stateCookie
+                            (noEnrolment ())
+                            (mintFor "n-1" "stub-patient")
+                            keyA
+                            "prescriber"
+
+                    let! opened = sessionOf env cookie
+
+                    let! challenge =
+                        async {
+                            match! CompositionRoot.processSigning env cookie (challengeOver opened) with
+                            | SigningResponse.ChallengeIssued nonce -> return nonce
+                            | other -> return failtest $"expected ChallengeIssued, got {other}"
+                        }
+
+                    let submission pin key : Submission =
+                        {
+                            Plan = OrderPlan.create Shared.Models.Patient.empty [||]
+                            Opened = opened.OpenedToken.Value
+                            Challenge = challenge
+                            Pin = pin
+                            IdemKey = key
+                        }
+
+                    match!
+                        CompositionRoot.processSigning env cookie (SigningCommand.Submit(submission "0000" "k-1"))
+                    with
+                    | SigningResponse.Refused(SigningRefusal.PinWrong 2) -> ()
+                    | other -> failtest $"expected PinWrong 2, got {other}"
+
+                    match!
+                        CompositionRoot.processSigning
+                            env
+                            cookie
+                            (SigningCommand.Submit(submission StubCredentials.stubPin "k-2"))
+                    with
+                    | SigningResponse.Submitted(signed, fresh) ->
+                        signed.Head.No |> Expect.equal "the first version" 1
+                        signed.Head.By.UserId |> Expect.equal "by the Session's user" "prescriber"
+                        fresh |> Expect.notEqual "re-minted" opened.OpenedToken.Value
+                    | other -> failtest $"expected Submitted, got {other}"
+
+                    // the ending: three wrong PINs on a fresh challenge and the re-minted token
+                    let! opened = sessionOf env cookie
+
+                    let! challenge =
+                        async {
+                            match! CompositionRoot.processSigning env cookie (challengeOver opened) with
+                            | SigningResponse.ChallengeIssued nonce -> return nonce
+                            | other -> return failtest $"expected ChallengeIssued, got {other}"
+                        }
+
+                    let wrong key =
+                        SigningCommand.Submit
+                            { submission "0000" key with
+                                Opened = opened.OpenedToken.Value
+                                Challenge = challenge
+                            }
+
+                    let! _ = CompositionRoot.processSigning env cookie (wrong "k-3")
+                    let! _ = CompositionRoot.processSigning env cookie (wrong "k-4")
+                    let! third = CompositionRoot.processSigning env cookie (wrong "k-5")
+
+                    third
+                    |> Expect.equal "the limit" (SigningResponse.Refused SigningRefusal.PinLimit)
+
+                    let! told = CompositionRoot.processSession env cookie (noEnrolment ()) SessionCommand.GetSession
+
+                    told
+                    |> Expect.equal "told once" (SessionResponse.SessionEnded SessionEnding.WrongPinLimit)
                 }
 
                 testAsync "a Reader's Session is refused" {

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -324,6 +324,46 @@ module SessionStubTests =
     let seeded = Hop.initialState (StubCredentials.seed salts)
 
 
+    /// An OrderScenario with only its order id set, every other field a default (built by
+    /// reflection: the order graph is too deep to write by hand), for the duplicate check.
+    let scenarioWithOrder (id: string) : OrderScenario =
+        let rec defaultOf (t: Type) : obj =
+            if t = typeof<string> then
+                box ""
+            elif t = typeof<bool> then
+                box false
+            elif t = typeof<int> then
+                box 0
+            elif t = typeof<decimal> then
+                box 0m
+            elif t = typeof<float> then
+                box 0.0
+            elif t = typeof<DateTime> then
+                box t0
+            elif t.IsArray then
+                box (Array.CreateInstance(t.GetElementType(), 0))
+            elif t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<option<_>> then
+                null
+            elif Microsoft.FSharp.Reflection.FSharpType.IsRecord t then
+                Microsoft.FSharp.Reflection.FSharpValue.MakeRecord(
+                    t,
+                    Microsoft.FSharp.Reflection.FSharpType.GetRecordFields t
+                    |> Array.map (fun f -> defaultOf f.PropertyType)
+                )
+            elif Microsoft.FSharp.Reflection.FSharpType.IsUnion t then
+                let case = (Microsoft.FSharp.Reflection.FSharpType.GetUnionCases t)[0]
+
+                Microsoft.FSharp.Reflection.FSharpValue.MakeUnion(
+                    case,
+                    case.GetFields() |> Array.map (fun f -> defaultOf f.PropertyType)
+                )
+            else
+                null
+
+        let scenario = defaultOf typeof<OrderScenario> :?> OrderScenario
+        { scenario with Order = { scenario.Order with Id = id } }
+
+
     /// The seal key of the tests, and another one.
     let sealKey = LaunchSeal.Key(Array.init LaunchSeal.keyLength byte)
 
@@ -2165,6 +2205,26 @@ module SessionStubTests =
                                 })
                     }
 
+                    test "the same order twice in the plan gets no challenge (Concept 10)" {
+                        let twice =
+                            OrderPlan.create stubPatient [| scenarioWithOrder "o-1"; scenarioWithOrder "o-1" |]
+
+                        let state, answer =
+                            stateOf [ opened ] [] |> ask t0 (counter "n") <| "s-1" <| (twice, token "s-1")
+
+                        answer
+                        |> Expect.equal "mismatch" (SigningResponse.Refused SigningRefusal.ChallengeMismatch)
+
+                        state.Challenges |> Expect.isEmpty "nothing stored"
+
+                        let once =
+                            OrderPlan.create stubPatient [| scenarioWithOrder "o-1"; scenarioWithOrder "o-2" |]
+
+                        stateOf [ opened ] [] |> ask t0 (counter "n") <| "s-1" <| (once, token "s-1")
+                        |> snd
+                        |> Expect.equal "issued" (SigningResponse.ChallengeIssued "n-1")
+                    }
+
                     test "refuses when the record moved on (Rule 20): whose version, and when" {
                         let byOther = signedBy other 1 (t0 - minutes 5.0)
 
@@ -2502,6 +2562,56 @@ module SessionStubTests =
                         state.Challenges
                         |> Map.containsKey "s-1"
                         |> Expect.isTrue "the challenge stands"
+                    }
+
+                    test
+                        "the same order twice in the plan is a mismatch at the commit too (Concept 10), the PIN never looked at" {
+                        let twice = [| scenarioWithOrder "o-1"; scenarioWithOrder "o-1" |]
+                        let planted = { snd (challenged "s-1" t0) with Scenarios = twice }
+
+                        let state, answer =
+                            submit
+                                (stateOf [ opened ] [] [ "s-1", planted ])
+                                "s-1"
+                                { submission "s-1" "0000" "k" with Plan = OrderPlan.create stubPatient twice }
+
+                        answer
+                        |> Expect.equal "mismatch" (SigningResponse.Refused SigningRefusal.ChallengeMismatch)
+
+                        (Hop.credentialOf "prescriber" state).WrongCount |> Expect.equal "not counted" 0
+
+                        let once = [| scenarioWithOrder "o-1"; scenarioWithOrder "o-2" |]
+                        let planted = { planted with Scenarios = once }
+
+                        match
+                            submit
+                                (stateOf [ opened ] [] [ "s-1", planted ])
+                                "s-1"
+                                { submission "s-1" "1234" "k" with Plan = OrderPlan.create stubPatient once }
+                            |> snd
+                        with
+                        | SigningResponse.Submitted(signed, _) -> signed.Scenarios |> Expect.equal "two orders" once
+                        | other -> failtest $"expected Submitted, got {other}"
+                    }
+
+                    test "the mail failing stops neither the ending nor the lock" {
+                        let broken (_: Mail) =
+                            raise (InvalidOperationException "smtp down")
+
+                        let state, _ =
+                            submitAt t0 (counter "id") broken ready "s-1" (submission "s-1" "0000" "k-1")
+
+                        let state, _ =
+                            submitAt t0 (counter "id") broken state "s-1" (submission "s-1" "0000" "k-2")
+
+                        let state, third =
+                            submitAt t0 (counter "id") broken state "s-1" (submission "s-1" "0000" "k-3")
+
+                        third
+                        |> Expect.equal "the limit" (SigningResponse.Refused SigningRefusal.PinLimit)
+
+                        state.Sessions |> Map.containsKey "s-1" |> Expect.isFalse "ended"
+                        (Hop.credentialOf "prescriber" state).LockedUntil |> Expect.isSome "locked"
                     }
 
                     test


### PR DESCRIPTION
## Summary

Plan [622](https://github.com/informedica/GenPRES/blob/master/docs/implementation-plans/622-signing-with-server-stubs.md) step 3: the commit of a signature, uc-03 step 3. Server and wire only; the client asks for it in steps 5 and 6, so nothing a User sees changes yet.

- **Wire**: `Submission { Plan; Opened; Challenge; Pin; IdemKey }` (never logged), `SigningCommand.Submit`, `SigningResponse.Submitted of SignedOrderPlan * OpenedToken` (the token re-minted over the new head, Rule 34), and `SignedOrderPlan.Verified`: whether the data the User saw was the platform's reading at the challenge (Rule 44).
- **The ladder** (`Hop.commit`), one act in the order of the model's `dbCommit`: the Session with a User and a Patient; the answer already given to this Session's idempotency key (Rule 45, refusals remembered too, so a transport retry of a wrong PIN counts once); the Role re-taken from the registry (Rule 38; a silent registry fails closed); the OpenedToken this Session holds (Rule 34); the record not moved on (Rule 20); the challenge this Session was issued, over exactly this plan (Rule 43; gone is `ChallengeExpired`, another nonce or plan is `ChallengeMismatch`); and the PIN last (Rules 23, 28), so a Submission that was never going to land costs no attempt.
- **The PIN**: a right entry appends the version (`By` and `PatientId` from the Session, orders, data and `Verified` from the challenge, `No` one above the patient's count, `Base` the head the Session opened with), spends the challenge, re-mints the OpenedToken and remembers the answer. The third wrong entry answers `PinLimit`, ends the Session with `WrongPinLimit` (told once at the next `GetSession`, acknowledged by the close as `SupersededByLaunch` is), locks the credential for the doubling delay and mails the User (Rule 27). A right entry while locked is refused as `Locked until` without counting; a wrong one counts and pushes the lock out.
- **Composition root**: `Submit` for the Session the cookie names; no cookie change, whatever the answer. `sessionDisabled` refuses.
- **Tests**: the ladder over a seeded state (six: the commit and the second version, the idempotency key, the refusals with the PIN never looked at, the challenge refusals, the three wrong PINs with the mail, the relaunch while locked), and the signature through the real hop: a wrong PIN, a signature, three wrong PINs, and `GetSession` telling `WrongPinLimit`. Server 234, shared 438, Fable and Fantomas green.

Left out, for the docs step: the duplicate `Order.Id` check the plan named; building an `OrderScenario` fixture needs a whole `Order`, and the challenge equality already pins the plan to what was shown.

Script-first: `Server/Scripts/Signing.fsx` (16 tests), migrated after review. The script's tests caught one bug before migration: a refusal helper closed over the state from before the PIN check, so a wrong PIN was answered but not counted.

## AI-assisted contribution

- [x] Vibe coded: drafted by Claude Code in the script, verified by its Expecto tests, then migrated and re-verified with the solution build, the server and shared test projects, the Fable compile and Fantomas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZWjibQUW8uqCVbfV4vDTf
