### PR TITLE
feat(client): the signing machine and its texts (#622)

### DIFF
--- a/src/Informedica.GenPRES.Client/Informedica.GenPRES.Client.fsproj
+++ b/src/Informedica.GenPRES.Client/Informedica.GenPRES.Client.fsproj
@@ -11,6 +11,8 @@
     <Compile Include="LanguagePolicy.fs" />
     <Compile Include="SessionMachine.fs" />
     <Compile Include="SessionGatePolicy.fs" />
+    <Compile Include="SigningMachine.fs" />
+    <Compile Include="SigningPolicy.fs" />
     <Compile Include="Keys.fs" />
     <Compile Include="AppEnv.fs" />
     <Compile Include="MUI.fs" />

--- a/src/Informedica.GenPRES.Client/SessionMachine.fs
+++ b/src/Informedica.GenPRES.Client/SessionMachine.fs
@@ -81,6 +81,10 @@ type SessionMsg =
     | Closed
     // the close request did not reach the server: the cookie is still there, so is the Session
     | CloseFailed of reason: string
+    // UC-3: a signing answer said the server ended the Session (Rule 28)
+    | EndedByServer of SessionEnding
+    // UC-3: a signature re-minted the OpenedToken over the new head (Rule 34)
+    | TokenRenewed of OpenedToken
 
 
 [<RequireQualifiedAccess>]
@@ -213,3 +217,13 @@ module Session =
         // with its patient, and the UI says so; the same guard as Closed
         | SessionMsg.CloseFailed _, Session.Closing session -> Session.Open session, []
         | SessionMsg.CloseFailed _, _ -> state, []
+
+        // UC-3: the server ended the Session at a signature (Rule 28); the gate says why and
+        // the close acknowledges it, as a Resumed ending does
+        | SessionMsg.EndedByServer ending, Session.Open _ -> Session.Ended ending, [ SessionEffect.CallCloseSession ]
+        | SessionMsg.EndedByServer _, _ -> state, []
+
+        // UC-3: the token the next signature has to present (Rule 34)
+        | SessionMsg.TokenRenewed token, Session.Open session ->
+            Session.Open { session with OpenedToken = Some token }, []
+        | SessionMsg.TokenRenewed _, _ -> state, []

--- a/src/Informedica.GenPRES.Client/SigningMachine.fs
+++ b/src/Informedica.GenPRES.Client/SigningMachine.fs
@@ -1,0 +1,127 @@
+/// The signing phase of an open Session (uc-03 steps 2 and 3): a pure state machine next to
+/// the Session's, with effects for the App to interpret. The machine holds no OpenedToken and
+/// no idempotency key: the effects name what it knows (the plan, the challenge, the PIN), and
+/// the interpreter completes each call from the open Session.
+///
+/// Two invariants (ext 3b, 3c): what is submitted is the plan the challenge was issued over,
+/// held in the state, never the live cart; and one request is in flight at a time.
+module SigningMachine
+
+open Shared.Types
+
+
+[<RequireQualifiedAccess>]
+type Signing =
+    | Idle
+    // step 2 asked; the notice token when the User accepted a data notice (Rule 44)
+    | Requesting of OrderPlan * notice: string option
+    // Rule 44: the data as it stands, to accept or to cancel
+    | Noticed of OrderPlan * DataNotice
+    // step 3: the dialog asks the PIN over this plan; the last refusal, if any
+    | Challenged of challenge: string * OrderPlan * SigningRefusal option
+    | Submitting of challenge: string * OrderPlan
+
+
+[<RequireQualifiedAccess>]
+type SigningMsg =
+    | Sign of OrderPlan
+    // Error = transport failure
+    | ChallengeAnswered of Result<SigningResponse, string>
+    // the data notice accepted: sign over the data as it stands
+    | Accept
+    | Confirm of pin: string
+    | Cancel
+    // Error = transport failure
+    | SubmitAnswered of Result<SigningResponse, string>
+
+
+[<RequireQualifiedAccess>]
+type SigningEffect =
+    // RequestSignChallenge, completed with the open Session's OpenedToken
+    | CallChallenge of OrderPlan * notice: string option
+    // Submit, completed with the open Session's OpenedToken and a fresh idempotency key
+    | CallSubmit of OrderPlan * challenge: string * pin: string
+    // the Session's token, re-minted over the new head (Rule 34)
+    | RenewToken of OpenedToken
+    // the server ended the Session (Rule 28)
+    | EndSession of SessionEnding
+    // the patient data as the notice showed it, so the cart is over it too
+    | SetPatient of Patient
+    // told once
+    | TellSigned of SignedOrderPlan
+    | TellRefused of SigningRefusal
+    | TellError of reason: string
+
+
+module Signing =
+
+    let transition (msg: SigningMsg) (state: Signing) : Signing * SigningEffect list =
+        match msg, state with
+        | SigningMsg.Sign plan, Signing.Idle ->
+            Signing.Requesting(plan, None), [ SigningEffect.CallChallenge(plan, None) ]
+        // one thing at a time
+        | SigningMsg.Sign _, _ -> state, []
+
+        | SigningMsg.ChallengeAnswered(Ok(SigningResponse.ChallengeIssued challenge)), Signing.Requesting(plan, _) ->
+            Signing.Challenged(challenge, plan, None), []
+        | SigningMsg.ChallengeAnswered(Ok(SigningResponse.DataNotice notice)), Signing.Requesting(plan, _) ->
+            Signing.Noticed(plan, notice), []
+        | SigningMsg.ChallengeAnswered(Ok(SigningResponse.Refused SigningRefusal.PinLimit)), Signing.Requesting _ ->
+            Signing.Idle, [ SigningEffect.EndSession SessionEnding.WrongPinLimit ]
+        | SigningMsg.ChallengeAnswered(Ok(SigningResponse.Refused refusal)), Signing.Requesting _ ->
+            Signing.Idle, [ SigningEffect.TellRefused refusal ]
+        // never an answer to a challenge request
+        | SigningMsg.ChallengeAnswered(Ok(SigningResponse.Submitted _)), Signing.Requesting _ -> Signing.Idle, []
+        | SigningMsg.ChallengeAnswered(Error reason), Signing.Requesting _ ->
+            Signing.Idle, [ SigningEffect.TellError reason ]
+        // an answer lands only on the request in flight
+        | SigningMsg.ChallengeAnswered _, _ -> state, []
+
+        // Rule 44: the User signs over the data as it stands; with a reading, the cart follows it
+        | SigningMsg.Accept, Signing.Noticed(plan, notice) ->
+            match notice.Data with
+            | Some data ->
+                let shown = { plan with Patient = data }
+
+                Signing.Requesting(shown, Some notice.Token),
+                [
+                    SigningEffect.SetPatient data
+                    SigningEffect.CallChallenge(shown, Some notice.Token)
+                ]
+            | None ->
+                Signing.Requesting(plan, Some notice.Token), [ SigningEffect.CallChallenge(plan, Some notice.Token) ]
+        | SigningMsg.Accept, _ -> state, []
+
+        // step 3: the plan submitted is the plan challenged (ext 3b, 3c)
+        | SigningMsg.Confirm pin, Signing.Challenged(challenge, plan, _) ->
+            Signing.Submitting(challenge, plan), [ SigningEffect.CallSubmit(plan, challenge, pin) ]
+        | SigningMsg.Confirm _, _ -> state, []
+
+        // the challenge is dropped, and the dialog with it; a request in flight cannot be cancelled
+        | SigningMsg.Cancel, Signing.Requesting _
+        | SigningMsg.Cancel, Signing.Noticed _
+        | SigningMsg.Cancel, Signing.Challenged _ -> Signing.Idle, []
+        | SigningMsg.Cancel, _ -> state, []
+
+        | SigningMsg.SubmitAnswered(Ok(SigningResponse.Submitted(signed, token))), Signing.Submitting _ ->
+            Signing.Idle,
+            [
+                SigningEffect.RenewToken token
+                SigningEffect.TellSigned signed
+            ]
+        // the dialog stays open with what went wrong (Rule 28: tries left, or locked)
+        | SigningMsg.SubmitAnswered(Ok(SigningResponse.Refused(SigningRefusal.PinWrong _ as refusal))),
+          Signing.Submitting(challenge, plan)
+        | SigningMsg.SubmitAnswered(Ok(SigningResponse.Refused(SigningRefusal.Locked _ as refusal))),
+          Signing.Submitting(challenge, plan) -> Signing.Challenged(challenge, plan, Some refusal), []
+        | SigningMsg.SubmitAnswered(Ok(SigningResponse.Refused SigningRefusal.PinLimit)), Signing.Submitting _ ->
+            Signing.Idle, [ SigningEffect.EndSession SessionEnding.WrongPinLimit ]
+        | SigningMsg.SubmitAnswered(Ok(SigningResponse.Refused refusal)), Signing.Submitting _ ->
+            Signing.Idle, [ SigningEffect.TellRefused refusal ]
+        // never an answer to a Submission
+        | SigningMsg.SubmitAnswered(Ok(SigningResponse.ChallengeIssued _)), Signing.Submitting _
+        | SigningMsg.SubmitAnswered(Ok(SigningResponse.DataNotice _)), Signing.Submitting _ -> Signing.Idle, []
+        // the request never got there: the challenge stands, the dialog comes back as it was
+        | SigningMsg.SubmitAnswered(Error reason), Signing.Submitting(challenge, plan) ->
+            Signing.Challenged(challenge, plan, None), [ SigningEffect.TellError reason ]
+        | SigningMsg.SubmitAnswered _, _ -> state, []

--- a/src/Informedica.GenPRES.Client/SigningMachine.fs
+++ b/src/Informedica.GenPRES.Client/SigningMachine.fs
@@ -1,10 +1,12 @@
 /// The signing phase of an open Session (uc-03 steps 2 and 3): a pure state machine next to
-/// the Session's, with effects for the App to interpret. The machine holds no OpenedToken and
-/// no idempotency key: the effects name what it knows (the plan, the challenge, the PIN), and
+/// the Session's, with effects for the App to interpret. The machine holds no OpenedToken: the
+/// effects name what it knows (the plan, the challenge, the PIN, the idempotency key), and
 /// the interpreter completes each call from the open Session.
 ///
-/// Two invariants (ext 3b, 3c): what is submitted is the plan the challenge was issued over,
-/// held in the state, never the live cart; and one request is in flight at a time.
+/// Three invariants (ext 3b, 3c, 3d): what is submitted is the plan the challenge was issued
+/// over, held in the state, never the live cart; one request is in flight at a time; and a
+/// Submission whose answer was lost is sent again under the same key (Rule 45), so the server
+/// answers what it already did, landed or not.
 module SigningMachine
 
 open Shared.Types
@@ -19,7 +21,10 @@ type Signing =
     | Noticed of OrderPlan * DataNotice
     // step 3: the dialog asks the PIN over this plan; the last refusal, if any
     | Challenged of challenge: string * OrderPlan * SigningRefusal option
-    | Submitting of challenge: string * OrderPlan
+    // the Submission in flight, under its key
+    | Submitting of challenge: string * OrderPlan * key: string
+    // the answer was lost (a transport error): the dialog asks again, the key is kept (Rule 45)
+    | Unsent of challenge: string * OrderPlan * key: string
 
 
 [<RequireQualifiedAccess>]
@@ -29,7 +34,8 @@ type SigningMsg =
     | ChallengeAnswered of Result<SigningResponse, string>
     // the data notice accepted: sign over the data as it stands
     | Accept
-    | Confirm of pin: string
+    // the PIN, and a fresh idempotency key the caller minted; ignored on a retry
+    | Confirm of pin: string * key: string
     | Cancel
     // Error = transport failure
     | SubmitAnswered of Result<SigningResponse, string>
@@ -39,8 +45,8 @@ type SigningMsg =
 type SigningEffect =
     // RequestSignChallenge, completed with the open Session's OpenedToken
     | CallChallenge of OrderPlan * notice: string option
-    // Submit, completed with the open Session's OpenedToken and a fresh idempotency key
-    | CallSubmit of OrderPlan * challenge: string * pin: string
+    // Submit, completed with the open Session's OpenedToken
+    | CallSubmit of OrderPlan * challenge: string * pin: string * key: string
     // the Session's token, re-minted over the new head (Rule 34)
     | RenewToken of OpenedToken
     // the server ended the Session (Rule 28)
@@ -92,15 +98,20 @@ module Signing =
                 Signing.Requesting(plan, Some notice.Token), [ SigningEffect.CallChallenge(plan, Some notice.Token) ]
         | SigningMsg.Accept, _ -> state, []
 
-        // step 3: the plan submitted is the plan challenged (ext 3b, 3c)
-        | SigningMsg.Confirm pin, Signing.Challenged(challenge, plan, _) ->
-            Signing.Submitting(challenge, plan), [ SigningEffect.CallSubmit(plan, challenge, pin) ]
+        // step 3: the plan submitted is the plan challenged (ext 3b, 3c), under the caller's key
+        | SigningMsg.Confirm(pin, key), Signing.Challenged(challenge, plan, _) ->
+            Signing.Submitting(challenge, plan, key), [ SigningEffect.CallSubmit(plan, challenge, pin, key) ]
+        // a retry after a lost answer goes out under the key it had (Rule 45): the server
+        // answers what it already did, whether the signature landed or not
+        | SigningMsg.Confirm(pin, _), Signing.Unsent(challenge, plan, key) ->
+            Signing.Submitting(challenge, plan, key), [ SigningEffect.CallSubmit(plan, challenge, pin, key) ]
         | SigningMsg.Confirm _, _ -> state, []
 
         // the challenge is dropped, and the dialog with it; a request in flight cannot be cancelled
         | SigningMsg.Cancel, Signing.Requesting _
         | SigningMsg.Cancel, Signing.Noticed _
-        | SigningMsg.Cancel, Signing.Challenged _ -> Signing.Idle, []
+        | SigningMsg.Cancel, Signing.Challenged _
+        | SigningMsg.Cancel, Signing.Unsent _ -> Signing.Idle, []
         | SigningMsg.Cancel, _ -> state, []
 
         | SigningMsg.SubmitAnswered(Ok(SigningResponse.Submitted(signed, token))), Signing.Submitting _ ->
@@ -111,9 +122,9 @@ module Signing =
             ]
         // the dialog stays open with what went wrong (Rule 28: tries left, or locked)
         | SigningMsg.SubmitAnswered(Ok(SigningResponse.Refused(SigningRefusal.PinWrong _ as refusal))),
