### PR TITLE
feat(client): sign the order plan with the PIN (#622)

### DIFF
--- a/src/Informedica.GenPRES.Client/App.fs
+++ b/src/Informedica.GenPRES.Client/App.fs
@@ -13,6 +13,7 @@ open Shared.Types
 open Shared.Models
 open Global
 open SessionMachine
+open SigningMachine
 
 
 module private Elmish =
@@ -52,6 +53,8 @@ module private Elmish =
             LogAnalysisReport: Deferred<string>
             // the launch Session (plan 409); Anonymous is the state every URL patient runs in
             Session: Session
+            // the signing phase of the open Session (plan 622); Idle whenever no Session is open
+            Signing: Signing
             // what the server was configured with: the default language, the demo flag
             Settings: Deferred<Api.ServerSettings>
             // the url or the User chose the language (LanguagePolicy); the server default no
@@ -64,6 +67,7 @@ module private Elmish =
         | UrlChanged of string list
         | AcceptDisclaimer
         | SessionMsg of SessionMsg
+        | SigningMsg of SigningMsg
 
         | UpdatePage of Global.Pages
         | UpdatePatient of Patient option
@@ -480,6 +484,7 @@ module private Elmish =
             LogFiles = HasNotStartedYet
             LogAnalysisReport = HasNotStartedYet
             Session = Session.Anonymous
+            Signing = Signing.Idle
             Settings = HasNotStartedYet
             LanguageChosen = (LanguagePolicy.Language.initial lang).Chosen
         }
@@ -660,6 +665,66 @@ module private Elmish =
                 }
                 |> Async.StartImmediate
             )
+
+
+    /// One command per signing effect (plan 622). The machine names the plan, the challenge,
+    /// the PIN and the key; the OpenedToken comes from the open Session here (Rule 34). Without
+    /// an open Session nothing is sent: the answer is a refusal. What is told (signed, refused,
+    /// an error) is put on the snackbar by `update`, not here.
+    let interpretSigningEffect (session: Session) (effect: SigningEffect) : Cmd<Msg> =
+        let token =
+            match session with
+            | Session.Open opened -> opened.OpenedToken
+            | _ -> None
+
+        match effect with
+        | SigningEffect.CallChallenge(plan, notice) ->
+            match token with
+            | None ->
+                Cmd.ofMsg (
+                    SigningMsg(SigningMsg.ChallengeAnswered(Ok(SigningResponse.Refused SigningRefusal.NoSession)))
+                )
+            | Some opened ->
+                async {
+                    try
+                        let! answer =
+                            serverApi.processSigning (Api.SigningCommand.RequestSignChallenge(plan, opened, notice))
+
+                        return SigningMsg(SigningMsg.ChallengeAnswered(Ok answer))
+                    with ex ->
+                        return SigningMsg(SigningMsg.ChallengeAnswered(Error ex.Message))
+                }
+                |> Cmd.fromAsync
+        | SigningEffect.CallSubmit(plan, challenge, pin, key) ->
+            match token with
+            | None ->
+                Cmd.ofMsg (SigningMsg(SigningMsg.SubmitAnswered(Ok(SigningResponse.Refused SigningRefusal.NoSession))))
+            | Some opened ->
+                async {
+                    try
+                        let! answer =
+                            serverApi.processSigning (
+                                Api.SigningCommand.Submit
+                                    {
+                                        Plan = plan
+                                        Opened = opened
+                                        Challenge = challenge
+                                        Pin = pin
+                                        IdemKey = key
+                                    }
+                            )
+
+                        return SigningMsg(SigningMsg.SubmitAnswered(Ok answer))
+                    with ex ->
+                        return SigningMsg(SigningMsg.SubmitAnswered(Error ex.Message))
+                }
+                |> Cmd.fromAsync
+        | SigningEffect.RenewToken token -> Cmd.ofMsg (SessionMsg(SessionMsg.TokenRenewed token))
+        | SigningEffect.EndSession ending -> Cmd.ofMsg (SessionMsg(SessionMsg.EndedByServer ending))
+        | SigningEffect.SetPatient patient -> Cmd.ofMsg (UpdatePatient(Some patient))
+        | SigningEffect.TellSigned _
+        | SigningEffect.TellRefused _
+        | SigningEffect.TellError _ -> Cmd.none
 
 
     let update (msg: Msg) (state: State) =
@@ -977,7 +1042,50 @@ module private Elmish =
                     }
                 | _ -> state
 
-            { state with Session = session }, effects |> List.map interpretSessionEffect |> Cmd.batch
+            // a signature belongs to an open Session: whatever ends the Session drops it (ext 3e)
+            let signing =
+                match session with
+                | Session.Open _ -> state.Signing
+                | _ -> Signing.Idle
+
+            { state with
+                Session = session
+                Signing = signing
+            },
+            effects |> List.map interpretSessionEffect |> Cmd.batch
+
+        | SigningMsg msg ->
+            let signing, effects = Signing.transition msg state.Signing
+
+            let tr term =
+                Global.getLocalizedTerm state.Localization state.Context.Localization (SigningPolicy.english term) term
+
+            let tell message severity (state: State) =
+                { state with
+                    SnackbarMsg = message
+                    SnackbarOpen = true
+                    SnackbarSeverity = severity
+                }
+
+            let state =
+                effects
+                |> List.fold
+                    (fun state effect ->
+                        match effect with
+                        | SigningEffect.TellSigned signed ->
+                            state |> tell (SigningPolicy.signedSentence tr signed) "success"
+                        | SigningEffect.TellRefused refusal ->
+                            state |> tell (SigningPolicy.refusalSentence tr refusal) "warning"
+                        | SigningEffect.TellError reason ->
+                            Logging.error "could not send the signature to the server" reason
+
+                            state
+                            |> tell "De handtekening kon niet worden verstuurd. Probeer het opnieuw." "error"
+                        | _ -> state
+                    )
+                    state
+
+            { state with Signing = signing }, effects |> List.map (interpretSigningEffect state.Session) |> Cmd.batch
 
         | LoadLocalization Started ->
             { state with Localization = InProgress }, Cmd.fromAsync (GoogleDocs.loadLocalization LoadLocalization)
@@ -1411,6 +1519,22 @@ type private ConcreteAppEnv
 
         member _.SupplyPin code pin =
             SessionMsg(SessionMsg.SupplyPin(code, pin)) |> dispatch
+
+    interface AppEnv.ISigning with
+        member _.Signing = state.Signing
+
+        member _.Sign plan =
+            SigningMsg(SigningMsg.Sign plan) |> dispatch
+
+        member _.Accept() =
+            SigningMsg SigningMsg.Accept |> dispatch
+
+        // Rule 45: one key per confirmation; the machine keeps it for a retry
+        member _.Confirm pin =
+            SigningMsg(SigningMsg.Confirm(pin, Guid.NewGuid().ToString())) |> dispatch
+
+        member _.Cancel() =
+            SigningMsg SigningMsg.Cancel |> dispatch
 
     interface AppEnv.IAuthentication with
         member _.IsAuthenticated = state.IsAuthenticated

