### PR TITLE
docs: record how plan 622 was built (#622)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -121,7 +121,7 @@ for the MailService too ([plan 615](docs/implementation-plans/615-enrolment-with
    Session opens as **Stub Prescriber (no PIN)**, and the outbox shows a second mail, "GenPRES:
    your PIN was set".
 4. Launch `no-pin` again, in this or another browser: the Session opens directly. The PIN lives
-   as long as the server runs. The seeded Prescribers (`prescriber`,
+   as long as the server runs. The seeded Prescribers (`prescriber`, `prescriber-b`,
    `prescriber-other-patient`) start with the PIN `1234`.
 
 Things worth trying here:
@@ -134,6 +134,43 @@ Things worth trying here:
   and a fresh launch mails a new code.
 - **Leaving**: **Close session** is not offered while enrolling; a relaunch replaces the
   attempt, and closing the tab abandons it.
+
+#### Signing an order plan
+
+A Prescriber signs the order plan with the PIN; signing is the only way anything reaches the
+record ([uc-03](docs/scenarios/integration/uc-03-prescribe-and-sign.md), Rules 42, 43). The
+demo keeps the record in memory
+([plan 622](docs/implementation-plans/622-signing-with-server-stubs.md)):
+
+1. Launch with the identity `prescriber`. The stub patient has no data, so give it an age in the
+   patient panel (a weight is estimated from it).
+2. Open **Voorschrijven** from the menu, pick a medication, a route, a form and an indication
+   (paracetamol, oral, tablet, mild pain will do), and press **Voorschrijven** on a scenario.
+3. Open **Behandel Plan**: the order is in the plan, with an **Ondertekenen** button above it.
+   Press it. The dialog lists the orders exactly as they will be signed and asks the PIN.
+4. Enter a wrong PIN: the dialog stays and says two tries are left. Enter `1234`: the dialog
+   closes and the snackbar says version 1 was signed by Stub Prescriber. Sign again: version 2.
+
+Things worth trying here:
+
+- **Three wrong PINs**: the dialog closes and the gate says the Session ended at the PIN limit;
+  the Sign button and the person menu are gone. Launch again: a right PIN inside the next minute
+  is refused as locked until a time, after that it signs. Every wrong entry past the third
+  doubles the delay, up to a day.
+- **Two browsers on one patient**: launch `prescriber-b` in another browser profile, prescribe
+  and sign there. The first browser's next **Ondertekenen** is refused: Stub Prescriber B signed
+  a newer version at that time (Rule 20). Launching the first identity again opens on the new
+  head, and signing works again.
+- **The patient without data**: launch with the PatientId `no-data`. The first **Ondertekenen**
+  is a notice instead of the dialog: the data could not be verified. **Doorgaan** asks the
+  challenge again with the notice accepted, and the version is signed as unverified (Rule 44).
+- **A Reader**: `reader` sees no Sign button.
+- **Watch the wire**: `RequestSignChallenge` answers `ChallengeIssued`, `Submit` answers
+  `Submitted` with the version and a fresh OpenedToken; the PIN travels in the Submission and
+  nowhere else, and never appears in the log. A Submission sent twice under the same key is
+  answered the same way once.
+- **Restart the server**: the record is gone with everything else; the next signature is
+  version 1 again.
 
 #### Things worth trying
 
@@ -154,8 +191,9 @@ Things worth trying here:
   and `/authorize` are 404, `/callback` redirects to `refused=invalid`.
 
 The stand-ins keep everything in memory: launches by nonce, sessions, endings, one-time codes,
-credentials and confirmation codes, the outbox. A restart forgets all of it: the browser's
-session cookie no longer finds a Session, and `no-pin` has to enrol again.
+credentials and confirmation codes, the outbox, the signed versions of every order plan. A
+restart forgets all of it: the browser's session cookie no longer finds a Session, `no-pin` has
+to enrol again, and the record starts from nothing.
 
 #### Cookies and the development proxy
 

--- a/docs/implementation-plans/409-client-launch-sequence.md
+++ b/docs/implementation-plans/409-client-launch-sequence.md
@@ -472,8 +472,13 @@ are listed per step with the reason.
 - The scope switch (#580), which retires the `IsProd` stop-gap.
 - On a launch URL the gate hides the language switcher; the language itself follows the
   server default since #601.
+- The head's orders into the cart at open (the second half of Rule 19) and Rule 21's notice
+  on every response.
 
 Closed since this list was written: the identity hop (`RedirectTo`, the callback, the `state`
 cookie), the Rule 8 and 11 endings, and the sealed Launch, all against server-hosted stubs
 ([plan 605](605-launch-with-server-stubs.md)); UC-2 enrolment against a stub MailService and an
-in-memory credential store ([plan 615](615-enrolment-with-server-stubs.md)).
+in-memory credential store ([plan 615](615-enrolment-with-server-stubs.md)); UC-3 signing
+against an in-memory record, the OpenedToken checked and re-minted at a signature and the
+Session opened with the head of the record
+([plan 622](622-signing-with-server-stubs.md)).

--- a/docs/implementation-plans/622-signing-with-server-stubs.md
+++ b/docs/implementation-plans/622-signing-with-server-stubs.md
@@ -184,9 +184,8 @@ active, PIN `1234`).
 
 `processCommand` unbound; `Keys.fs` without `sign`; the OpenedToken opaque on the wire; the
 head's orders not loaded into the cart at open (the second half of Rule 19) and Rule 21's
-notice on every response, both a follow-up plan; the DataNotice round trip (Rule 44, ext 2b)
-refused as `DataChanged`; Rule 41's out-of-time Session; the audit (Rule 46);
-`Integration.fsx`.
+notice on every response, both a follow-up plan; the KnowledgeRuleSet of Rule 44 (Concept 18);
+Rule 41's out-of-time Session; the audit (Rule 46); `Integration.fsx`.
 
 ## Confidence
 
@@ -245,3 +244,52 @@ the client, migration by the maintainer after review.
   blocked Submission leaves `WrongCount` unchanged. The version committed is the plan
   challenged, not the cart at the time of the PIN.
 - `dotnet run ServerTests`, the Fable compile and Fantomas stay green after every step.
+
+## As built
+
+Every step landed as one PR from a fork branch against `master`, script-first for the server
+and Shared code (`Server/Scripts/Signing.fsx`, rewritten for each step, and
+`Shared/Scripts/Localization.fsx`), reviewed and migrated by the maintainer, client edits
+direct. Every review round changed the design below; the deviations follow the table.
+
+| Step | PR | Landed |
+|------|----|--------|
+| plan | [#623](https://github.com/informedica/GenPRES/pull/623) | this document; review: the Submission carries the OpenedToken, the remembered answers are keyed by Session, the challenge lives two minutes, the machine's effects carry no token |
+| 1 | [#624](https://github.com/informedica/GenPRES/pull/624) | `OrderPlanHead`, `SignedOrderPlan`, `SessionEnding.WrongPinLimit`, the credential's lock, `Records`, `OpenedWith` at open; no change in behaviour; review: the lock capped at a day |
+| 2 | [#626](https://github.com/informedica/GenPRES/pull/626) | the challenge ladder, `SigningRefusal`, `DataNotice`, `SessionPort.challenge`, `processSigning`; review: a notice drops the standing challenge |
+| 3 | [#627](https://github.com/informedica/GenPRES/pull/627) | `Submission`, `Submitted`, `Hop.commit` in the model's order with the PIN last, the ending and its mail; review: a plan naming an order twice refused, the mail best effort |
+| 4 | [#628](https://github.com/informedica/GenPRES/pull/628) | `prescriber-b` |
+| 5 | [#629](https://github.com/informedica/GenPRES/pull/629) | `SigningMachine`, `SigningPolicy`, `EndedByServer` and `TokenRenewed`, nineteen `Terms`; review: `Unsent` and the kept key |
+| 6 | [#630](https://github.com/informedica/GenPRES/pull/630) | the wiring, the Sign button, `Views/SignDialog.fs`, a server fix found in the browser; review: answers land only on their request, a twentieth term |
+| 7 | this PR | uc-03 as-built note, uc-01, uc-02 and plan 409 updated, `DEVELOPMENT.md` signing walkthrough, this table |
+
+### Deviations from the text above
+
+- **Rule 44 is a notice, not a refusal.** Decided in review of step 2: a `DataChanged` refusal
+  would have left a Session unsignable for good, since the Session keeps the data it opened
+  with. The challenge answers `DataNotice { Data; Token }` with the data as it stands (`None`
+  when unreadable), the User proceeds by returning the token with the next request, and the
+  challenge records `Verified`. A wrong, spent, expired or unfitting notice token is a fresh
+  notice. The KnowledgeRuleSet is still not built.
+- **No equality between the plan's data and the Session's (Rule 33).** The challenge compared
+  them and refused `NoPatient`; in the demo the User enters age and weight because the stub
+  platform has none, so nothing could be signed (found in the browser walk of step 6). Rule 33
+  is the Patient's identity, which is the Session's; the data the User saw, entered or read, is
+  what the signed version records. `NoPatient` is only a Session without a Patient.
+- **The duplicate `Order.Id` check** was left out of step 3 for want of a fixture, then built on
+  review, at the challenge and at the commit, with a scenario the tests build by reflection.
+- **The lock is capped** at 24 hours (`Credential.lockMax`, review on #624): the model's delay
+  only grows because it decays with time, and the decay is not built.
+- **A notice drops the Session's standing challenge** (review on #626): it was over the data
+  before the change.
+- **The PIN-limit mail is best effort** (review on #627): the ending and the lock land whatever
+  the MailService does.
+- **The machine owns the request id and the key.** `Sign` and `Confirm` carry ids the App
+  mints; `Unsent` keeps the key of a Submission whose answer was lost, and the next `Confirm`
+  retries under it (Rule 45, review on #629); every answer names the request id or the key it
+  answers and lands only there, so a signature of an earlier Session never touches a later one
+  (review on #630). `CallSubmit` carries the key; the interpreter adds only the OpenedToken.
+- **The cart follows a notice's reading.** `Accept` with a reading sets the patient, so the
+  plan the User signs is over the data they were shown.
+- **Twenty terms, not about twelve**: one per refusal, the notice in both cases, the signed
+  sentence, and one for a transport failure at a signature.

--- a/docs/scenarios/integration/uc-01-launch.md
+++ b/docs/scenarios/integration/uc-01-launch.md
@@ -302,15 +302,21 @@ Where the code departs from the text above, on purpose:
 The PIN detour of 5.4 is built too: a Prescriber without a PIN suspends into
 [uc-02](uc-02-enrolment.md) and continues once the PIN is set (its as-built note is there).
 
-Not built: step 7 (the signed request and the OpenedToken check), the audit (Rule 46), the
-newest TreatmentPlan of 5.6, and the absolute lifetime and idle endings of Rule 10.
+Since [plan 622](../../implementation-plans/622-signing-with-server-stubs.md) the Session
+opens with the head of the record (5.6, Rule 19) and the OpenedToken is checked and re-minted
+at a signature (Rule 34); the head's orders are not yet loaded into the cart at open.
+
+Not built: step 7 (the signed request), the audit (Rule 46), and the absolute lifetime and idle
+endings of Rule 10.
 
 ## Left out
 
 - **The PIN detour.** A Prescriber with no PIN is not refused: the launch suspends into UC-2
   and continues at 5.5 once the PIN is set.
 - **The audit.** Every launch, honored or refused, is appended to the audit (Rule 46).
-- **Everything after the launch**: prescribing and signing, and the ten other use cases.
+- **Everything after the launch**: prescribing and signing
+  ([uc-03](uc-03-prescribe-and-sign.md), built against stubs since plan 622), and the nine
+  other use cases.
 - **The confirmation code.** UC-2 and UC-6 mail a code to set or replace a PIN. It is not the
   authorization code of step 4, which never leaves the browser and the two servers.
 

--- a/docs/scenarios/integration/uc-02-enrolment.md
+++ b/docs/scenarios/integration/uc-02-enrolment.md
@@ -122,8 +122,9 @@ Where the code departs from the text above, on purpose:
 - **The Client's form** does the cheap checks first (six digits, four to six digits, the repeat
   agrees) and shows the server's answer as the field's error until the User edits it.
 
-Not built: the audit (Rule 46), and the wrong-PIN limit at signing (Rule 28's count is kept and
-reset, nothing reads it yet).
+Not built: the audit (Rule 46). The wrong-PIN limit at signing (Rule 28) is built by
+[plan 622](../../implementation-plans/622-signing-with-server-stubs.md); see
+[uc-03](uc-03-prescribe-and-sign.md#as-built-against-stubs).
 
 ---
 

--- a/docs/scenarios/integration/uc-03-prescribe-and-sign.md
+++ b/docs/scenarios/integration/uc-03-prescribe-and-sign.md
@@ -82,10 +82,11 @@ token — is refused before the PIN is looked at, so it costs the User no attemp
 - **A new KnowledgeRuleSet** (ext 1b). Published mid-Session, it reaches the next
   computation, and the challenge is issued under it. The signed plan records which set.
 - **The Patient Data changing** (ext 2b). No challenge is issued until the User has seen
-  the data as it now stands, or been told it could not be checked, and accepted it.
+  the data as it now stands, or been told it could not be checked, and accepted it. Built as
+  a notice with a token (below).
 - **The wrong PIN** (ext 3a). No TreatmentPlan is committed and no token is spent. Wrong entries
   count across Sessions; at the limit the Session ends and signing locks for a growing
-  delay.
+  delay. Built, with the delay capped (below).
 - **Canceling and editing** (ext 3b), **someone else at the keyboard** (ext 3c), **a late
   or repeated Submission** (ext 3d), and **never signing at all** (ext 3e).
 - **The audit.** Every Submission, committed or refused, is appended (Rule 46).
@@ -118,6 +119,49 @@ sequenceDiagram
     S-->>C: Computed
     Note over U,C: editing is possible again, and the next signature<br/>asks for a challenge of its own
 ```
+
+## As built against stubs
+
+Steps 2 and 3 run in the demo server since
+[plan 622](../../implementation-plans/622-signing-with-server-stubs.md), on the stand-ins of
+[uc-01](uc-01-launch.md#as-built-against-stubs) and [uc-02](uc-02-enrolment.md#as-built-against-stubs)
+plus the record half of the Database: the signed versions per patient, in memory, and a
+second stub Prescriber, `prescriber-b`, so that the record can move on under a Session. The
+stub registry is asked again at every commit (Rule 38). The walkthrough is in
+[DEVELOPMENT.md](../../../DEVELOPMENT.md#signing-an-order-plan). In the code the TreatmentPlan
+is the `OrderPlan`, and a signed version of it a `SignedOrderPlan`.
+
+Where the code departs from the text above, on purpose:
+
+- **Step 1 is not session-bound.** Compute reads no SessionRecord and touches nothing
+  (Rule 9 belongs to the idle lifetime, not built); it keeps working without a launch (UC-7).
+  Only steps 2 and 3 need the Session the cookie names.
+- **The challenge is kept, not sealed.** One per Session on the server's state, two minutes,
+  replaced by a re-request and dropped by a data notice; a Submission must name its nonce and
+  carry exactly the plan it was issued over (Rule 43: the orders and the patient data compared
+  as values). The OpenedToken is opaque too: a Submission must present the one the Session
+  holds, and the commit re-mints it over the new head (Rule 34). Both are sealed when the
+  store leaves the process.
+- **The data notice has no token type of its own.** When the platform reads other data than
+  the Session opened with, or none, the answer is a notice with the data as it stands and a
+  token; the User proceeds by returning it, and the challenge records whether the data was the
+  platform's reading. The KnowledgeRuleSet (Concept 18) is not built.
+- **The plan's data is the User's.** What the User entered or was shown is what the signed
+  version records; the Patient is the Session's (Rule 33). Nothing compares the plan's data
+  with the Session's.
+- **The lock is one minute, doubling, capped at a day.** The model's delay decays with time;
+  the cap stands in for the decay.
+- **The Role re-take fails closed.** A registry that cannot answer refuses the signature;
+  Rule 38's bounded grace is not built.
+- **Rule 45 by Session and key.** The remembered answers are looked up under the Session and
+  the client's key, refusals too, for two minutes; the Client keeps the key of a Submission
+  whose answer was lost and retries under it.
+- **The Client's dialog** shows the orders as they will be signed and asks the PIN; a wrong
+  PIN or a lock keeps it open, the PIN limit ends the Session and the gate says why, every
+  other refusal is told once. An answer lands only on the request it answers.
+
+Not built: the audit (Rule 46), and Rule 21's notice on every response (the record moving on is
+told at the challenge and at the commit only).
 
 ---
 


### PR DESCRIPTION
## Summary

Plan [622](https://github.com/informedica/GenPRES/blob/master/docs/implementation-plans/622-signing-with-server-stubs.md) step 7, docs only. With #630 merged, UC-3 runs end to end against the stubs; this writes down how it was built and where it departs from the plan and the design.

- **Plan 622**: the as-built table (#623 to #630) and nine deviations, each from a review round or the browser walk: Rule 44 as a notice with a token, no equality between the plan's data and the Session's (Rule 33 is the Patient's identity), the duplicate order check built after all, the lock capped at a day, a notice dropping the standing challenge, the best-effort mail, the machine owning the request id and the key (with `Unsent` and the Rule 45 retry), the cart following a notice's reading, twenty terms. "What stays as is" no longer names a `DataChanged` refusal.
- **uc-03**: an "As built against stubs" section in uc-02's shape: what stands in, eight deliberate departures (Compute unbound, the challenge and token kept rather than sealed, the notice without its own token type, the User's data, the capped lock, the fail-closed Role re-take, Rule 45 by Session and key, the dialog), and what is not built (the audit, Rule 21's notice on every response). The ext 2b and ext 3a bullets say they are built.
- **uc-01**: the Session opens with the head and the OpenedToken is checked and re-minted at a signature; "Left out" points to uc-03.
- **uc-02**: the wrong-PIN limit is no longer "not built".
- **Plan 409**: UC-3 in "Closed since"; the head's orders at open and Rule 21's notice added as open.
- **DEVELOPMENT.md**: "Signing an order plan" between the enrolment walkthrough and the things worth trying: the walkthrough as run in Chrome for #630, then three wrong PINs, two browsers on one patient (`prescriber-b`, Rule 20), the `no-data` notice, a Reader, the wire, a restart. `prescriber-b` joins the seeded-PIN sentence and the record joins the in-memory list.

Not in this PR, decided with the maintainer: renaming the design's TreatmentPlan to OrderPlan across the integration docs and `Integration.fsx` (19 files, about 340 occurrences) is a separate docs PR; WorkPlan stays the design's word; the page's `Treatment Plan` term key is a code and workbook matter for a follow-up.

markdownlint: no new issues; the pre-existing trailing spaces in `DEVELOPMENT.md` stand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZWjibQUW8uqCVbfV4vDTf