-          Signing.Submitting(challenge, plan)
+          Signing.Submitting(challenge, plan, _)
         | SigningMsg.SubmitAnswered(Ok(SigningResponse.Refused(SigningRefusal.Locked _ as refusal))),
-          Signing.Submitting(challenge, plan) -> Signing.Challenged(challenge, plan, Some refusal), []
+          Signing.Submitting(challenge, plan, _) -> Signing.Challenged(challenge, plan, Some refusal), []
         | SigningMsg.SubmitAnswered(Ok(SigningResponse.Refused SigningRefusal.PinLimit)), Signing.Submitting _ ->
             Signing.Idle, [ SigningEffect.EndSession SessionEnding.WrongPinLimit ]
         | SigningMsg.SubmitAnswered(Ok(SigningResponse.Refused refusal)), Signing.Submitting _ ->
@@ -121,7 +132,8 @@ module Signing =
         // never an answer to a Submission
         | SigningMsg.SubmitAnswered(Ok(SigningResponse.ChallengeIssued _)), Signing.Submitting _
         | SigningMsg.SubmitAnswered(Ok(SigningResponse.DataNotice _)), Signing.Submitting _ -> Signing.Idle, []
-        // the request never got there: the challenge stands, the dialog comes back as it was
-        | SigningMsg.SubmitAnswered(Error reason), Signing.Submitting(challenge, plan) ->
-            Signing.Challenged(challenge, plan, None), [ SigningEffect.TellError reason ]
+        // the answer was lost: whether the signature landed is unknown, so the dialog comes
+        // back and the next Confirm retries under the same key (Rule 45)
+        | SigningMsg.SubmitAnswered(Error reason), Signing.Submitting(challenge, plan, key) ->
+            Signing.Unsent(challenge, plan, key), [ SigningEffect.TellError reason ]
         | SigningMsg.SubmitAnswered _, _ -> state, []