--- a/src/Informedica.GenPRES.Client/App.fs
+++ b/src/Informedica.GenPRES.Client/App.fs
@@ -668,9 +668,11 @@ module private Elmish =
 
 
     /// One command per signing effect (plan 622). The machine names the plan, the challenge,
-    /// the PIN and the key; the OpenedToken comes from the open Session here (Rule 34). Without
-    /// an open Session nothing is sent: the answer is a refusal. What is told (signed, refused,
-    /// an error) is put on the snackbar by `update`, not here.
+    /// the PIN, the request id and the key; the OpenedToken comes from the open Session here
+    /// (Rule 34), and every answer carries the request id or the key it answers, so the machine
+    /// can drop one that belongs to an earlier Session. Without an open Session nothing is sent:
+    /// the answer is a refusal. What is told (signed, refused, an error) is put on the snackbar
+    /// by `update`, not here.
     let interpretSigningEffect (session: Session) (effect: SigningEffect) : Cmd<Msg> =
         let token =
             match session with
@@ -678,11 +680,13 @@ module private Elmish =
             | _ -> None
 
         match effect with
-        | SigningEffect.CallChallenge(plan, notice) ->
+        | SigningEffect.CallChallenge(plan, notice, request) ->
             match token with
             | None ->
                 Cmd.ofMsg (
-                    SigningMsg(SigningMsg.ChallengeAnswered(Ok(SigningResponse.Refused SigningRefusal.NoSession)))
+                    SigningMsg(
+                        SigningMsg.ChallengeAnswered(request, Ok(SigningResponse.Refused SigningRefusal.NoSession))
+                    )
                 )
             | Some opened ->
                 async {
@@ -690,15 +694,17 @@ module private Elmish =
                         let! answer =
                             serverApi.processSigning (Api.SigningCommand.RequestSignChallenge(plan, opened, notice))
 
-                        return SigningMsg(SigningMsg.ChallengeAnswered(Ok answer))
+                        return SigningMsg(SigningMsg.ChallengeAnswered(request, Ok answer))
                     with ex ->
-                        return SigningMsg(SigningMsg.ChallengeAnswered(Error ex.Message))
+                        return SigningMsg(SigningMsg.ChallengeAnswered(request, Error ex.Message))
                 }
                 |> Cmd.fromAsync
         | SigningEffect.CallSubmit(plan, challenge, pin, key) ->
             match token with
             | None ->
-                Cmd.ofMsg (SigningMsg(SigningMsg.SubmitAnswered(Ok(SigningResponse.Refused SigningRefusal.NoSession))))
+                Cmd.ofMsg (
+                    SigningMsg(SigningMsg.SubmitAnswered(key, Ok(SigningResponse.Refused SigningRefusal.NoSession)))
+                )
             | Some opened ->
                 async {
                     try
@@ -714,9 +720,9 @@ module private Elmish =
                                     }
                             )
 
-                        return SigningMsg(SigningMsg.SubmitAnswered(Ok answer))
+                        return SigningMsg(SigningMsg.SubmitAnswered(key, Ok answer))
                     with ex ->
-                        return SigningMsg(SigningMsg.SubmitAnswered(Error ex.Message))
+                        return SigningMsg(SigningMsg.SubmitAnswered(key, Error ex.Message))
                 }
                 |> Cmd.fromAsync
         | SigningEffect.RenewToken token -> Cmd.ofMsg (SessionMsg(SessionMsg.TokenRenewed token))
@@ -1079,8 +1085,7 @@ module private Elmish =
                         | SigningEffect.TellError reason ->
                             Logging.error "could not send the signature to the server" reason
 
-                            state
-                            |> tell "De handtekening kon niet worden verstuurd. Probeer het opnieuw." "error"
+                            state |> tell (tr Terms.``Signing Send Failed``) "error"
                         | _ -> state
                     )
                     state
@@ -1523,8 +1528,9 @@ type private ConcreteAppEnv
     interface AppEnv.ISigning with
         member _.Signing = state.Signing
 
+        // one request id per Sign, so the answer lands on this request and no other
         member _.Sign plan =
-            SigningMsg(SigningMsg.Sign plan) |> dispatch
+            SigningMsg(SigningMsg.Sign(plan, Guid.NewGuid().ToString())) |> dispatch
 
         member _.Accept() =
             SigningMsg SigningMsg.Accept |> dispatch

--- a/src/Informedica.GenPRES.Client/AppEnv.fs
+++ b/src/Informedica.GenPRES.Client/AppEnv.fs
@@ -84,6 +84,20 @@ type ISession =
     abstract SupplyPin: string -> string -> unit
 
 
+/// The signing phase of the open Session (UC-3, plan 622): its state, and the actions the
+/// dialog offers on it
+[<Interface>]
+type ISigning =
+    abstract Signing: SigningMachine.Signing
+    // uc-03 step 2: the plan as shown
+    abstract Sign: OrderPlan -> unit
+    // Rule 44: the data notice accepted
+    abstract Accept: unit -> unit
+    // uc-03 step 3: the PIN; the idempotency key is minted here, once per confirmation
+    abstract Confirm: string -> unit
+    abstract Cancel: unit -> unit
+
+
 /// Authentication state and commands
 [<Interface>]
 type IAuthentication =

--- a/src/Informedica.GenPRES.Client/Informedica.GenPRES.Client.fsproj
+++ b/src/Informedica.GenPRES.Client/Informedica.GenPRES.Client.fsproj
@@ -44,6 +44,7 @@
     <Compile Include="./Views/Totals.fs" />
     <Compile Include="./Views/Prescribe.fs" />
     <Compile Include="./Views/Nutrition.fs" />
+    <Compile Include="./Views/SignDialog.fs" />
     <Compile Include="./Views/OrderPlan.fs" />
     <Compile Include="./Views/Formulary.fs" />
     <Compile Include="./Views/Parenteralia.fs" />

--- a/src/Informedica.GenPRES.Client/SigningMachine.fs
+++ b/src/Informedica.GenPRES.Client/SigningMachine.fs
@@ -1,12 +1,14 @@
 /// The signing phase of an open Session (uc-03 steps 2 and 3): a pure state machine next to
 /// the Session's, with effects for the App to interpret. The machine holds no OpenedToken: the
-/// effects name what it knows (the plan, the challenge, the PIN, the idempotency key), and
+/// effects name what it knows (the plan, the challenge, the PIN, the request and the key), and
 /// the interpreter completes each call from the open Session.
 ///
-/// Three invariants (ext 3b, 3c, 3d): what is submitted is the plan the challenge was issued
-/// over, held in the state, never the live cart; one request is in flight at a time; and a
+/// Four invariants (ext 3b, 3c, 3d): what is submitted is the plan the challenge was issued
+/// over, held in the state, never the live cart; one request is in flight at a time; a
 /// Submission whose answer was lost is sent again under the same key (Rule 45), so the server
-/// answers what it already did, landed or not.
+/// answers what it already did, landed or not; and an answer names the request it answers (the
+/// request id for a challenge, the key for a Submission) and lands only on that request, so an
+/// answer to a signature of an earlier Session never touches a later one.
 module SigningMachine
 
 open Shared.Types