--- a/src/Informedica.GenPRES.Client/SigningPolicy.fs
+++ b/src/Informedica.GenPRES.Client/SigningPolicy.fs
@@ -1,0 +1,101 @@
+/// What the signing UI says and offers (uc-03 steps 2 and 3), decided from the Session and
+/// the signing phase: every text a `Terms` case, so the view only renders.
+module SigningPolicy
+
+open Shared
+open Shared.Types
+open SessionMachine
+open SigningMachine
+
+
+/// The English default of every signing term: what the UI shows when the sheet has no row
+/// yet, and what the tests assert.
+let english (term: Terms) : string =
+    match term with
+    | Terms.``Signing Sign`` -> "Sign"
+    | Terms.``Signing Dialog Title`` -> "Sign the order plan"
+    | Terms.``Signing Dialog Text`` -> "Sign the orders as shown with your PIN, or cancel and edit."
+    | Terms.``Signing Pin`` -> "PIN"
+    | Terms.``Signing Cancel`` -> "Cancel"
+    | Terms.``Signing Proceed`` -> "Continue"
+    | Terms.``Signing Signed`` -> "Version {0} was signed by {1}."
+    | Terms.``Signing Data Changed`` ->
+        "The patient data changed since the session opened. It is shown as it stands now; continue to sign over it, or cancel."
+    | Terms.``Signing Data Unverified`` ->
+        "The patient data could not be verified. Continue to sign over the data the session opened with, or cancel."
+    | Terms.``Signing Refusal No Session`` -> "There is no session to sign in. Open GenPRES again from MainEHR."
+    | Terms.``Signing Refusal No Patient`` -> "The plan is not over this session's patient."
+    | Terms.``Signing Refusal Not Prescriber`` -> "Only a Prescriber can sign."
+    | Terms.``Signing Refusal Blocked`` ->
+        "{0} signed a newer version at {1}. Open the patient again to continue from it."
+    | Terms.``Signing Refusal Stale Token`` -> "The session is not current. Reload the page."
+    | Terms.``Signing Refusal Challenge Mismatch`` -> "The plan changed since it was shown. Sign again."
+    | Terms.``Signing Refusal Challenge Expired`` -> "The signature took too long. Sign again."
+    | Terms.``Signing Refusal Pin Wrong`` -> "The PIN is not right. {0} tries left."
+    | Terms.``Signing Refusal Pin Limit`` ->
+        "The PIN was entered wrong three times. Your session was ended and signing is locked for a while."
+    | Terms.``Signing Refusal Locked`` -> "Signing is locked until {0}."
+    | _ -> SessionGatePolicy.english term
+
+
+/// A moment as the User reads it: the local time of day.
+let time (at: System.DateTime) = at.ToLocalTime().ToString "HH:mm"
+
+
+/// One sentence per refusal, the numbers and names filled in.
+let refusalSentence (tr: Terms -> string) (refusal: SigningRefusal) =
+    match refusal with
+    | SigningRefusal.NoSession -> tr Terms.``Signing Refusal No Session``
+    | SigningRefusal.NoPatient -> tr Terms.``Signing Refusal No Patient``
+    | SigningRefusal.NotPrescriber -> tr Terms.``Signing Refusal Not Prescriber``
+    | SigningRefusal.Blocked head ->
+        tr Terms.``Signing Refusal Blocked``
+        |> SessionGatePolicy.fill [ head.By.DisplayName; time head.SignedAt ]
+    | SigningRefusal.StaleToken -> tr Terms.``Signing Refusal Stale Token``
+    | SigningRefusal.ChallengeMismatch -> tr Terms.``Signing Refusal Challenge Mismatch``
+    | SigningRefusal.ChallengeExpired -> tr Terms.``Signing Refusal Challenge Expired``
+    | SigningRefusal.PinWrong left -> tr Terms.``Signing Refusal Pin Wrong`` |> SessionGatePolicy.fill [ string left ]
+    | SigningRefusal.PinLimit -> tr Terms.``Signing Refusal Pin Limit``
+    | SigningRefusal.Locked until -> tr Terms.``Signing Refusal Locked`` |> SessionGatePolicy.fill [ time until ]
+
+
+/// What the User is told once the version landed.
+let signedSentence (tr: Terms -> string) (signed: SignedOrderPlan) =
+    tr Terms.``Signing Signed``
+    |> SessionGatePolicy.fill [ string signed.Head.No; signed.Head.By.DisplayName ]
+
+
+/// Rule 44: what the notice says, with or without a reading.
+let noticeSentence (tr: Terms -> string) (notice: DataNotice) =
+    match notice.Data with
+    | Some _ -> tr Terms.``Signing Data Changed``
+    | None -> tr Terms.``Signing Data Unverified``
+
+
+/// The PIN's own check before anything is sent: the enrolment's four to six digits.
+let pinError (tr: Terms -> string) (pin: string) =
+    if SessionGatePolicy.digits 4 6 pin then
+        None
+    else
+        Some(tr Terms.``Session Enrolment Pin Format``)
+
+
+/// Whether the plan can be signed: an open Session as Prescriber for a patient, and at least
+/// one order (Rules 13, 26).
+let canSign (session: Session) (plan: OrderPlan) =
+    match session with
+    | Session.Open opened ->
+        (opened.User |> Option.map _.Role) = Some UserRole.Prescriber
+        && opened.PatientContext.IsSome
+        && plan.Scenarios.Length > 0
+    | _ -> false
+
+
+/// Whether the dialog is up: the notice, the PIN question, or the Submission in flight.
+let dialogOpen (signing: Signing) =
+    match signing with
+    | Signing.Noticed _
+    | Signing.Challenged _
+    | Signing.Submitting _ -> true
+    | Signing.Idle
+    | Signing.Requesting _ -> false

--- a/src/Informedica.GenPRES.Client/SigningPolicy.fs
+++ b/src/Informedica.GenPRES.Client/SigningPolicy.fs
@@ -91,11 +91,13 @@ let canSign (session: Session) (plan: OrderPlan) =
     | _ -> false
 
 
-/// Whether the dialog is up: the notice, the PIN question, or the Submission in flight.
+/// Whether the dialog is up: the notice, the PIN question, the Submission in flight, or the
+/// retry after a lost answer.
 let dialogOpen (signing: Signing) =
     match signing with
     | Signing.Noticed _
     | Signing.Challenged _
-    | Signing.Submitting _ -> true
+    | Signing.Submitting _
+    | Signing.Unsent _ -> true
     | Signing.Idle
     | Signing.Requesting _ -> false

--- a/src/Informedica.GenPRES.Shared/Localization.fs
+++ b/src/Informedica.GenPRES.Shared/Localization.fs
@@ -177,6 +177,27 @@ type Terms =
     | ``Session Enrolment Wrong Code``
     | ``Session Enrolment Code Void``
     | ``Session Enrolment Expired``
+    // signing (UC-3, plan 622): the button, the dialog, the data notice (Rule 44), the signed
+    // sentence with {0} the version and {1} the signer, and one sentence per refusal
+    | ``Signing Sign``
+    | ``Signing Dialog Title``
+    | ``Signing Dialog Text``
+    | ``Signing Pin``
+    | ``Signing Cancel``
+    | ``Signing Proceed``
+    | ``Signing Signed``
+    | ``Signing Data Changed``
+    | ``Signing Data Unverified``
+    | ``Signing Refusal No Session``
+    | ``Signing Refusal No Patient``
+    | ``Signing Refusal Not Prescriber``
+    | ``Signing Refusal Blocked``
+    | ``Signing Refusal Stale Token``
+    | ``Signing Refusal Challenge Mismatch``
+    | ``Signing Refusal Challenge Expired``
+    | ``Signing Refusal Pin Wrong``
+    | ``Signing Refusal Pin Limit``
+    | ``Signing Refusal Locked``
 
 
 module Localization =