@@ -15,8 +17,8 @@ open Shared.Types
 [<RequireQualifiedAccess>]
 type Signing =
     | Idle
-    // step 2 asked; the notice token when the User accepted a data notice (Rule 44)
-    | Requesting of OrderPlan * notice: string option
+    // step 2 asked under a request id; the notice token when the User accepted a data notice
+    | Requesting of OrderPlan * notice: string option * request: string
     // Rule 44: the data as it stands, to accept or to cancel
     | Noticed of OrderPlan * DataNotice
     // step 3: the dialog asks the PIN over this plan; the last refusal, if any
@@ -29,23 +31,24 @@ type Signing =
 
 [<RequireQualifiedAccess>]
 type SigningMsg =
-    | Sign of OrderPlan
-    // Error = transport failure
-    | ChallengeAnswered of Result<SigningResponse, string>
+    // the plan as shown, and a request id the caller minted
+    | Sign of OrderPlan * request: string
+    // the answer to the challenge request with this id; Error = transport failure
+    | ChallengeAnswered of request: string * Result<SigningResponse, string>
     // the data notice accepted: sign over the data as it stands
     | Accept
     // the PIN, and a fresh idempotency key the caller minted; ignored on a retry
     | Confirm of pin: string * key: string
     | Cancel
-    // Error = transport failure
-    | SubmitAnswered of Result<SigningResponse, string>
+    // the answer to the Submission under this key; Error = transport failure
+    | SubmitAnswered of key: string * Result<SigningResponse, string>
 
 
 [<RequireQualifiedAccess>]
 type SigningEffect =
-    // RequestSignChallenge, completed with the open Session's OpenedToken
-    | CallChallenge of OrderPlan * notice: string option
-    // Submit, completed with the open Session's OpenedToken
+    // RequestSignChallenge, completed with the open Session's OpenedToken; answered under the request id
+    | CallChallenge of OrderPlan * notice: string option * request: string
+    // Submit, completed with the open Session's OpenedToken; answered under the key
     | CallSubmit of OrderPlan * challenge: string * pin: string * key: string
     // the Session's token, re-minted over the new head (Rule 34)
     | RenewToken of OpenedToken
@@ -63,39 +66,45 @@ module Signing =
 
     let transition (msg: SigningMsg) (state: Signing) : Signing * SigningEffect list =
         match msg, state with
-        | SigningMsg.Sign plan, Signing.Idle ->
-            Signing.Requesting(plan, None), [ SigningEffect.CallChallenge(plan, None) ]
+        | SigningMsg.Sign(plan, request), Signing.Idle ->
+            Signing.Requesting(plan, None, request), [ SigningEffect.CallChallenge(plan, None, request) ]
         // one thing at a time
         | SigningMsg.Sign _, _ -> state, []
 
-        | SigningMsg.ChallengeAnswered(Ok(SigningResponse.ChallengeIssued challenge)), Signing.Requesting(plan, _) ->
+        // an answer lands only on the request it answers
+        | SigningMsg.ChallengeAnswered(answered, _), Signing.Requesting(_, _, request) when answered <> request ->
+            state, []
+        | SigningMsg.ChallengeAnswered(_, Ok(SigningResponse.ChallengeIssued challenge)), Signing.Requesting(plan, _, _) ->
             Signing.Challenged(challenge, plan, None), []
-        | SigningMsg.ChallengeAnswered(Ok(SigningResponse.DataNotice notice)), Signing.Requesting(plan, _) ->
+        | SigningMsg.ChallengeAnswered(_, Ok(SigningResponse.DataNotice notice)), Signing.Requesting(plan, _, _) ->
             Signing.Noticed(plan, notice), []
-        | SigningMsg.ChallengeAnswered(Ok(SigningResponse.Refused SigningRefusal.PinLimit)), Signing.Requesting _ ->
+        | SigningMsg.ChallengeAnswered(_, Ok(SigningResponse.Refused SigningRefusal.PinLimit)), Signing.Requesting _ ->
             Signing.Idle, [ SigningEffect.EndSession SessionEnding.WrongPinLimit ]
-        | SigningMsg.ChallengeAnswered(Ok(SigningResponse.Refused refusal)), Signing.Requesting _ ->
+        | SigningMsg.ChallengeAnswered(_, Ok(SigningResponse.Refused refusal)), Signing.Requesting _ ->
             Signing.Idle, [ SigningEffect.TellRefused refusal ]
         // never an answer to a challenge request
-        | SigningMsg.ChallengeAnswered(Ok(SigningResponse.Submitted _)), Signing.Requesting _ -> Signing.Idle, []
-        | SigningMsg.ChallengeAnswered(Error reason), Signing.Requesting _ ->
+        | SigningMsg.ChallengeAnswered(_, Ok(SigningResponse.Submitted _)), Signing.Requesting _ -> Signing.Idle, []
+        | SigningMsg.ChallengeAnswered(_, Error reason), Signing.Requesting _ ->
             Signing.Idle, [ SigningEffect.TellError reason ]
-        // an answer lands only on the request in flight
         | SigningMsg.ChallengeAnswered _, _ -> state, []
 
-        // Rule 44: the User signs over the data as it stands; with a reading, the cart follows it
+        // Rule 44: the User signs over the data as it stands; with a reading, the cart follows it.
+        // The notice token is the request id: one notice, one acceptance
         | SigningMsg.Accept, Signing.Noticed(plan, notice) ->
             match notice.Data with
             | Some data ->
                 let shown = { plan with Patient = data }
 
-                Signing.Requesting(shown, Some notice.Token),
+                Signing.Requesting(shown, Some notice.Token, notice.Token),
                 [
                     SigningEffect.SetPatient data
-                    SigningEffect.CallChallenge(shown, Some notice.Token)
+                    SigningEffect.CallChallenge(shown, Some notice.Token, notice.Token)
                 ]
             | None ->
-                Signing.Requesting(plan, Some notice.Token), [ SigningEffect.CallChallenge(plan, Some notice.Token) ]
+                Signing.Requesting(plan, Some notice.Token, notice.Token),
+                [
+                    SigningEffect.CallChallenge(plan, Some notice.Token, notice.Token)
+                ]
         | SigningMsg.Accept, _ -> state, []
 
         // step 3: the plan submitted is the plan challenged (ext 3b, 3c), under the caller's key
@@ -114,26 +123,28 @@ module Signing =
         | SigningMsg.Cancel, Signing.Unsent _ -> Signing.Idle, []
         | SigningMsg.Cancel, _ -> state, []
 
-        | SigningMsg.SubmitAnswered(Ok(SigningResponse.Submitted(signed, token))), Signing.Submitting _ ->
+        // an answer lands only on the Submission it answers
+        | SigningMsg.SubmitAnswered(answered, _), Signing.Submitting(_, _, key) when answered <> key -> state, []
+        | SigningMsg.SubmitAnswered(_, Ok(SigningResponse.Submitted(signed, token))), Signing.Submitting _ ->
             Signing.Idle,
             [
                 SigningEffect.RenewToken token
                 SigningEffect.TellSigned signed
             ]
         // the dialog stays open with what went wrong (Rule 28: tries left, or locked)
-        | SigningMsg.SubmitAnswered(Ok(SigningResponse.Refused(SigningRefusal.PinWrong _ as refusal))),
+        | SigningMsg.SubmitAnswered(_, Ok(SigningResponse.Refused(SigningRefusal.PinWrong _ as refusal))),
           Signing.Submitting(challenge, plan, _)
-        | SigningMsg.SubmitAnswered(Ok(SigningResponse.Refused(SigningRefusal.Locked _ as refusal))),
+        | SigningMsg.SubmitAnswered(_, Ok(SigningResponse.Refused(SigningRefusal.Locked _ as refusal))),
           Signing.Submitting(challenge, plan, _) -> Signing.Challenged(challenge, plan, Some refusal), []
-        | SigningMsg.SubmitAnswered(Ok(SigningResponse.Refused SigningRefusal.PinLimit)), Signing.Submitting _ ->
+        | SigningMsg.SubmitAnswered(_, Ok(SigningResponse.Refused SigningRefusal.PinLimit)), Signing.Submitting _ ->
             Signing.Idle, [ SigningEffect.EndSession SessionEnding.WrongPinLimit ]
-        | SigningMsg.SubmitAnswered(Ok(SigningResponse.Refused refusal)), Signing.Submitting _ ->
+        | SigningMsg.SubmitAnswered(_, Ok(SigningResponse.Refused refusal)), Signing.Submitting _ ->
             Signing.Idle, [ SigningEffect.TellRefused refusal ]
         // never an answer to a Submission
-        | SigningMsg.SubmitAnswered(Ok(SigningResponse.ChallengeIssued _)), Signing.Submitting _
-        | SigningMsg.SubmitAnswered(Ok(SigningResponse.DataNotice _)), Signing.Submitting _ -> Signing.Idle, []
+        | SigningMsg.SubmitAnswered(_, Ok(SigningResponse.ChallengeIssued _)), Signing.Submitting _
+        | SigningMsg.SubmitAnswered(_, Ok(SigningResponse.DataNotice _)), Signing.Submitting _ -> Signing.Idle, []
         // the answer was lost: whether the signature landed is unknown, so the dialog comes
         // back and the next Confirm retries under the same key (Rule 45)
-        | SigningMsg.SubmitAnswered(Error reason), Signing.Submitting(challenge, plan, key) ->
+        | SigningMsg.SubmitAnswered(_, Error reason), Signing.Submitting(challenge, plan, key) ->
             Signing.Unsent(challenge, plan, key), [ SigningEffect.TellError reason ]
         | SigningMsg.SubmitAnswered _, _ -> state, []

--- a/src/Informedica.GenPRES.Client/SigningPolicy.fs
+++ b/src/Informedica.GenPRES.Client/SigningPolicy.fs
@@ -35,6 +35,7 @@ let english (term: Terms) : string =
     | Terms.``Signing Refusal Pin Limit`` ->
         "The PIN was entered wrong three times. Your session was ended and signing is locked for a while."
     | Terms.``Signing Refusal Locked`` -> "Signing is locked until {0}."
+    | Terms.``Signing Send Failed`` -> "The signature could not be sent. Try again."
     | _ -> SessionGatePolicy.english term
 
 

--- a/src/Informedica.GenPRES.Client/Views/OrderPlan.fs
+++ b/src/Informedica.GenPRES.Client/Views/OrderPlan.fs
@@ -16,6 +16,8 @@ module OrderPlan =
         let envOrderPlan = AppEnv.asEnv<AppEnv.IOrderPlan> props.appEnv
         let orderPlan = envOrderPlan.OrderPlan
         let orderPlanCommand = envOrderPlan.OrderPlanCommand
+        let session = AppEnv.asEnv<AppEnv.ISession> props.appEnv
+        let signing = AppEnv.asEnv<AppEnv.ISigning> props.appEnv
 
         let updateOrderPlan tp =
             orderPlanCommand (Api.UpdateOrderPlan(tp, None))
@@ -52,6 +54,10 @@ module OrderPlan =
 
 
         let getTerm = Global.getLocalizedTerm localizationTerms lang