--- a/src/Informedica.GenPRES.Shared/Scripts/Localization.fsx
+++ b/src/Informedica.GenPRES.Shared/Scripts/Localization.fsx
@@ -70,6 +70,27 @@ type SessionTerms =
     | ``Session Enrolment Wrong Code``
     | ``Session Enrolment Code Void``
     | ``Session Enrolment Expired``
+    // signing (UC-3, plan 622 PR 5): the button, the dialog, the data notice (Rule 44), the
+    // signed sentence with {0} the version and {1} the signer, and one sentence per refusal
+    | ``Signing Sign``
+    | ``Signing Dialog Title``
+    | ``Signing Dialog Text``
+    | ``Signing Pin``
+    | ``Signing Cancel``
+    | ``Signing Proceed``
+    | ``Signing Signed``
+    | ``Signing Data Changed``
+    | ``Signing Data Unverified``
+    | ``Signing Refusal No Session``
+    | ``Signing Refusal No Patient``
+    | ``Signing Refusal Not Prescriber``
+    | ``Signing Refusal Blocked``
+    | ``Signing Refusal Stale Token``
+    | ``Signing Refusal Challenge Mismatch``
+    | ``Signing Refusal Challenge Expired``
+    | ``Signing Refusal Pin Wrong``
+    | ``Signing Refusal Pin Limit``
+    | ``Signing Refusal Locked``
 
 
 /// The English defaults: the strings the client shows today, verbatim.
@@ -116,6 +137,28 @@ let english term =
     | ``Session Enrolment Wrong Code`` -> "The code is not right. {0} tries left."
     | ``Session Enrolment Code Void`` -> "The code is void after three wrong tries."
     | ``Session Enrolment Expired`` -> "The enrolment has expired."
+    | ``Signing Sign`` -> "Sign"
+    | ``Signing Dialog Title`` -> "Sign the order plan"
+    | ``Signing Dialog Text`` -> "Sign the orders as shown with your PIN, or cancel and edit."
+    | ``Signing Pin`` -> "PIN"
+    | ``Signing Cancel`` -> "Cancel"
+    | ``Signing Proceed`` -> "Continue"
+    | ``Signing Signed`` -> "Version {0} was signed by {1}."
+    | ``Signing Data Changed`` ->
+        "The patient data changed since the session opened. It is shown as it stands now; continue to sign over it, or cancel."
+    | ``Signing Data Unverified`` ->
+        "The patient data could not be verified. Continue to sign over the data the session opened with, or cancel."
+    | ``Signing Refusal No Session`` -> "There is no session to sign in. Open GenPRES again from MainEHR."
+    | ``Signing Refusal No Patient`` -> "The plan is not over this session's patient."
+    | ``Signing Refusal Not Prescriber`` -> "Only a Prescriber can sign."
+    | ``Signing Refusal Blocked`` -> "{0} signed a newer version at {1}. Open the patient again to continue from it."
+    | ``Signing Refusal Stale Token`` -> "The session is not current. Reload the page."
+    | ``Signing Refusal Challenge Mismatch`` -> "The plan changed since it was shown. Sign again."
+    | ``Signing Refusal Challenge Expired`` -> "The signature took too long. Sign again."
+    | ``Signing Refusal Pin Wrong`` -> "The PIN is not right. {0} tries left."
+    | ``Signing Refusal Pin Limit`` ->
+        "The PIN was entered wrong three times. Your session was ended and signing is locked for a while."
+    | ``Signing Refusal Locked`` -> "Signing is locked until {0}."
 
 
 /// Dutch, for the sheet; the other four languages stay empty and fall back to English.
@@ -163,6 +206,29 @@ let dutch term =
     | ``Session Enrolment Wrong Code`` -> "De code klopt niet. Nog {0} pogingen."
     | ``Session Enrolment Code Void`` -> "De code is na drie verkeerde pogingen niet meer geldig."
     | ``Session Enrolment Expired`` -> "De inschrijving is verlopen."
+    | ``Signing Sign`` -> "Ondertekenen"
+    | ``Signing Dialog Title`` -> "Onderteken het voorschrijfplan"
+    | ``Signing Dialog Text`` -> "Onderteken de voorschriften zoals getoond met uw pincode, of annuleer en pas aan."
+    | ``Signing Pin`` -> "Pincode"
+    | ``Signing Cancel`` -> "Annuleren"
+    | ``Signing Proceed`` -> "Doorgaan"
+    | ``Signing Signed`` -> "Versie {0} is ondertekend door {1}."
+    | ``Signing Data Changed`` ->
+        "De patiëntgegevens zijn gewijzigd sinds de sessie werd geopend. Ze worden getoond zoals ze nu zijn; ga door om daarover te ondertekenen, of annuleer."
+    | ``Signing Data Unverified`` ->
+        "De patiëntgegevens konden niet worden geverifieerd. Ga door om te ondertekenen over de gegevens waarmee de sessie is geopend, of annuleer."
+    | ``Signing Refusal No Session`` -> "Er is geen sessie om in te ondertekenen. Open GenPRES opnieuw vanuit MainEHR."
+    | ``Signing Refusal No Patient`` -> "Het plan hoort niet bij de patiënt van deze sessie."
+    | ``Signing Refusal Not Prescriber`` -> "Alleen een voorschrijver kan ondertekenen."
+    | ``Signing Refusal Blocked`` ->
+        "{0} heeft om {1} een nieuwere versie ondertekend. Open de patiënt opnieuw om daarvan verder te gaan."
+    | ``Signing Refusal Stale Token`` -> "De sessie is niet actueel. Laad de pagina opnieuw."
+    | ``Signing Refusal Challenge Mismatch`` -> "Het plan is gewijzigd sinds het werd getoond. Onderteken opnieuw."
+    | ``Signing Refusal Challenge Expired`` -> "Het ondertekenen duurde te lang. Onderteken opnieuw."
+    | ``Signing Refusal Pin Wrong`` -> "De pincode klopt niet. Nog {0} pogingen."
+    | ``Signing Refusal Pin Limit`` ->
+        "De pincode is drie keer verkeerd ingevoerd. Uw sessie is beëindigd en ondertekenen is een tijdje geblokkeerd."
+    | ``Signing Refusal Locked`` -> "Ondertekenen is geblokkeerd tot {0}."
 
 
 let all =
@@ -291,7 +357,7 @@ let tests =
                 |> Expect.equal "distinct keys" all.Length
             }
 
-            test "placeholders appear only in the attempt, enrolment and wrong-code texts, in both languages" {
+            test "placeholders appear only in the attempt, enrolment, wrong-code and signing texts, in both languages" {
                 let withPlaceholders =
                     all
                     |> Array.filter (fun t -> (english t).Contains "{0}" || (dutch t).Contains "{0}")
@@ -305,10 +371,20 @@ let tests =
                         ``Session Gate Unreachable Text``
                         ``Session Gate Enrolment Text``
                         ``Session Enrolment Wrong Code``
+                        ``Signing Signed``
+                        ``Signing Refusal Blocked``
+                        ``Signing Refusal Pin Wrong``
+                        ``Signing Refusal Locked``
                      |]
                      |> Array.sort)
 
-                for t in [ ``Session Gate Opening Text``; ``Session Gate Enrolment Text`` ] do
+                for t in
+                    [
+                        ``Session Gate Opening Text``
+                        ``Session Gate Enrolment Text``
+                        ``Signing Signed``
+                        ``Signing Refusal Blocked``
+                    ] do
                     (english t).Contains "{1}" |> Expect.isTrue $"{{1}} en {t}"
                     (dutch t).Contains "{1}" |> Expect.isTrue $"{{1}} nl {t}"
             }