+
+        // the sheet's translation in the User's language, else the policy's English
+        let tr term =
+            Global.getLocalizedTerm localizationTerms lang (SigningPolicy.english term) term
 
         let columns =
             [|
@@ -354,6 +360,30 @@ module OrderPlan =
                 """
             | _ -> null
 
+        // UC-3: a Prescriber with an open Session signs the plan as shown (plan 622)
+        let onSign =
+            fun _ ->
+                match orderPlan with
+                | Resolved tp -> signing.Sign tp
+                | _ -> ()
+
+        let signBtn =
+            match orderPlan with
+            | Resolved tp when SigningPolicy.canSign session.Session tp ->
+                JSX.jsx
+                    $"""
+                import Button from '@mui/material/Button';
+
+                <Box sx={ {| marginTop = 2 |} }>
+                    <Button variant="contained" onClick={onSign} startIcon={Mui.Icons.Assignment} >
+                        {tr Terms.``Signing Sign``}
+                    </Button>
+                </Box>
+                """
+            | _ -> null
+
+        let signDialog = SignDialog.View {| appEnv = props.appEnv |}
+
         let responsiveTable =
             Components.ResponsiveTable.View
                 {|
@@ -390,6 +420,7 @@ module OrderPlan =
         import Modal from '@mui/material/Modal';
 
         <Box sx={ {| height = "100%" |} }>
+            {signBtn}
             {deleteBtn}
             {responsiveTable}
             <Modal open={modalOpen} onClose={handleModalClose} >
@@ -397,5 +428,6 @@ module OrderPlan =
                     {orderView}
                 </Box>
             </Modal>
+            {signDialog}
         </Box>
         """

--- a/src/Informedica.GenPRES.Client/Views/SignDialog.fs
+++ b/src/Informedica.GenPRES.Client/Views/SignDialog.fs
@@ -1,0 +1,239 @@
+namespace Views
+
+
+/// <summary>
+/// The signing dialog (uc-03 steps 2 and 3, plan 622): modal over the order plan while a
+/// challenge stands. It shows the orders exactly as they will be signed (Rule 43) and asks the
+/// PIN; sign as shown, or cancel and edit (ext 3b). Before a challenge, when the patient data
+/// changed or cannot be read, it is the data notice instead (Rule 44): continue over the data
+/// as it stands, or cancel. Every text is a Terms case; what the dialog offers comes from
+/// SigningPolicy, and what happens from the signing machine.
+/// </summary>
+module SignDialog =
+
+    open Fable.Core
+    open Fable.Core.JsInterop
+    open Feliz
+    open Shared
+    open Shared.Types
+    open Shared.Models
+    open SigningMachine
+    open SigningPolicy
+
+
+    [<JSX.Component>]
+    let View (props: {| appEnv: obj |}) =
+        let signing = AppEnv.asEnv<AppEnv.ISigning> props.appEnv
+        let terms = (AppEnv.asEnv<AppEnv.ILocalization> props.appEnv).LocalizationTerms
+        let context: Global.Context = React.useContext Global.context
+
+        // the sheet's translation in the User's language, else the policy's English
+        let tr term =
+            Global.getLocalizedTerm terms context.Localization (english term) term
+
+        let phase = signing.Signing
+        let isOpen = dialogOpen phase
+
+        // the PIN lives here until it is sent; a local check runs first, the server's answer
+        // comes back through the machine as the challenge's refusal
+        let pin, setPin = React.useState ""
+        let localError, setLocalError = React.useState<string option> None
+        // the server's answer is shown until the User edits the field; the next answer shows again
+        let edited, setEdited = React.useState false
+
+        // the field belongs to one signature: cleared whenever the dialog closes
+        React.useEffect (
+            (fun () ->
+                if not isOpen then
+                    setPin ""
+                    setLocalError None
+                    setEdited false
+            ),
+            [| box isOpen |]
+        )
+
+        let busy =
+            match phase with
+            | Signing.Submitting _ -> true
+            | _ -> false
+
+        // an answer arrived (the request in flight is over): show it, until the next edit
+        React.useEffect ((fun () -> setEdited false), [| box busy |])
+
+        let onPin (e: Browser.Types.Event) =
+            setPin (e.target?value: string)
+            setLocalError None
+            setEdited true
+
+        let confirm () =
+            match pinError tr pin with
+            | Some error -> setLocalError (Some error)
+            | None -> signing.Confirm pin
+
+        let onConfirm = fun _ -> confirm ()
+
+        let onKeyDown (e: Browser.Types.KeyboardEvent) =
+            if e.key = "Enter" then
+                confirm ()
+
+        let onCancel = fun _ -> signing.Cancel()
+        let onAccept = fun _ -> signing.Accept()
+
+        let refusal =
+            match phase with
+            | Signing.Challenged(_, _, refusal) -> refusal
+            | _ -> None
+
+        let error =
+            localError
+            |> Option.orElse (
+                if edited then
+                    None
+                else
+                    refusal |> Option.map (refusalSentence tr)
+            )
+
+        let notice =
+            match phase with
+            | Signing.Noticed(_, notice) -> Some notice
+            | _ -> None
+
+        let orders =
+            match phase with
+            | Signing.Noticed(plan, _)
+            | Signing.Challenged(_, plan, _)
+            | Signing.Submitting(_, plan, _)
+            | Signing.Unsent(_, plan, _) -> plan.Scenarios
+            | _ -> [||]
+
+        let body =
+            match notice with
+            | Some notice -> noticeSentence tr notice
+            | None -> tr Terms.``Signing Dialog Text``
+
+        // the orders as they will be signed: each scenario's prescription, one line per row
+        let orderList =
+            orders
+            |> Array.mapi (fun i sc ->
+                let rows =
+                    sc.Prescription
+                    |> TextBlock.flatten
+                    |> Array.mapi (fun j row ->
+                        let cells = row |> Array.map Mui.TypoGraphy.fromTextBlock
+
+                        JSX.jsx
+                            $"""
+                        <Box key={j} sx={ {|
+                                              display = "flex"
+                                              flexWrap = "wrap"
+                                              gap = 1
+                                          |} }>
+                            {cells}
+                        </Box>
+                        """
+                    )
+
+                JSX.jsx
+                    $"""
+                <ListItem key={i} divider={true}>
+                    <ListItemText primary={sc.Order.Orderable.Name} secondary={rows} />
+                </ListItem>
+                """
+            )
+
+        let pinField =
+            match notice with
+            | Some _ -> null
+            | None ->
+                let hasError = error.IsSome
+                let helper = error |> Option.defaultValue ""
+
+                JSX.jsx
+                    $"""
+                <TextField
+                    id="sign-dialog-pin"
+                    name="pin"
+                    autoFocus={true}
+                    margin="dense"
+                    label={tr Terms.``Signing Pin``}
+                    type="password"
+                    fullWidth={true}
+                    variant="outlined"
+                    value={pin}
+                    onChange={onPin}
+                    onKeyDown={onKeyDown}
+                    disabled={busy}
+                    error={hasError}
+                    helperText={helper}
+                    slotProps={ {|
+                                    htmlInput =
+                                        {|
+                                            inputMode = "numeric"
+                                            autoComplete = "current-password"
+                                            maxLength = 6
+                                        |}
+                                |} }
+                />
+                """
+
+        let progress =
+            if busy then
+                JSX.jsx
+                    $"""
+                <Box sx={ {| marginTop = 2 |} }>
+                    <CircularProgress size={24} />
+                </Box>
+                """
+            else
+                null
+
+        let primary =
+            match notice with
+            | Some _ ->
+                JSX.jsx
+                    $"""
+                <Button key="accept" variant="contained" color="primary" onClick={onAccept}>
+                    {tr Terms.``Signing Proceed``}
+                </Button>
+                """
+            | None ->
+                JSX.jsx
+                    $"""
+                <Button key="sign" variant="contained" color="primary" onClick={onConfirm} disabled={busy}>
+                    {tr Terms.``Signing Sign``}
+                </Button>
+                """
+
+        JSX.jsx
+            $"""
+        import Box from '@mui/material/Box';
+        import Button from '@mui/material/Button';
+        import CircularProgress from '@mui/material/CircularProgress';
+        import Dialog from '@mui/material/Dialog';
+        import DialogActions from '@mui/material/DialogActions';
+        import DialogContent from '@mui/material/DialogContent';
+        import DialogContentText from '@mui/material/DialogContentText';
+        import DialogTitle from '@mui/material/DialogTitle';
+        import List from '@mui/material/List';
+        import ListItem from '@mui/material/ListItem';
+        import ListItemText from '@mui/material/ListItemText';
+        import TextField from '@mui/material/TextField';
+
+        <Dialog open={isOpen} onClose={onCancel} fullWidth={true} maxWidth="sm" aria-labelledby="sign-dialog-title">
+            <DialogTitle id="sign-dialog-title">{tr Terms.``Signing Dialog Title``}</DialogTitle>
+            <DialogContent>
+                <DialogContentText>{body}</DialogContentText>
+                <List dense={true}>
+                    {orderList}
+                </List>
+                {pinField}
+                {progress}
+            </DialogContent>
+            <DialogActions>
+                <Button key="cancel" onClick={onCancel} disabled={busy}>
+                    {tr Terms.``Signing Cancel``}
+                </Button>
+                {primary}
+            </DialogActions>
+        </Dialog>
+        """

--- a/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
@@ -946,9 +946,10 @@ module Hop =
     /// OpenedToken this Session holds (Rule 34); the patient data re-read (Rule 44): when it is
     /// not what the Session opened with and no notice over this reading was accepted, no
     /// challenge yet but a `DataNotice`, replacing any earlier notice and dropping any earlier
-    /// challenge (it was over the data before the change); the plan over the data as
-    /// it stands (Rule 33); the record not moved on (Rule 20). Then a challenge over exactly
-    /// this plan (Rule 43), replacing the Session's earlier one and spending the notice. The
+    /// challenge (it was over the data before the change); the record not moved on (Rule 20).
+    /// Then a challenge over exactly this plan (Rule 43), replacing the Session's earlier one
+    /// and spending the notice. The plan's own patient data is what the User saw, entered or
+    /// read, and is recorded as such (Rule 44); the Patient is the Session's (Rule 33). The
     /// PIN is not involved: a refusal here costs no attempt (Rule 28).
     let challenge
         (now: DateTime)
@@ -1005,9 +1006,6 @@ module Hop =
                                 Data = current
                                 Token = nonce
                             }
-                    // unverified data: the plan stays over what the Session opened with
-                    elif plan.Patient <> (current |> Option.defaultValue patient.Patient) then
-                        refuse SigningRefusal.NoPatient
                     // Concept 10: no challenge over a plan that names an order twice
                     elif duplicateOrders plan.Scenarios then
                         refuse SigningRefusal.ChallengeMismatch

--- a/src/Informedica.GenPRES.Shared/Localization.fs
+++ b/src/Informedica.GenPRES.Shared/Localization.fs
@@ -198,6 +198,7 @@ type Terms =
     | ``Signing Refusal Pin Wrong``
     | ``Signing Refusal Pin Limit``
     | ``Signing Refusal Locked``
+    | ``Signing Send Failed``
 
 
 module Localization =

--- a/src/Informedica.GenPRES.Shared/Scripts/Localization.fsx
+++ b/src/Informedica.GenPRES.Shared/Scripts/Localization.fsx
@@ -91,6 +91,7 @@ type SessionTerms =
     | ``Signing Refusal Pin Wrong``
     | ``Signing Refusal Pin Limit``
     | ``Signing Refusal Locked``
+    | ``Signing Send Failed``
 
 
 /// The English defaults: the strings the client shows today, verbatim.
@@ -159,6 +160,7 @@ let english term =
     | ``Signing Refusal Pin Limit`` ->
         "The PIN was entered wrong three times. Your session was ended and signing is locked for a while."
     | ``Signing Refusal Locked`` -> "Signing is locked until {0}."
+    | ``Signing Send Failed`` -> "The signature could not be sent. Try again."
 
 
 /// Dutch, for the sheet; the other four languages stay empty and fall back to English.
@@ -229,6 +231,7 @@ let dutch term =
     | ``Signing Refusal Pin Limit`` ->
         "De pincode is drie keer verkeerd ingevoerd. Uw sessie is beëindigd en ondertekenen is een tijdje geblokkeerd."
     | ``Signing Refusal Locked`` -> "Ondertekenen is geblokkeerd tot {0}."
+    | ``Signing Send Failed`` -> "De handtekening kon niet worden verstuurd. Probeer het opnieuw."
 
 
 let all =

--- a/src/Informedica.GenPRES.Shared/Types.fs
+++ b/src/Informedica.GenPRES.Shared/Types.fs
@@ -720,7 +720,7 @@ module Types =
     type SigningRefusal =
         // no Session for the cookie, or none at all
         | NoSession