--- a/tests/Informedica.GenPRES.Shared.Tests/Informedica.GenPRES.Shared.Tests.fsproj
+++ b/tests/Informedica.GenPRES.Shared.Tests/Informedica.GenPRES.Shared.Tests.fsproj
@@ -21,6 +21,10 @@
     <Compile Include="SessionMachineTests.fs" />
     <Compile Include="..\..\src\Informedica.GenPRES.Client\SessionGatePolicy.fs" />
     <Compile Include="SessionGatePolicyTests.fs" />
+    <Compile Include="..\..\src\Informedica.GenPRES.Client\SigningMachine.fs" />
+    <Compile Include="SigningMachineTests.fs" />
+    <Compile Include="..\..\src\Informedica.GenPRES.Client\SigningPolicy.fs" />
+    <Compile Include="SigningPolicyTests.fs" />
     <Compile Include="Main.fs" />
     <None Include="Scripts\load.fsx" />
     <None Include="scripts\CalcYearsOracle.fsx" />

--- a/tests/Informedica.GenPRES.Shared.Tests/SessionMachineTests.fs
+++ b/tests/Informedica.GenPRES.Shared.Tests/SessionMachineTests.fs
@@ -508,6 +508,33 @@ module SessionMachineTests =
                         ]
                 }
 
+                test
+                    "EndedByServer from Open is Ended and acknowledges it with a close; elsewhere dropped (UC-3, Rule 28)" {
+                    transition (SessionMsg.EndedByServer SessionEnding.WrongPinLimit) (Session.Open full)
+                    |> Expect.equal
+                        "ended"
+                        (Session.Ended SessionEnding.WrongPinLimit, [ SessionEffect.CallCloseSession ])
+
+                    for state in
+                        [
+                            Session.Anonymous
+                            Session.Closing full
+                            Session.Resuming
+                            launching
+                        ] do
+                        transition (SessionMsg.EndedByServer SessionEnding.WrongPinLimit) state
+                        |> Expect.equal $"{state}" (state, [])
+                }
+
+                test "TokenRenewed from Open replaces the token; elsewhere dropped (UC-3, Rule 34)" {
+                    transition (SessionMsg.TokenRenewed(OpenedToken "t2")) (Session.Open full)
+                    |> Expect.equal "renewed" (Session.Open { full with OpenedToken = Some(OpenedToken "t2") }, [])
+
+                    for state in [ Session.Anonymous; Session.Closing full; launching ] do
+                        transition (SessionMsg.TokenRenewed(OpenedToken "t2")) state
+                        |> Expect.equal $"{state}" (state, [])
+                }
+
                 test "the happy path: present, open, close" {
                     let state, effects =
                         run

--- a/tests/Informedica.GenPRES.Shared.Tests/SigningMachineTests.fs
+++ b/tests/Informedica.GenPRES.Shared.Tests/SigningMachineTests.fs
@@ -37,7 +37,8 @@ module Fixtures =
         }
 
     let challenged = Signing.Challenged("c-1", plan, None)
-    let submitting = Signing.Submitting("c-1", plan)
+    let submitting = Signing.Submitting("c-1", plan, "k-1")
+    let unsent = Signing.Unsent("c-1", plan, "k-1")
     let requesting = Signing.Requesting(plan, None)
 
     let transition = Signing.transition
@@ -60,6 +61,7 @@ let tests =
                         requesting
                         challenged
                         submitting
+                        unsent
                         Signing.Noticed(
                             plan,
                             {
@@ -99,7 +101,7 @@ let tests =
                 |> Expect.equal "transport" (Signing.Idle, [ SigningEffect.TellError "down" ])
 
                 // an answer lands only on the request in flight
-                for state in [ Signing.Idle; challenged; submitting ] do
+                for state in [ Signing.Idle; challenged; submitting; unsent ] do
                     transition (SigningMsg.ChallengeAnswered(Ok(SigningResponse.ChallengeIssued "c-9"))) state
                     |> Expect.equal $"{state}" (state, [])
             }
@@ -133,25 +135,26 @@ let tests =
                     "over the opened data"
                     (Signing.Requesting(plan, Some "d-2"), [ SigningEffect.CallChallenge(plan, Some "d-2") ])
 
-                for state in [ Signing.Idle; requesting; challenged; submitting ] do
+                for state in [ Signing.Idle; requesting; challenged; submitting; unsent ] do
                     transition SigningMsg.Accept state |> Expect.equal $"{state}" (state, [])
             }
 
             test
-                "Confirm sends the PIN over the challenged plan, once at a time; Cancel drops the challenge but not a request in flight" {
-                transition (SigningMsg.Confirm "1234") challenged
-                |> Expect.equal "sent" (submitting, [ SigningEffect.CallSubmit(plan, "c-1", "1234") ])
+                "Confirm sends the PIN over the challenged plan under the caller's key, once at a time; Cancel drops the challenge but not a request in flight" {
+                transition (SigningMsg.Confirm("1234", "k-1")) challenged
+                |> Expect.equal "sent" (submitting, [ SigningEffect.CallSubmit(plan, "c-1", "1234", "k-1") ])
 
-                transition (SigningMsg.Confirm "1234") submitting
+                transition (SigningMsg.Confirm("1234", "k-2")) submitting
                 |> Expect.equal "not twice" (submitting, [])
 
-                transition (SigningMsg.Confirm "1234") Signing.Idle
+                transition (SigningMsg.Confirm("1234", "k-2")) Signing.Idle
                 |> Expect.equal "nothing to confirm" (Signing.Idle, [])
 
                 for state in
                     [
                         requesting
                         challenged
+                        unsent
                         Signing.Noticed(
                             plan,
                             {
@@ -212,14 +215,33 @@ let tests =
                     transition (SigningMsg.SubmitAnswered(Ok(SigningResponse.Refused refusal))) submitting
                     |> Expect.equal $"{refusal}" (Signing.Idle, [ SigningEffect.TellRefused refusal ])
 
-                transition (SigningMsg.SubmitAnswered(Error "down")) submitting
-                |> Expect.equal "dialog back" (challenged, [ SigningEffect.TellError "down" ])
-
-                for state in [ Signing.Idle; requesting; challenged ] do
+                for state in [ Signing.Idle; requesting; challenged; unsent ] do
                     transition
                         (SigningMsg.SubmitAnswered(Ok(SigningResponse.Submitted(signed, OpenedToken "t2"))))
                         state
                     |> Expect.equal $"{state}" (state, [])
+            }
+
+            test
+                "a lost answer: the dialog comes back and the retry goes out under the same key, so the server answers what it did (Rule 45, ext 3d)" {
+                transition (SigningMsg.SubmitAnswered(Error "down")) submitting
+                |> Expect.equal "unsent, told" (unsent, [ SigningEffect.TellError "down" ])
+
+                // the caller mints a fresh key; the machine keeps the one the lost Submission had
+                transition (SigningMsg.Confirm("1234", "k-fresh")) unsent
+                |> Expect.equal "same key" (submitting, [ SigningEffect.CallSubmit(plan, "c-1", "1234", "k-1") ])
+
+                // the signature had landed: the remembered answer is what comes back
+                transition
+                    (SigningMsg.SubmitAnswered(Ok(SigningResponse.Submitted(signed, OpenedToken "t2"))))
+                    submitting
+                |> Expect.equal
+                    "signed after all"
+                    (Signing.Idle,
+                     [
+                         SigningEffect.RenewToken(OpenedToken "t2")
+                         SigningEffect.TellSigned signed
+                     ])
             }
 
             test "the plan submitted is the plan challenged, whatever the cart did meanwhile (ext 3b, 3c)" {
@@ -228,9 +250,9 @@ let tests =
                 let state, _ =
                     transition (SigningMsg.ChallengeAnswered(Ok(SigningResponse.ChallengeIssued "c-1"))) state
                 // the cart moved on: the machine never sees it
-                let _, effects = transition (SigningMsg.Confirm "1234") state
+                let _, effects = transition (SigningMsg.Confirm("1234", "k-1")) state
 
                 effects
-                |> Expect.equal "the challenged plan" [ SigningEffect.CallSubmit(plan, "c-1", "1234") ]
+                |> Expect.equal "the challenged plan" [ SigningEffect.CallSubmit(plan, "c-1", "1234", "k-1") ]
             }
         ]

--- a/tests/Informedica.GenPRES.Shared.Tests/SigningMachineTests.fs
+++ b/tests/Informedica.GenPRES.Shared.Tests/SigningMachineTests.fs
@@ -1,0 +1,236 @@
+module Informedica.GenPRES.Shared.Tests.SigningMachineTests
+
+open System
+open Expecto
+open Expecto.Flip
+open Shared.Types
+open SigningMachine
+
+
+module Fixtures =
+
+    let patient = Shared.Models.Patient.empty
+    let otherData = { patient with Department = Some "ICU" }
+    let plan = Shared.Models.OrderPlan.create patient [||]
+
+    let prescriber =
+        {
+            UserId = "prescriber"
+            DisplayName = "Stub Prescriber"
+            Role = UserRole.Prescriber
+        }
+
+    let signed: SignedOrderPlan =
+        {
+            Head =
+                {
+                    Id = "plan-1"
+                    No = 1
+                    By = prescriber
+                    SignedAt = DateTime(2026, 9, 11, 12, 0, 0, DateTimeKind.Utc)
+                }
+            PatientId = "stub-patient"
+            Base = None
+            Scenarios = [||]
+            Patient = patient
+            Verified = true
+        }
+
+    let challenged = Signing.Challenged("c-1", plan, None)
+    let submitting = Signing.Submitting("c-1", plan)
+    let requesting = Signing.Requesting(plan, None)
+
+    let transition = Signing.transition
+
+
+open Fixtures
+
+
+[<Tests>]
+let tests =
+    testList
+        "Signing.transition"
+        [
+            test "Sign from Idle asks the challenge over the plan; elsewhere it is a no-op" {
+                transition (SigningMsg.Sign plan) Signing.Idle
+                |> Expect.equal "asked" (requesting, [ SigningEffect.CallChallenge(plan, None) ])
+
+                for state in
+                    [
+                        requesting
+                        challenged
+                        submitting
+                        Signing.Noticed(
+                            plan,
+                            {
+                                Data = None
+                                Token = "d"
+                            }
+                        )
+                    ] do
+                    transition (SigningMsg.Sign plan) state |> Expect.equal $"{state}" (state, [])
+            }
+
+            test
+                "the challenge answered: issued opens the dialog, a notice asks, a refusal is told, the PIN limit ends the Session" {
+                transition (SigningMsg.ChallengeAnswered(Ok(SigningResponse.ChallengeIssued "c-1"))) requesting
+                |> Expect.equal "dialog" (challenged, [])
+
+                let notice =
+                    {
+                        Data = Some otherData
+                        Token = "d-1"
+                    }
+
+                transition (SigningMsg.ChallengeAnswered(Ok(SigningResponse.DataNotice notice))) requesting
+                |> Expect.equal "notice" (Signing.Noticed(plan, notice), [])
+
+                transition
+                    (SigningMsg.ChallengeAnswered(Ok(SigningResponse.Refused SigningRefusal.NotPrescriber)))
+                    requesting
+                |> Expect.equal "told" (Signing.Idle, [ SigningEffect.TellRefused SigningRefusal.NotPrescriber ])
+
+                transition
+                    (SigningMsg.ChallengeAnswered(Ok(SigningResponse.Refused SigningRefusal.PinLimit)))
+                    requesting
+                |> Expect.equal "ended" (Signing.Idle, [ SigningEffect.EndSession SessionEnding.WrongPinLimit ])
+
+                transition (SigningMsg.ChallengeAnswered(Error "down")) requesting
+                |> Expect.equal "transport" (Signing.Idle, [ SigningEffect.TellError "down" ])
+
+                // an answer lands only on the request in flight
+                for state in [ Signing.Idle; challenged; submitting ] do
+                    transition (SigningMsg.ChallengeAnswered(Ok(SigningResponse.ChallengeIssued "c-9"))) state
+                    |> Expect.equal $"{state}" (state, [])
+            }
+
+            test "a notice accepted: the challenge is asked again with the token, over the data as it stands (Rule 44)" {
+                let changed =
+                    {
+                        Data = Some otherData
+                        Token = "d-1"
+                    }
+
+                let shown = { plan with Patient = otherData }
+
+                transition SigningMsg.Accept (Signing.Noticed(plan, changed))
+                |> Expect.equal
+                    "over the reading"
+                    (Signing.Requesting(shown, Some "d-1"),
+                     [
+                         SigningEffect.SetPatient otherData
+                         SigningEffect.CallChallenge(shown, Some "d-1")
+                     ])
+
+                let unverified =
+                    {
+                        Data = None
+                        Token = "d-2"
+                    }
+
+                transition SigningMsg.Accept (Signing.Noticed(plan, unverified))
+                |> Expect.equal
+                    "over the opened data"
+                    (Signing.Requesting(plan, Some "d-2"), [ SigningEffect.CallChallenge(plan, Some "d-2") ])
+
+                for state in [ Signing.Idle; requesting; challenged; submitting ] do
+                    transition SigningMsg.Accept state |> Expect.equal $"{state}" (state, [])
+            }
+
+            test
+                "Confirm sends the PIN over the challenged plan, once at a time; Cancel drops the challenge but not a request in flight" {
+                transition (SigningMsg.Confirm "1234") challenged
+                |> Expect.equal "sent" (submitting, [ SigningEffect.CallSubmit(plan, "c-1", "1234") ])
+
+                transition (SigningMsg.Confirm "1234") submitting
+                |> Expect.equal "not twice" (submitting, [])
+
+                transition (SigningMsg.Confirm "1234") Signing.Idle
+                |> Expect.equal "nothing to confirm" (Signing.Idle, [])
+
+                for state in
+                    [
+                        requesting
+                        challenged
+                        Signing.Noticed(
+                            plan,
+                            {
+                                Data = None
+                                Token = "d"
+                            }
+                        )
+                    ] do
+                    transition SigningMsg.Cancel state |> Expect.equal $"{state}" (Signing.Idle, [])
+
+                transition SigningMsg.Cancel submitting
+                |> Expect.equal "in flight" (submitting, [])
+
+                transition SigningMsg.Cancel Signing.Idle
+                |> Expect.equal "idle" (Signing.Idle, [])
+            }
+
+            test
+                "the Submission answered: signed renews the token and is told; a wrong PIN or a lock keeps the dialog; the limit ends the Session; the rest is told" {
+                transition
+                    (SigningMsg.SubmitAnswered(Ok(SigningResponse.Submitted(signed, OpenedToken "t2"))))
+                    submitting
+                |> Expect.equal
+                    "signed"
+                    (Signing.Idle,
+                     [
+                         SigningEffect.RenewToken(OpenedToken "t2")
+                         SigningEffect.TellSigned signed
+                     ])
+
+                transition
+                    (SigningMsg.SubmitAnswered(Ok(SigningResponse.Refused(SigningRefusal.PinWrong 2))))
+                    submitting
+                |> Expect.equal "dialog kept" (Signing.Challenged("c-1", plan, Some(SigningRefusal.PinWrong 2)), [])
+
+                let until = DateTime(2026, 9, 11, 12, 1, 0, DateTimeKind.Utc)
+
+                transition
+                    (SigningMsg.SubmitAnswered(Ok(SigningResponse.Refused(SigningRefusal.Locked until))))
+                    submitting
+                |> Expect.equal
+                    "dialog kept, locked"
+                    (Signing.Challenged("c-1", plan, Some(SigningRefusal.Locked until)), [])
+
+                transition (SigningMsg.SubmitAnswered(Ok(SigningResponse.Refused SigningRefusal.PinLimit))) submitting
+                |> Expect.equal "ended" (Signing.Idle, [ SigningEffect.EndSession SessionEnding.WrongPinLimit ])
+
+                for refusal in
+                    [
+                        SigningRefusal.NoSession
+                        SigningRefusal.NoPatient
+                        SigningRefusal.NotPrescriber
+                        SigningRefusal.Blocked signed.Head
+                        SigningRefusal.StaleToken
+                        SigningRefusal.ChallengeMismatch
+                        SigningRefusal.ChallengeExpired
+                    ] do
+                    transition (SigningMsg.SubmitAnswered(Ok(SigningResponse.Refused refusal))) submitting
+                    |> Expect.equal $"{refusal}" (Signing.Idle, [ SigningEffect.TellRefused refusal ])
+
+                transition (SigningMsg.SubmitAnswered(Error "down")) submitting
+                |> Expect.equal "dialog back" (challenged, [ SigningEffect.TellError "down" ])
+
+                for state in [ Signing.Idle; requesting; challenged ] do
+                    transition
+                        (SigningMsg.SubmitAnswered(Ok(SigningResponse.Submitted(signed, OpenedToken "t2"))))
+                        state
+                    |> Expect.equal $"{state}" (state, [])
+            }
+
+            test "the plan submitted is the plan challenged, whatever the cart did meanwhile (ext 3b, 3c)" {
+                let state, _ = transition (SigningMsg.Sign plan) Signing.Idle
+
+                let state, _ =
+                    transition (SigningMsg.ChallengeAnswered(Ok(SigningResponse.ChallengeIssued "c-1"))) state
+                // the cart moved on: the machine never sees it
+                let _, effects = transition (SigningMsg.Confirm "1234") state
+
+                effects
+                |> Expect.equal "the challenged plan" [ SigningEffect.CallSubmit(plan, "c-1", "1234") ]
+            }
+        ]

--- a/tests/Informedica.GenPRES.Shared.Tests/SigningPolicyTests.fs
+++ b/tests/Informedica.GenPRES.Shared.Tests/SigningPolicyTests.fs
@@ -210,6 +210,7 @@ let tests =
                 |> Expect.isTrue "noticed"
 
                 dialogOpen (Signing.Challenged("c", plan, None)) |> Expect.isTrue "challenged"
-                dialogOpen (Signing.Submitting("c", plan)) |> Expect.isTrue "submitting"
+                dialogOpen (Signing.Submitting("c", plan, "k")) |> Expect.isTrue "submitting"
+                dialogOpen (Signing.Unsent("c", plan, "k")) |> Expect.isTrue "unsent"
             }
         ]

--- a/tests/Informedica.GenPRES.Shared.Tests/SigningPolicyTests.fs
+++ b/tests/Informedica.GenPRES.Shared.Tests/SigningPolicyTests.fs
@@ -1,0 +1,215 @@
+module Informedica.GenPRES.Shared.Tests.SigningPolicyTests
+
+open System
+open Expecto
+open Expecto.Flip
+open Shared
+open Shared.Types
+open SessionMachine
+open SigningMachine
+open SigningPolicy
+
+
+module Fixtures =
+
+    let patient = Shared.Models.Patient.empty
+
+    let userOf role =
+        {
+            UserId = "u"
+            DisplayName = "Stub Prescriber B"
+            Role = role
+        }
+
+    let openedAs role withPatient =
+        {
+            User = Some(userOf role)
+            PatientContext =
+                if withPatient then
+                    Some
+                        {
+                            PatientId = "p"
+                            Patient = patient
+                        }
+                else
+                    None
+            OpenedToken = Some(OpenedToken "t")
+            KeyThumbprint = Some "thumb"
+        }
+
+    let head =
+        {
+            Id = "plan-2"
+            No = 2
+            By = userOf UserRole.Prescriber
+            SignedAt = DateTime(2026, 9, 11, 12, 0, 0, DateTimeKind.Utc)
+        }
+
+    /// A translator that shows which term was asked for, so a test can assert terms, not prose.
+    let named (term: Terms) = $"<{term}>"
+
+
+open Fixtures
+
+
+[<Tests>]
+let tests =
+    testList
+        "SigningPolicy"
+        [
+            test "every signing term has an English default that is not its name" {
+                for term in
+                    [
+                        Terms.``Signing Sign``
+                        Terms.``Signing Dialog Title``
+                        Terms.``Signing Dialog Text``
+                        Terms.``Signing Pin``
+                        Terms.``Signing Cancel``
+                        Terms.``Signing Proceed``
+                        Terms.``Signing Signed``
+                        Terms.``Signing Data Changed``
+                        Terms.``Signing Data Unverified``
+                        Terms.``Signing Refusal No Session``
+                        Terms.``Signing Refusal No Patient``
+                        Terms.``Signing Refusal Not Prescriber``
+                        Terms.``Signing Refusal Blocked``
+                        Terms.``Signing Refusal Stale Token``
+                        Terms.``Signing Refusal Challenge Mismatch``
+                        Terms.``Signing Refusal Challenge Expired``
+                        Terms.``Signing Refusal Pin Wrong``
+                        Terms.``Signing Refusal Pin Limit``
+                        Terms.``Signing Refusal Locked``
+                    ] do
+                    english term |> Expect.notEqual $"default for {term}" $"{term}"
+
+                english Terms.``Session Ending Pin Limit``
+                |> Expect.equal
+                    "the session terms fall through"
+                    (SessionGatePolicy.english Terms.``Session Ending Pin Limit``)
+            }
+
+            test "one term per refusal; the block names the signer and the time, the tries and the lock are filled" {
+                let untilUtc = DateTime(2026, 9, 11, 12, 1, 0, DateTimeKind.Utc)
+
+                [
+                    SigningRefusal.NoSession, "<Signing Refusal No Session>"
+                    SigningRefusal.NoPatient, "<Signing Refusal No Patient>"
+                    SigningRefusal.NotPrescriber, "<Signing Refusal Not Prescriber>"
+                    SigningRefusal.Blocked head, "<Signing Refusal Blocked>"
+                    SigningRefusal.StaleToken, "<Signing Refusal Stale Token>"
+                    SigningRefusal.ChallengeMismatch, "<Signing Refusal Challenge Mismatch>"
+                    SigningRefusal.ChallengeExpired, "<Signing Refusal Challenge Expired>"
+                    SigningRefusal.PinWrong 2, "<Signing Refusal Pin Wrong>"
+                    SigningRefusal.PinLimit, "<Signing Refusal Pin Limit>"
+                    SigningRefusal.Locked untilUtc, "<Signing Refusal Locked>"
+                ]
+                |> List.iter (fun (refusal, term) -> refusalSentence named refusal |> Expect.equal $"{refusal}" term)
+
+                refusalSentence english (SigningRefusal.PinWrong 2)
+                |> Expect.equal "filled" "The PIN is not right. 2 tries left."
+
+                let blocked = refusalSentence english (SigningRefusal.Blocked head)
+
+                blocked
+                |> Expect.stringStarts "the signer" "Stub Prescriber B signed a newer version at "
+
+                blocked |> Expect.stringContains "a time of day" (time head.SignedAt)
+                time head.SignedAt |> Expect.isMatch "HH:mm" @"^\d{2}:\d{2}$"
+
+                refusalSentence english (SigningRefusal.Locked untilUtc)
+                |> Expect.equal "the lock" $"Signing is locked until {time untilUtc}."
+            }
+
+            test "the signed sentence names the version and the signer; the notice its case" {
+                let signed: SignedOrderPlan =
+                    {
+                        Head = head
+                        PatientId = "p"
+                        Base = Some "plan-1"
+                        Scenarios = [||]
+                        Patient = patient
+                        Verified = true
+                    }
+
+                signedSentence english signed
+                |> Expect.equal "filled" "Version 2 was signed by Stub Prescriber B."
+
+                signedSentence named signed |> Expect.equal "term" "<Signing Signed>"
+
+                noticeSentence
+                    named
+                    {
+                        Data = Some patient
+                        Token = "d"
+                    }
+                |> Expect.equal "changed" "<Signing Data Changed>"
+
+                noticeSentence
+                    named
+                    {
+                        Data = None
+                        Token = "d"
+                    }
+                |> Expect.equal "unverified" "<Signing Data Unverified>"
+            }
+
+            test "the PIN's own check is the enrolment's: four to six digits" {
+                for ok in [ "1234"; "123456" ] do
+                    pinError english ok |> Expect.isNone ok
+
+                for bad in [ "123"; "1234567"; "12a4"; "" ] do
+                    pinError named bad |> Expect.equal bad (Some "<Session Enrolment Pin Format>")
+            }
+
+            test "canSign: an open Session as Prescriber for a patient with at least one order" {
+                let withOrders =
+                    { Shared.Models.OrderPlan.create patient [||] with
+                        Scenarios = [| Unchecked.defaultof<OrderScenario> |]
+                    }
+
+                let empty = Shared.Models.OrderPlan.create patient [||]
+
+                canSign (Session.Open(openedAs UserRole.Prescriber true)) withOrders
+                |> Expect.isTrue "prescriber"
+
+                canSign (Session.Open(openedAs UserRole.Prescriber true)) empty
+                |> Expect.isFalse "nothing to sign"
+
+                canSign (Session.Open(openedAs UserRole.Reader true)) withOrders
+                |> Expect.isFalse "reader"
+
+                canSign (Session.Open(openedAs UserRole.Prescriber false)) withOrders
+                |> Expect.isFalse "no patient"
+
+                canSign (Session.Open { openedAs UserRole.Prescriber true with User = None }) withOrders
+                |> Expect.isFalse "anonymous"
+
+                for session in
+                    [
+                        Session.Anonymous
+                        Session.Resuming
+                        Session.Closing(openedAs UserRole.Prescriber true)
+                    ] do
+                    canSign session withOrders |> Expect.isFalse $"{session}"
+            }
+
+            test "the dialog is up while noticed, challenged or submitting" {
+                let plan = Shared.Models.OrderPlan.create patient [||]
+                dialogOpen Signing.Idle |> Expect.isFalse "idle"
+                dialogOpen (Signing.Requesting(plan, None)) |> Expect.isFalse "requesting"
+
+                dialogOpen (
+                    Signing.Noticed(
+                        plan,
+                        {
+                            Data = None
+                            Token = "d"
+                        }
+                    )
+                )
+                |> Expect.isTrue "noticed"
+
+                dialogOpen (Signing.Challenged("c", plan, None)) |> Expect.isTrue "challenged"
+                dialogOpen (Signing.Submitting("c", plan)) |> Expect.isTrue "submitting"
+            }
+        ]


### PR DESCRIPTION
## Summary

Plan [622](https://github.com/informedica/GenPRES/blob/master/docs/implementation-plans/622-signing-with-server-stubs.md) step 5: the client's signing machine, its texts, and the two session messages the signature needs. No view yet (step 6), so nothing a User sees changes; the machines are pure and tested in the shared test project.

- **`SigningMachine.fs`** (pure, next to `SessionMachine`): `Idle | Requesting | Noticed | Challenged | Submitting`. `Sign` asks the challenge; a data notice (Rule 44) is accepted by asking again with its token over the data as it stands, with a `SetPatient` so the cart follows the reading; `Confirm` submits the plan the challenge was issued over, never the live cart (ext 3b, 3c); a wrong PIN or a lock keeps the dialog with the refusal; `PinLimit` ends the Session; other refusals are told once; a transport error on the Submission brings the dialog back. The effects carry no OpenedToken and no idempotency key: the App interpreter (step 6) completes each call from the open Session (review on #623).
- **`SigningPolicy.fs`**: the English defaults (falling through to the session gate's), one sentence per refusal with the signer and time, the tries and the lock filled in, the signed and notice sentences, the enrolment's PIN check, `canSign` (an open Session as Prescriber for a patient with at least one order) and `dialogOpen`.
- **`SessionMachine.fs`**: `EndedByServer` from `Open` is `Ended` with the acknowledging close, as a resumed ending is (Rule 28); `TokenRenewed` replaces the open Session's token (Rule 34).
- **Terms**: nineteen `Signing …` cases, drafted in `Shared/Scripts/Localization.fsx` with English and Dutch (17 script tests) and migrated to `Localization.fs`.
- **Tests**: `SigningMachineTests` (6), `SigningPolicyTests` (6), `SessionMachineTests` (+2). Shared 452 (was 438), server 238, Fable and Fantomas green.

## Localization

Nineteen rows for the workbook (English, Dutch; the other languages empty):

```text
Signing Sign	Ondertekenen	Ondertekenen				
Signing Dialog Title	Onderteken het voorschrijfplan	Onderteken het voorschrijfplan				
Signing Dialog Text	Onderteken de voorschriften zoals getoond met uw pincode, of annuleer en pas aan.	Onderteken de voorschriften zoals getoond met uw pincode, of annuleer en pas aan.				
Signing Pin	Pincode	Pincode				
Signing Cancel	Annuleren	Annuleren				
Signing Proceed	Doorgaan	Doorgaan				
Signing Signed	Versie {0} is ondertekend door {1}.	Versie {0} is ondertekend door {1}.				
Signing Data Changed	De patiëntgegevens zijn gewijzigd sinds de sessie werd geopend. Ze worden getoond zoals ze nu zijn; ga door om daarover te ondertekenen, of annuleer.	De patiëntgegevens zijn gewijzigd sinds de sessie werd geopend. Ze worden getoond zoals ze nu zijn; ga door om daarover te ondertekenen, of annuleer.				
Signing Data Unverified	De patiëntgegevens konden niet worden geverifieerd. Ga door om te ondertekenen over de gegevens waarmee de sessie is geopend, of annuleer.	De patiëntgegevens konden niet worden geverifieerd. Ga door om te ondertekenen over de gegevens waarmee de sessie is geopend, of annuleer.				
Signing Refusal No Session	Er is geen sessie om in te ondertekenen. Open GenPRES opnieuw vanuit MainEHR.	Er is geen sessie om in te ondertekenen. Open GenPRES opnieuw vanuit MainEHR.				
Signing Refusal No Patient	Het plan hoort niet bij de patiënt van deze sessie.	Het plan hoort niet bij de patiënt van deze sessie.				
Signing Refusal Not Prescriber	Alleen een voorschrijver kan ondertekenen.	Alleen een voorschrijver kan ondertekenen.				
Signing Refusal Blocked	{0} heeft om {1} een nieuwere versie ondertekend. Open de patiënt opnieuw om daarvan verder te gaan.	{0} heeft om {1} een nieuwere versie ondertekend. Open de patiënt opnieuw om daarvan verder te gaan.				
Signing Refusal Stale Token	De sessie is niet actueel. Laad de pagina opnieuw.	De sessie is niet actueel. Laad de pagina opnieuw.				
Signing Refusal Challenge Mismatch	Het plan is gewijzigd sinds het werd getoond. Onderteken opnieuw.	Het plan is gewijzigd sinds het werd getoond. Onderteken opnieuw.				
Signing Refusal Challenge Expired	Het ondertekenen duurde te lang. Onderteken opnieuw.	Het ondertekenen duurde te lang. Onderteken opnieuw.				
Signing Refusal Pin Wrong	De pincode klopt niet. Nog {0} pogingen.	De pincode klopt niet. Nog {0} pogingen.				
Signing Refusal Pin Limit	De pincode is drie keer verkeerd ingevoerd. Uw sessie is beëindigd en ondertekenen is een tijdje geblokkeerd.	De pincode is drie keer verkeerd ingevoerd. Uw sessie is beëindigd en ondertekenen is een tijdje geblokkeerd.				
Signing Refusal Locked	Ondertekenen is geblokkeerd tot {0}.	Ondertekenen is geblokkeerd tot {0}.				
```

## AI-assisted contribution

- [x] Vibe coded: the machine, the policy and the tests written by Claude Code as direct client edits (the UI exception), the terms drafted in the localization script; verified with the shared and server test projects, the solution build, the Fable compile and Fantomas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZWjibQUW8uqCVbfV4vDTf