-        // the Session has no Patient, or the plan names other patient data (Rule 33)
+        // the Session has no Patient (ext 1a): nothing to sign for
         | NoPatient
         // nobody to sign as, or the Role is not Prescriber (Concept 7, Rule 38)
         | NotPrescriber

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -1954,7 +1954,8 @@ module SessionStubTests =
             testList
                 "Hop.challenge"
                 [
-                    test "refuses: no Session, the anonymous Session, no Patient, other patient data (Rule 33)" {
+                    test
+                        "refuses: no Session, the anonymous Session, no Patient; the plan's own data is the User's (Rules 33, 44)" {
                         stateOf [] [] |> ask t0 (counter "n") <| "s-9" <| (plan, token "s-9")
                         |> snd
                         |> Expect.equal "no session" (SigningResponse.Refused SigningRefusal.NoSession)
@@ -1971,11 +1972,12 @@ module SessionStubTests =
                         |> snd
                         |> Expect.equal "no patient" (SigningResponse.Refused SigningRefusal.NoPatient)
 
+                        // the data the User entered or saw is what the plan carries; the Patient is the Session's
                         stateOf [ opened ] [] |> ask t0 (counter "n")
                         <| "s-1"
                         <| (OrderPlan.create otherData [||], token "s-1")
                         |> snd
-                        |> Expect.equal "other data" (SigningResponse.Refused SigningRefusal.NoPatient)
+                        |> Expect.equal "entered data: issued" (SigningResponse.ChallengeIssued "n-1")
                     }
 
                     test "refuses a Reader (Rule 26) before the token is looked at, and a stale token (Rule 34)" {
@@ -2115,16 +2117,6 @@ module SessionStubTests =
                             stateOf [ changed ] [] |> ask t0 nonces
                             <| "s-1"
                             <| (OrderPlan.create otherData [||], token "s-1")
-
-                        askWith
-                            "n-1"
-                            (t0 + seconds 5.0)
-                            nonces
-                            state
-                            "s-1"
-                            (OrderPlan.create otherData [||], token "s-1")
-                        |> snd
-                        |> Expect.equal "not over the data told" (SigningResponse.Refused SigningRefusal.NoPatient)
 
                         let state, answer =
                             askWith "n-1" (t0 + seconds 5.0) nonces state "s-1" (plan, token "s-1")

--- a/tests/Informedica.GenPRES.Shared.Tests/SigningMachineTests.fs
+++ b/tests/Informedica.GenPRES.Shared.Tests/SigningMachineTests.fs
@@ -36,12 +36,18 @@ module Fixtures =
             Verified = true
         }
 
+    let requesting = Signing.Requesting(plan, None, "r-1")
     let challenged = Signing.Challenged("c-1", plan, None)
     let submitting = Signing.Submitting("c-1", plan, "k-1")
     let unsent = Signing.Unsent("c-1", plan, "k-1")
-    let requesting = Signing.Requesting(plan, None)
 
     let transition = Signing.transition
+
+    let issued request =
+        SigningMsg.ChallengeAnswered(request, Ok(SigningResponse.ChallengeIssued "c-1"))
+
+    let submitted key =
+        SigningMsg.SubmitAnswered(key, Ok(SigningResponse.Submitted(signed, OpenedToken "t2")))
 
 
 open Fixtures
@@ -52,9 +58,9 @@ let tests =
     testList
         "Signing.transition"
         [
-            test "Sign from Idle asks the challenge over the plan; elsewhere it is a no-op" {
-                transition (SigningMsg.Sign plan) Signing.Idle
-                |> Expect.equal "asked" (requesting, [ SigningEffect.CallChallenge(plan, None) ])
+            test "Sign from Idle asks the challenge over the plan under the request id; elsewhere it is a no-op" {
+                transition (SigningMsg.Sign(plan, "r-1")) Signing.Idle
+                |> Expect.equal "asked" (requesting, [ SigningEffect.CallChallenge(plan, None, "r-1") ])
 
                 for state in
                     [
@@ -70,13 +76,13 @@ let tests =
                             }
                         )
                     ] do
-                    transition (SigningMsg.Sign plan) state |> Expect.equal $"{state}" (state, [])
+                    transition (SigningMsg.Sign(plan, "r-9")) state
+                    |> Expect.equal $"{state}" (state, [])
             }
 
             test
                 "the challenge answered: issued opens the dialog, a notice asks, a refusal is told, the PIN limit ends the Session" {
-                transition (SigningMsg.ChallengeAnswered(Ok(SigningResponse.ChallengeIssued "c-1"))) requesting
-                |> Expect.equal "dialog" (challenged, [])
+                transition (issued "r-1") requesting |> Expect.equal "dialog" (challenged, [])
 
                 let notice =
                     {
@@ -84,29 +90,40 @@ let tests =
                         Token = "d-1"
                     }
 
-                transition (SigningMsg.ChallengeAnswered(Ok(SigningResponse.DataNotice notice))) requesting
+                transition (SigningMsg.ChallengeAnswered("r-1", Ok(SigningResponse.DataNotice notice))) requesting
                 |> Expect.equal "notice" (Signing.Noticed(plan, notice), [])
 
                 transition
-                    (SigningMsg.ChallengeAnswered(Ok(SigningResponse.Refused SigningRefusal.NotPrescriber)))
+                    (SigningMsg.ChallengeAnswered("r-1", Ok(SigningResponse.Refused SigningRefusal.NotPrescriber)))
                     requesting
                 |> Expect.equal "told" (Signing.Idle, [ SigningEffect.TellRefused SigningRefusal.NotPrescriber ])
 
                 transition
-                    (SigningMsg.ChallengeAnswered(Ok(SigningResponse.Refused SigningRefusal.PinLimit)))
+                    (SigningMsg.ChallengeAnswered("r-1", Ok(SigningResponse.Refused SigningRefusal.PinLimit)))
                     requesting
                 |> Expect.equal "ended" (Signing.Idle, [ SigningEffect.EndSession SessionEnding.WrongPinLimit ])
 
-                transition (SigningMsg.ChallengeAnswered(Error "down")) requesting
+                transition (SigningMsg.ChallengeAnswered("r-1", Error "down")) requesting
                 |> Expect.equal "transport" (Signing.Idle, [ SigningEffect.TellError "down" ])
-
-                // an answer lands only on the request in flight
-                for state in [ Signing.Idle; challenged; submitting; unsent ] do
-                    transition (SigningMsg.ChallengeAnswered(Ok(SigningResponse.ChallengeIssued "c-9"))) state
-                    |> Expect.equal $"{state}" (state, [])
             }
 
-            test "a notice accepted: the challenge is asked again with the token, over the data as it stands (Rule 44)" {
+            test
+                "an answer lands only on the request it answers: another request id, or no request in flight, is dropped" {
+                // a challenge asked by an earlier Session answers after a later one asked its own
+                transition (issued "r-old") requesting
+                |> Expect.equal "another request" (requesting, [])
+
+                transition
+                    (SigningMsg.ChallengeAnswered("r-old", Ok(SigningResponse.Refused SigningRefusal.PinLimit)))
+                    requesting
+                |> Expect.equal "not even the PIN limit" (requesting, [])
+
+                for state in [ Signing.Idle; challenged; submitting; unsent ] do
+                    transition (issued "r-1") state |> Expect.equal $"{state}" (state, [])
+            }
+
+            test
+                "a notice accepted: the challenge is asked again with the token as the request id, over the data as it stands (Rule 44)" {
                 let changed =
                     {
                         Data = Some otherData
@@ -118,10 +135,10 @@ let tests =
                 transition SigningMsg.Accept (Signing.Noticed(plan, changed))
                 |> Expect.equal
                     "over the reading"
-                    (Signing.Requesting(shown, Some "d-1"),
+                    (Signing.Requesting(shown, Some "d-1", "d-1"),
                      [
                          SigningEffect.SetPatient otherData
-                         SigningEffect.CallChallenge(shown, Some "d-1")
+                         SigningEffect.CallChallenge(shown, Some "d-1", "d-1")
                      ])
 
                 let unverified =
@@ -133,7 +150,8 @@ let tests =
                 transition SigningMsg.Accept (Signing.Noticed(plan, unverified))
                 |> Expect.equal
                     "over the opened data"
-                    (Signing.Requesting(plan, Some "d-2"), [ SigningEffect.CallChallenge(plan, Some "d-2") ])
+                    (Signing.Requesting(plan, Some "d-2", "d-2"),
+                     [ SigningEffect.CallChallenge(plan, Some "d-2", "d-2") ])
 
                 for state in [ Signing.Idle; requesting; challenged; submitting; unsent ] do
                     transition SigningMsg.Accept state |> Expect.equal $"{state}" (state, [])
@@ -174,9 +192,7 @@ let tests =
 
             test
                 "the Submission answered: signed renews the token and is told; a wrong PIN or a lock keeps the dialog; the limit ends the Session; the rest is told" {
-                transition
-                    (SigningMsg.SubmitAnswered(Ok(SigningResponse.Submitted(signed, OpenedToken "t2"))))
-                    submitting
+                transition (submitted "k-1") submitting
                 |> Expect.equal
                     "signed"
                     (Signing.Idle,
@@ -186,20 +202,22 @@ let tests =
                      ])
 
                 transition
-                    (SigningMsg.SubmitAnswered(Ok(SigningResponse.Refused(SigningRefusal.PinWrong 2))))
+                    (SigningMsg.SubmitAnswered("k-1", Ok(SigningResponse.Refused(SigningRefusal.PinWrong 2))))
                     submitting
                 |> Expect.equal "dialog kept" (Signing.Challenged("c-1", plan, Some(SigningRefusal.PinWrong 2)), [])
 
                 let until = DateTime(2026, 9, 11, 12, 1, 0, DateTimeKind.Utc)
 
                 transition
-                    (SigningMsg.SubmitAnswered(Ok(SigningResponse.Refused(SigningRefusal.Locked until))))
+                    (SigningMsg.SubmitAnswered("k-1", Ok(SigningResponse.Refused(SigningRefusal.Locked until))))
                     submitting
                 |> Expect.equal
                     "dialog kept, locked"
                     (Signing.Challenged("c-1", plan, Some(SigningRefusal.Locked until)), [])
 
-                transition (SigningMsg.SubmitAnswered(Ok(SigningResponse.Refused SigningRefusal.PinLimit))) submitting
+                transition
+                    (SigningMsg.SubmitAnswered("k-1", Ok(SigningResponse.Refused SigningRefusal.PinLimit)))
+                    submitting
                 |> Expect.equal "ended" (Signing.Idle, [ SigningEffect.EndSession SessionEnding.WrongPinLimit ])
 
                 for refusal in
@@ -212,29 +230,36 @@ let tests =
                         SigningRefusal.ChallengeMismatch
                         SigningRefusal.ChallengeExpired
                     ] do
-                    transition (SigningMsg.SubmitAnswered(Ok(SigningResponse.Refused refusal))) submitting
+                    transition (SigningMsg.SubmitAnswered("k-1", Ok(SigningResponse.Refused refusal))) submitting
                     |> Expect.equal $"{refusal}" (Signing.Idle, [ SigningEffect.TellRefused refusal ])
+            }
+
+            test
+                "a Submission's answer lands only under its key: an earlier Session's signature never touches a later one" {
+                // signed under another key: neither the token renewed nor the signature told
+                transition (submitted "k-old") submitting
+                |> Expect.equal "another key" (submitting, [])
+
+                transition
+                    (SigningMsg.SubmitAnswered("k-old", Ok(SigningResponse.Refused SigningRefusal.PinLimit)))
+                    submitting
+                |> Expect.equal "not even the PIN limit" (submitting, [])
 
                 for state in [ Signing.Idle; requesting; challenged; unsent ] do
-                    transition
-                        (SigningMsg.SubmitAnswered(Ok(SigningResponse.Submitted(signed, OpenedToken "t2"))))
-                        state
-                    |> Expect.equal $"{state}" (state, [])
+                    transition (submitted "k-1") state |> Expect.equal $"{state}" (state, [])
             }
 
             test
                 "a lost answer: the dialog comes back and the retry goes out under the same key, so the server answers what it did (Rule 45, ext 3d)" {
-                transition (SigningMsg.SubmitAnswered(Error "down")) submitting
+                transition (SigningMsg.SubmitAnswered("k-1", Error "down")) submitting
                 |> Expect.equal "unsent, told" (unsent, [ SigningEffect.TellError "down" ])
 
                 // the caller mints a fresh key; the machine keeps the one the lost Submission had
                 transition (SigningMsg.Confirm("1234", "k-fresh")) unsent
                 |> Expect.equal "same key" (submitting, [ SigningEffect.CallSubmit(plan, "c-1", "1234", "k-1") ])
 
-                // the signature had landed: the remembered answer is what comes back
-                transition
-                    (SigningMsg.SubmitAnswered(Ok(SigningResponse.Submitted(signed, OpenedToken "t2"))))
-                    submitting
+                // the signature had landed: the remembered answer is what comes back, under that key
+                transition (submitted "k-1") submitting
                 |> Expect.equal
                     "signed after all"
                     (Signing.Idle,
@@ -245,10 +270,8 @@ let tests =
             }
 
             test "the plan submitted is the plan challenged, whatever the cart did meanwhile (ext 3b, 3c)" {
-                let state, _ = transition (SigningMsg.Sign plan) Signing.Idle
-
-                let state, _ =
-                    transition (SigningMsg.ChallengeAnswered(Ok(SigningResponse.ChallengeIssued "c-1"))) state
+                let state, _ = transition (SigningMsg.Sign(plan, "r-1")) Signing.Idle
+                let state, _ = transition (issued "r-1") state
                 // the cart moved on: the machine never sees it
                 let _, effects = transition (SigningMsg.Confirm("1234", "k-1")) state
 

--- a/tests/Informedica.GenPRES.Shared.Tests/SigningPolicyTests.fs
+++ b/tests/Informedica.GenPRES.Shared.Tests/SigningPolicyTests.fs
@@ -79,6 +79,7 @@ let tests =
                         Terms.``Signing Refusal Pin Wrong``
                         Terms.``Signing Refusal Pin Limit``
                         Terms.``Signing Refusal Locked``
+                        Terms.``Signing Send Failed``
                     ] do
                     english term |> Expect.notEqual $"default for {term}" $"{term}"
 
@@ -196,7 +197,7 @@ let tests =
             test "the dialog is up while noticed, challenged or submitting" {
                 let plan = Shared.Models.OrderPlan.create patient [||]
                 dialogOpen Signing.Idle |> Expect.isFalse "idle"
-                dialogOpen (Signing.Requesting(plan, None)) |> Expect.isFalse "requesting"
+                dialogOpen (Signing.Requesting(plan, None, "r")) |> Expect.isFalse "requesting"
 
                 dialogOpen (
                     Signing.Noticed(


### PR DESCRIPTION
## Summary

Plan [622](https://github.com/informedica/GenPRES/blob/master/docs/implementation-plans/622-signing-with-server-stubs.md) step 6: the User can sign. With this, uc-03 runs end to end against the stubs.

- **`App.fs`**: `Signing` in the state, `SigningMsg`, and `interpretSigningEffect`: the machine's `CallChallenge` and `CallSubmit` are completed with the open Session's OpenedToken (Rule 34); `RenewToken` and `EndSession` become the session machine's `TokenRenewed` and `EndedByServer`; `SetPatient` follows a data notice into the patient; what is told (signed, refused, a transport error) goes on the snackbar from `update`, translated through the terms. A Session that stops being open drops the signing phase (ext 3e).
- **`AppEnv.ISigning`**: `Sign`, `Accept`, `Confirm` (mints one idempotency key per confirmation, Rule 45), `Cancel`.
- **`Views/OrderPlan.fs`**: a Sign button when `SigningPolicy.canSign` holds (an open Session as Prescriber for a patient, at least one order), sending the resolved `OrderPlan`.
- **`Views/SignDialog.fs`**: an MUI `Dialog` open while noticed, challenged, submitting or unsent: the orders as they will be signed (each scenario's prescription, Rule 43), the PIN field with the enrolment's local check, Cancel and Sign (disabled while the Submission is in flight), the server's refusal under the field until the next edit; or, for a data notice (Rule 44), the notice sentence with Continue and Cancel.
- **Server fix, found in the browser**: the challenge refused every plan whose patient data was not the data the Session opened with. In the demo the User has to enter age and weight because the stub platform has none, so nothing could be signed. Rule 33 is about the Patient's identity; the data the User saw is what the signed plan records (Rule 44). The data equality is gone from `Hop.challenge`; the two tests that asserted it now assert the challenge is issued. `NoPatient` remains for a Session without a Patient.

## Browser walk (`GENPRES_PROD=0 dotnet run`)

Launch `prescriber`, age 10 years, prescribe paracetamol oral tablet, plan page: **Ondertekenen** (the sheet's Dutch), the dialog lists the order as shown and asks the PIN. A wrong PIN keeps the dialog with "2 tries left"; `1234` closes it with "Versie 1 is ondertekend door Stub Prescriber." on the snackbar; signing again gives version 2, so the re-minted token is carried. Three wrong PINs: the dialog closes, the gate says the Session ended at the PIN limit, the Sign button and the person menu are gone, and continuing without a patient is offered. On the wire: `RequestSignChallenge` → `ChallengeIssued`, `Submit` (plan, opened token, challenge, PIN, key) → `Submitted` with version 1 and a fresh token.

Shared 453, server 238, Fable and Fantomas green.

## AI-assisted contribution

- [x] Vibe coded: the wiring, the dialog and the view edits written by Claude Code as direct client edits (the UI exception); the server fix and its tests are two edits to already migrated code; verified with the test projects, the Fable compile, Fantomas and the browser walk above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZWjibQUW8uqCVbfV4vDTf
