### PR TITLE
feat(server): carry the OpenedToken and the notice on Compute (#635)

### DIFF
--- a/src/Informedica.GenPRES.Client/App.fs
+++ b/src/Informedica.GenPRES.Client/App.fs
@@ -120,7 +120,7 @@ module private Elmish =
         | LoadLogAnalysisResult of ApiResponse
 
 
-    and ApiResponse = AsyncOperationStatus<Result<Api.Response, string[]>>
+    and ApiResponse = AsyncOperationStatus<Result<Api.Reply, string[]>>
 
 
     let serverApi =
@@ -151,16 +151,36 @@ module private Elmish =
         |> Cmd.fromAsync
 
 
-    let createApiMsg msg cmd =
+    /// The OpenedToken the Session holds, sent with every computing request (Rule 34); none
+    /// without an open Session.
+    let tokenOf (session: Session) =
+        match session with
+        | Session.Open opened -> opened.OpenedToken
+        | _ -> None
+
+
+    let createApiMsg (opened: OpenedToken option) msg cmd =
         async {
-            let! result = serverApi.processCommand cmd
+            let! result =
+                serverApi.processCommand (
+                    {
+                        Opened = opened
+                        Command = cmd
+                    }
+                    : Api.Request
+                )
+
             return Finished result |> msg
         }
         |> Cmd.fromAsync
 
 
-    let processApiMsg (state: State) msg =
-        match msg with
+    let processApiMsg (state: State) (reply: Api.Reply) =
+        // plan 635 PR 1: the notice is carried and logged, not shown yet
+        reply.Notice
+        |> Option.iter (fun notice -> Logging.warning "record notice" notice)
+
+        match reply.Response with
         | Api.OrderContextResp(Api.OrderContextResult ctx) -> { state with OrderContext = Resolved ctx }, Cmd.none
         | Api.OrderPlanResp(Api.OrderPlanFiltered tp)
         | Api.OrderPlanResp(Api.OrderPlanUpdated tp) ->
@@ -215,17 +235,20 @@ module private Elmish =
             { state with LogAnalysisReport = Resolved report }, Cmd.none
 
 
-    let loadOrderContext resp =
-        Api.OrderContextCmd >> createApiMsg resp
+    let loadOrderContext opened resp =
+        Api.OrderContextCmd >> createApiMsg opened resp
 
 
-    let loadOrderPlan resp = Api.OrderPlanCmd >> createApiMsg resp
+    let loadOrderPlan opened resp =
+        Api.OrderPlanCmd >> createApiMsg opened resp
 
 
-    let loadFormuarly = Api.FormularyCmd >> createApiMsg LoadFormulary
+    let loadFormuarly opened =
+        Api.FormularyCmd >> createApiMsg opened LoadFormulary
 
 
-    let loadParenteralia = Api.ParenteraliaCmd >> createApiMsg LoadParenteralia
+    let loadParenteralia opened =
+        Api.ParenteraliaCmd >> createApiMsg opened LoadParenteralia
 
 
     // url needs to be in format: http://localhost:8080/#patient?by=2&bm=0&bd=1
@@ -674,10 +697,7 @@ module private Elmish =
     /// the answer is a refusal. What is told (signed, refused, an error) is put on the snackbar
     /// by `update`, not here.
     let interpretSigningEffect (session: Session) (effect: SigningEffect) : Cmd<Msg> =
-        let token =
-            match session with
-            | Session.Open opened -> opened.OpenedToken
-            | _ -> None
+        let token = tokenOf session
 
         match effect with
         | SigningEffect.CallChallenge(plan, notice, request) ->
@@ -828,7 +848,7 @@ module private Elmish =
         | Login password ->
             state,
             Api.LogAnalyzerCmd(Api.ValidatePassword password)
-            |> createApiMsg LoadLoginResult
+            |> createApiMsg (tokenOf state.Session) LoadLoginResult
 
         | LoadLoginResult(Finished(Ok resp)) -> processOk resp
 
@@ -855,7 +875,7 @@ module private Elmish =
         | ListLogFiles ->
             { state with LogFiles = InProgress },
             Api.LogAnalyzerCmd(Api.ListLogFiles state.AuthToken)
-            |> createApiMsg LoadLogFilesResult
+            |> createApiMsg (tokenOf state.Session) LoadLogFilesResult
 
         | LoadLogFilesResult(Finished(Ok resp)) -> processOk resp
 
@@ -867,7 +887,7 @@ module private Elmish =
         | AnalyzeLogFile fileName ->
             { state with LogAnalysisReport = InProgress },
             Api.LogAnalyzerCmd(Api.AnalyzeLogFile(state.AuthToken, fileName))
-            |> createApiMsg LoadLogAnalysisResult
+            |> createApiMsg (tokenOf state.Session) LoadLogAnalysisResult
 
         | LoadLogAnalysisResult(Finished(Ok resp)) -> processOk resp
 
@@ -1200,7 +1220,7 @@ module private Elmish =
                 | Api.ReloadResources pw ->
                     { state with OrderContext = HasNotStartedYet },
                     (Api.ReloadResources pw, OrderContext.empty)
-                    |> loadOrderContext (fun resp -> LoadOrderContextResult(cmd, resp))
+                    |> loadOrderContext (tokenOf state.Session) (fun resp -> LoadOrderContextResult(cmd, resp))
                 | _ -> { state with OrderContext = HasNotStartedYet }, Cmd.none
             | Some pat ->
                 match state.OrderContext with
@@ -1209,11 +1229,11 @@ module private Elmish =
                 | HasNotStartedYet ->
                     { state with OrderContext = InProgress },
                     (cmd, OrderContext.empty |> OrderContext.setPatient pat)
-                    |> loadOrderContext (fun resp -> LoadOrderContextResult(cmd, resp))
+                    |> loadOrderContext (tokenOf state.Session) (fun resp -> LoadOrderContextResult(cmd, resp))
                 | Resolved ctx ->
                     { state with OrderContext = Recalculating ctx },
                     (cmd, { ctx with Patient = pat })
-                    |> loadOrderContext (fun resp -> LoadOrderContextResult(cmd, resp))
+                    |> loadOrderContext (tokenOf state.Session) (fun resp -> LoadOrderContextResult(cmd, resp))
 
         | LoadOrderContextResult(_, Finished(Ok msg)) -> msg |> processOk
         | LoadOrderContextResult(_, Finished(Error err)) ->
@@ -1243,7 +1263,7 @@ module private Elmish =
                 | _ ->
                     { state with OrderPlan = Recalculating tp },
                     Api.OrderPlanCmd(Api.UpdateOrderPlan(tp, Some(ctxCmd, ctx)))
-                    |> createApiMsg (fun resp -> LoadOrderPlanResult(tpCmd, resp))
+                    |> createApiMsg (tokenOf state.Session) (fun resp -> LoadOrderPlanResult(tpCmd, resp))
             | Api.UpdateOrderPlan(tp, None) ->
                 let onlySetOrderContext =
                     state.OrderPlan
@@ -1295,7 +1315,8 @@ module private Elmish =
                         | Api.UpdateOrderPlan(_, ctxOpt) -> Api.UpdateOrderPlan(OrderPlan.create pat [||], ctxOpt)
 
                     { state with OrderPlan = InProgress },
-                    apiCmd |> loadOrderPlan (fun resp -> LoadOrderPlanResult(cmd, resp))
+                    apiCmd
+                    |> loadOrderPlan (tokenOf state.Session) (fun resp -> LoadOrderPlanResult(cmd, resp))
                 | Resolved tp ->
                     let apiCmd =
                         match cmd with
@@ -1303,7 +1324,8 @@ module private Elmish =
                         | Api.UpdateOrderPlan(_, ctxOpt) -> Api.UpdateOrderPlan(tp, ctxOpt)
 
                     { state with OrderPlan = InProgress },
-                    apiCmd |> loadOrderPlan (fun resp -> LoadOrderPlanResult(cmd, resp))
+                    apiCmd
+                    |> loadOrderPlan (tokenOf state.Session) (fun resp -> LoadOrderPlanResult(cmd, resp))
 
         | LoadOrderPlanResult(_, Finished(Ok msg)) -> msg |> processOk
         | LoadOrderPlanResult(_, Finished(Error err)) ->
@@ -1317,7 +1339,7 @@ module private Elmish =
 
             { state with NutritionPlan = planState },
             Api.NutritionPlanCmd npCmd
-            |> createApiMsg (fun resp -> LoadNutritionPlanResult(npCmd, resp))
+            |> createApiMsg (tokenOf state.Session) (fun resp -> LoadNutritionPlanResult(npCmd, resp))
 
         | LoadNutritionPlanResult(_, Started) -> state, Cmd.none
         | LoadNutritionPlanResult(_, Finished(Ok msg)) -> msg |> processOk
@@ -1333,7 +1355,7 @@ module private Elmish =
                     | Resolved form -> { form with Patient = state.Patient }
                     | _ -> Formulary.empty
 
-                let cmd = form |> loadFormuarly
+                let cmd = form |> loadFormuarly (tokenOf state.Session)
 
                 { state with Formulary = InProgress }, cmd
 
@@ -1373,7 +1395,7 @@ module private Elmish =
                 let cmd =
                     let par = state.Parenteralia |> Deferred.defaultValue Parenteralia.empty
 
-                    loadParenteralia par
+                    loadParenteralia (tokenOf state.Session) par
 
                 { state with Parenteralia = InProgress }, cmd
 
@@ -1419,7 +1441,7 @@ module private Elmish =
             else
                 { state with Interactions = InProgress },
                 Api.InteractionCmd(Api.CheckInteractions drugs)
-                |> createApiMsg LoadInteractionsResult
+                |> createApiMsg (tokenOf state.Session) LoadInteractionsResult
 
         | LoadInteractionsResult(Finished(Ok msg)) -> msg |> processOk
         | LoadInteractionsResult(Finished(Error err)) ->
@@ -1431,7 +1453,8 @@ module private Elmish =
             | InProgress -> state, Cmd.none
             | _ ->
                 { state with InteractionDrugNames = InProgress },
-                Api.InteractionCmd Api.GetDrugNames |> createApiMsg LoadInteractionDrugNames
+                Api.InteractionCmd Api.GetDrugNames
+                |> createApiMsg (tokenOf state.Session) LoadInteractionDrugNames
 
         | LoadInteractionDrugNames(Finished(Ok msg)) ->
             let state, cmd = msg |> processOk

--- a/src/Informedica.GenPRES.Server/Scripts/Compute.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/Compute.fsx
@@ -1,0 +1,322 @@
+// Compute bound to the Session (plan 635), PR 1: the request and reply envelopes, the Session
+// marked seen, and the notice that the record moved on. No visible change yet: the client sends
+// the token and logs the notice.
+//
+// Script-first draft (script-only policy) of:
+//   - the wire: `RecordNotice` → `Shared/Types.fs`; `Request`, `Reply` and
+//     `IServerApi.processCommand: Request -> Async<Result<Reply, string[]>>` → `Shared/Api.fs`;
+//   - `Hop`: `SessionRecord.Seen` (Rule 9), `touch`, `seen` (Rules 11, 21, 22) → `Adapters.fs`,
+//     with `touch` applied by every port member that takes the session cookie's id (`find`,
+//     `challenge`, `submit`, `seen`; `close` excepted, as the model excepts `CloseSession`);
+//   - `SessionPort.seen` → `Ports.fs`; `processCommand` reading the cookie → `CompositionRoot.fs`.
+//
+// Only what changes is re-stated: the state here has the three fields `seen` reads. Run:
+// `dotnet fsi Compute.fsx` from this directory (build first).
+
+#I __SOURCE_DIRECTORY__
+#r "nuget: Expecto, 10.2.3"
+
+#load "load.fsx"
+
+open System
+open Shared.Types
+open Shared.Models
+open ServerApi
+
+
+// ---------------------------------------------------------------------------------------------
+// Wire (→ Shared/Types.fs, Shared/Api.fs)
+// ---------------------------------------------------------------------------------------------
+
+/// What a reply says about the Session next to its result. Rules 21, 22: a version newer than
+/// the one the request's OpenedToken names exists, whose and when; it gates nothing. Rule 11:
+/// the server ended this Session, told at the next request.
+[<RequireQualifiedAccess>]
+type RecordNotice =
+    | NewerVersion of OrderPlanHead
+    | Ended of SessionEnding
+
+
+/// Every computing request: the command and the OpenedToken the Session holds (Rule 34).
+/// `None` where there is none to send: no Session, an anonymous one, or a client acting before
+/// its first token arrived.
+type Request =
+    {
+        Opened: OpenedToken option
+        Command: Shared.Api.Command
+    }
+
+
+/// Every computing reply: the result, and what the Session is told with it.
+type Reply =
+    {
+        Response: Shared.Api.Response
+        Notice: RecordNotice option
+    }
+
+
+// ---------------------------------------------------------------------------------------------
+// The Session seen, and the notice (→ ServerApi.Adapters.fs, `Hop`)
+// ---------------------------------------------------------------------------------------------
+
+module Hop =
+
+    /// A Session as the store holds it: what the client learns, the login it belongs to
+    /// (Rule 8), the head of the record it opened with (Rule 19), and when it was last seen
+    /// (Rule 9; nothing acts on it yet).
+    type SessionRecord =
+        {
+            Session: SessionOpened
+            Login: string option
+            OpenedWith: string option
+            Seen: DateTime
+        }
+
+
+    /// The state of PR 1: only the fields `seen` reads.
+    type State =
+        {
+            Sessions: Map<string, SessionRecord>
+            Endings: Map<string, SessionEnding * DateTime>
+            Records: Map<string, SignedOrderPlan list>
+        }
+
+
+    let emptyState =
+        {
+            Sessions = Map.empty
+            Endings = Map.empty
+            Records = Map.empty
+        }
+
+
+    /// Rule 19: the most recent signed version of a patient's record, if any.
+    let headOf (patientId: string) (state: State) =
+        state.Records |> Map.tryFind patientId |> Option.bind List.tryHead
+
+
+    /// Rule 20: the head of the record, when it is not the version the Session opened with.
+    let blockedBy (record: SessionRecord) (patientId: string) (state: State) =
+        match headOf patientId state with
+        | Some head when Some head.Head.Id <> record.OpenedWith -> Some head.Head
+        | _ -> None
+
+
+    /// Rule 9: a request from the Session refreshes its idle clock. Nothing to refresh when
+    /// there is no such Session.
+    let touch (now: DateTime) (sid: string) (state: State) : State =
+        { state with Sessions = state.Sessions |> Map.change sid (Option.map (fun r -> { r with Seen = now })) }
+
+
+    /// uc-03 step 1, for every computing request that names a Session: no Session under this
+    /// id and an ending recorded for it, the ending (Rule 11); a Session, touched, and Rule 21's
+    /// comparison when the token is the Session's own: a newer version than the one it opened
+    /// with, whose and when (Rule 22: told, never enforced). An anonymous Session, one without
+    /// a Patient, no head, or a token that is not the Session's: nothing to say.
+    let seen (now: DateTime) (sid: string) (opened: OpenedToken option) (state: State) : State * RecordNotice option =
+        match state.Sessions |> Map.tryFind sid with
+        | None ->
+            state, state.Endings |> Map.tryFind sid |> Option.map (fst >> RecordNotice.Ended)
+        | Some record ->
+            let state = touch now sid state
+
+            match record.Session.User, record.Session.PatientContext with
+            | Some _, Some patient when opened.IsSome && opened = record.Session.OpenedToken ->
+                state, blockedBy record patient.PatientId state |> Option.map RecordNotice.NewerVersion
+            | _ -> state, None
+
+
+// ---------------------------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------------------------
+
+open Expecto
+open Expecto.Flip
+
+
+let t0 = DateTime(2026, 9, 11, 12, 0, 0, DateTimeKind.Utc)
+let t1 = t0.AddMinutes 5.0
+
+let prescriber =
+    {
+        UserId = "prescriber"
+        DisplayName = "Stub Prescriber"
+        Role = UserRole.Prescriber
+    }
+
+let other =
+    { prescriber with
+        UserId = "prescriber-b"
+        DisplayName = "Stub Prescriber B"
+    }
+
+
+let signedBy (user: UserContext) no (at: DateTime) : SignedOrderPlan =
+    {
+        Head =
+            {
+                Id = $"plan-{no}"
+                No = no
+                By = user
+                SignedAt = at
+            }
+        PatientId = "pat-1"
+        Base = if no > 1 then Some $"plan-{no - 1}" else None
+        Scenarios = [||]
+        Patient = Patient.empty
+        Verified = true
+    }
+
+
+let session (user: UserContext option) (patientId: string option) (sid: string) (openedWith: string option) : Hop.SessionRecord =
+    {
+        Session =
+            {
+                User = user
+                PatientContext =
+                    patientId
+                    |> Option.map (fun pid ->
+                        {
+                            PatientId = pid
+                            Patient = Patient.empty
+                        }
+                    )
+                OpenedToken = Some(OpenedToken $"opened-{sid}")
+                KeyThumbprint = Some "t"
+            }
+        Login = user |> Option.map _.UserId
+        OpenedWith = openedWith
+        Seen = t0
+    }
+
+
+let withSession (record: Hop.SessionRecord) sid (state: Hop.State) =
+    { state with Sessions = state.Sessions |> Map.add sid record }
+
+let withRecord patientId (versions: SignedOrderPlan list) (state: Hop.State) =
+    { state with Records = state.Records |> Map.add patientId versions }
+
+let own sid = Some(OpenedToken $"opened-{sid}")
+
+
+let tests =
+    testList
+        "seen (Rules 9, 11, 21, 22)"
+        [
+            test "an unknown Session with no ending: nothing to say, nothing touched" {
+                let state, notice = Hop.emptyState |> Hop.seen t1 "s-1" (own "s-1")
+                notice |> Expect.isNone "no notice"
+                state |> Expect.equal "unchanged" Hop.emptyState
+            }
+
+            test "an unknown Session with an ending recorded: the ending (Rule 11)" {
+                let state =
+                    { Hop.emptyState with
+                        Endings = Map.ofList [ "s-1", (SessionEnding.SupersededByLaunch, t0) ]
+                    }
+
+                let _, notice = state |> Hop.seen t1 "s-1" (own "s-1")
+
+                notice
+                |> Expect.equal "ended" (Some(RecordNotice.Ended SessionEnding.SupersededByLaunch))
+            }
+
+            test "a Session is touched by every seen request (Rule 9)" {
+                let state =
+                    Hop.emptyState
+                    |> withSession (session (Some prescriber) (Some "pat-1") "s-1" None) "s-1"
+
+                let state, _ = state |> Hop.seen t1 "s-1" None
+                state.Sessions["s-1"].Seen |> Expect.equal "seen now" t1
+            }
+
+            test "touching an unknown Session changes nothing" {
+                Hop.emptyState |> Hop.touch t1 "s-9" |> Expect.equal "unchanged" Hop.emptyState
+            }
+
+            test "the Session's own token, no head: nothing to say" {
+                let state =
+                    Hop.emptyState
+                    |> withSession (session (Some prescriber) (Some "pat-1") "s-1" None) "s-1"
+
+                let _, notice = state |> Hop.seen t1 "s-1" (own "s-1")
+                notice |> Expect.isNone "no notice"
+            }
+
+            test "the Session's own token, the head it opened with: nothing to say" {
+                let state =
+                    Hop.emptyState
+                    |> withRecord "pat-1" [ signedBy prescriber 1 t0 ]
+                    |> withSession (session (Some prescriber) (Some "pat-1") "s-1" (Some "plan-1")) "s-1"
+
+                let _, notice = state |> Hop.seen t1 "s-1" (own "s-1")
+                notice |> Expect.isNone "no notice"
+            }
+
+            test "the Session's own token, a newer head: whose and when (Rules 21, 22)" {
+                let state =
+                    Hop.emptyState
+                    |> withRecord "pat-1" [ signedBy other 2 t1; signedBy prescriber 1 t0 ]
+                    |> withSession (session (Some prescriber) (Some "pat-1") "s-1" (Some "plan-1")) "s-1"
+
+                let state, notice = state |> Hop.seen t1 "s-1" (own "s-1")
+
+                notice
+                |> Expect.equal "newer version" (Some(RecordNotice.NewerVersion (signedBy other 2 t1).Head))
+
+                state.Sessions["s-1"].OpenedWith
+                |> Expect.equal "nothing opened: Rule 20 stays the guard" (Some "plan-1")
+            }
+
+            test "a Session opened from nothing, a first version signed elsewhere: a notice" {
+                let state =
+                    Hop.emptyState
+                    |> withRecord "pat-1" [ signedBy other 1 t1 ]
+                    |> withSession (session (Some prescriber) (Some "pat-1") "s-1" None) "s-1"
+
+                let _, notice = state |> Hop.seen t1 "s-1" (own "s-1")
+                notice |> Expect.isSome "newer version"
+            }
+
+            test "a token that is not the Session's, a newer head: nothing to say, still touched" {
+                let state =
+                    Hop.emptyState
+                    |> withRecord "pat-1" [ signedBy other 2 t1; signedBy prescriber 1 t0 ]
+                    |> withSession (session (Some prescriber) (Some "pat-1") "s-1" (Some "plan-1")) "s-1"
+
+                let state, notice = state |> Hop.seen t1 "s-1" (own "s-2")
+                notice |> Expect.isNone "no notice"
+                state.Sessions["s-1"].Seen |> Expect.equal "seen" t1
+
+                let _, notice = state |> Hop.seen t1 "s-1" None
+                notice |> Expect.isNone "no token, no notice"
+            }
+
+            test "an anonymous Session, or one without a Patient: nothing to say" {
+                let state =
+                    Hop.emptyState
+                    |> withRecord "pat-1" [ signedBy other 2 t1 ]
+                    |> withSession (session None (Some "pat-1") "s-a" None) "s-a"
+                    |> withSession (session (Some prescriber) None "s-n" None) "s-n"
+
+                let _, notice = state |> Hop.seen t1 "s-a" (own "s-a")
+                notice |> Expect.isNone "anonymous"
+
+                let _, notice = state |> Hop.seen t1 "s-n" (own "s-n")
+                notice |> Expect.isNone "no patient"
+            }
+
+            test "the notice is stateless: the same request says it again" {
+                let state =
+                    Hop.emptyState
+                    |> withRecord "pat-1" [ signedBy other 2 t1; signedBy prescriber 1 t0 ]
+                    |> withSession (session (Some prescriber) (Some "pat-1") "s-1" (Some "plan-1")) "s-1"
+
+                let state, first = state |> Hop.seen t1 "s-1" (own "s-1")
+                let _, second = state |> Hop.seen (t1.AddMinutes 1.0) "s-1" (own "s-1")
+                second |> Expect.equal "again" first
+            }
+        ]
+
+
+runTestsWithCLIArgs [] [||] tests |> ignore

--- a/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
@@ -401,13 +401,15 @@ module Hop =
 
 
     /// A Session as the store holds it: what the client learns, the login it belongs to
-    /// (Rule 8: a User has at most one open Session), and the head of the record it opened
-    /// with (Rule 19; `None` from nothing), which a Submission is checked against (Rule 20).
+    /// (Rule 8: a User has at most one open Session), the head of the record it opened with
+    /// (Rule 19; `None` from nothing), which a Submission is checked against (Rule 20), and
+    /// when it was last seen (Rule 9; nothing acts on it yet, Rule 10's lifetimes are not built).
     type SessionRecord =
         {
             Session: SessionOpened
             Login: string option
             OpenedWith: string option
+            Seen: DateTime
         }
 
 
@@ -628,6 +630,7 @@ module Hop =
                         Session = session
                         Login = login
                         OpenedWith = headOf patientId state |> Option.map _.Head.Id
+                        Seen = now
                     }
             Endings =
                 superseded
@@ -914,9 +917,16 @@ module Hop =
                     state, SupplyPinResult.Opened(id, session)
 
 
-    let find (id: string) (state: State) : State * SessionLookup =
+    /// Rule 9: a request from the Session refreshes its idle clock. Applied by every member that
+    /// takes the session cookie's id, `close` excepted (the model excepts `CloseSession`).
+    /// Nothing to refresh when there is no such Session.
+    let touch (now: DateTime) (sid: string) (state: State) : State =
+        { state with Sessions = state.Sessions |> Map.change sid (Option.map (fun r -> { r with Seen = now })) }
+
+
+    let find (now: DateTime) (id: string) (state: State) : State * SessionLookup =
         match state.Sessions |> Map.tryFind id with
-        | Some record -> state, SessionLookup.Found record.Session
+        | Some record -> touch now id state, SessionLookup.Found record.Session
         | None ->
             match state.Endings |> Map.tryFind id with
             | Some(ending, _) -> state, SessionLookup.Ended ending
@@ -935,6 +945,24 @@ module Hop =
         match headOf patientId state with
         | Some head when Some head.Head.Id <> record.OpenedWith -> Some head.Head
         | _ -> None
+
+
+    /// uc-03 step 1, for every computing request that names a Session: no Session under this
+    /// id and an ending recorded for it, the ending (Rule 11); a Session, touched, and Rule 21's
+    /// comparison when the token is the Session's own: a version newer than the one it opened
+    /// with, whose and when (Rule 22: told, never enforced; Rule 20 stays the only guard). An
+    /// anonymous Session, one without a Patient, no head, or a token that is not the Session's:
+    /// nothing to say.
+    let seen (now: DateTime) (sid: string) (opened: OpenedToken option) (state: State) : State * RecordNotice option =
+        match state.Sessions |> Map.tryFind sid with
+        | None -> state, state.Endings |> Map.tryFind sid |> Option.map (fst >> RecordNotice.Ended)
+        | Some record ->
+            let state = touch now sid state
+
+            match record.Session.User, record.Session.PatientContext with
+            | Some _, Some patient when opened.IsSome && opened = record.Session.OpenedToken ->
+                state, blockedBy record patient.PatientId state |> Option.map RecordNotice.NewerVersion
+            | _ -> state, None
 
 
     /// Concept 10: an order appears once in a plan.
@@ -960,7 +988,7 @@ module Hop =
         (state: State)
         : State * SigningResponse
         =
-        let state = dropExpired now state
+        let state = dropExpired now state |> touch now sid
         let refuse refusal = state, SigningResponse.Refused refusal
 
         match state.Sessions |> Map.tryFind sid with
@@ -1052,7 +1080,7 @@ module Hop =
         (state: State)
         : State * SigningResponse
         =
-        let state = dropExpired now state
+        let state = dropExpired now state |> touch now sid
         let refuse refusal = state, SigningResponse.Refused refusal
 
         match state.Sessions |> Map.tryFind sid with
@@ -1243,7 +1271,7 @@ module Hop =
                                     cb
                             )
                     }
-            find = fun id -> async { return update (find id) }
+            find = fun id -> async { return update (find (now ()) id) }
             close = fun id -> async { return update (fun s -> close id s, ()) }
             findEnrolment = fun attempt -> async { return update (findEnrolment (now ()) attempt) }
             supplyPin =
@@ -1274,6 +1302,7 @@ module Hop =
                     async {
                         return update (fun s -> commit (now ()) newId registry.standing mail.send sid submission s)
                     }
+            seen = fun sid opened -> async { return update (seen (now ()) sid opened) }
         }
 
 
@@ -1753,6 +1782,7 @@ module Adapters =
             dropEnrolment = fun _ -> async { return () }
             challenge = fun _ _ -> async { return SigningResponse.Refused SigningRefusal.NoSession }
             submit = fun _ _ -> async { return SigningResponse.Refused SigningRefusal.NoSession }
+            seen = fun _ _ -> async { return None }
         }
 
 

--- a/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
@@ -147,14 +147,41 @@ module CompositionRoot =
         : IServerApi
         =
         {
+            // uc-03 step 1: the Session the cookie names is marked seen and told what it is
+            // told (Rules 9, 11, 21) before the command is computed; without a cookie the
+            // request computes as it always did (UC-7). The token is never logged.
             processCommand =
-                fun cmd ->
+                fun request ->
                     async {
+                        let cmd = request.Command
+
                         try
                             writeInfoMessage $"Processing command: {cmd |> Command.toString}"
+
+                            let! notice =
+                                match cookie.read () with
+                                | None -> async { return None }
+                                | Some id -> env.session.seen id request.Opened
+
                             let! result = Command.processCmd env cmd
-                            writeInfoMessage $"Finished processing command: {cmd |> Command.toString}"
-                            return result
+
+                            let told =
+                                match notice with
+                                | Some(RecordNotice.NewerVersion _) -> ", the record moved on"
+                                | Some(RecordNotice.Ended _) -> ", the Session ended"
+                                | None -> ""
+
+                            writeInfoMessage $"Finished processing command: {cmd |> Command.toString}{told}"
+
+                            return
+                                result
+                                |> Result.map (fun response ->
+                                    ({
+                                        Response = response
+                                        Notice = notice
+                                    }
+                                    : Reply)
+                                )
                         with ex ->
                             writeErrorMessage $"Error processing command: {cmd |> Command.toString}\n{ex}"
                             return Error [| ex.Message |]

--- a/src/Informedica.GenPRES.Server/ServerApi.Ports.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Ports.fs
@@ -174,6 +174,9 @@ type SessionPort =
         challenge: string -> OrderPlan * OpenedToken * string option -> Async<SigningResponse>
         // UC-3 step 3: the signature, for the Session the cookie names
         submit: string -> Submission -> Async<SigningResponse>
+        // uc-03 step 1, every computing request: the Session the cookie names is marked seen
+        // (Rule 9) and told whether the record moved on (Rule 21) or the Session ended (Rule 11)
+        seen: string -> OpenedToken option -> Async<RecordNotice option>
     }
 
 

--- a/src/Informedica.GenPRES.Shared/Api.fs
+++ b/src/Informedica.GenPRES.Shared/Api.fs
@@ -97,6 +97,24 @@ module Api =
         | DrugNamesLoaded of string[]
 
 
+    /// Every computing request: the command and the OpenedToken the Session holds (Rule 34).
+    /// `None` where there is none to send: no Session, an anonymous one, or a client acting
+    /// before its first token arrived.
+    type Request =
+        {
+            Opened: OpenedToken option
+            Command: Command
+        }
+
+
+    /// Every computing reply: the result, and what the Session is told with it (Rules 11, 21).
+    type Reply =
+        {
+            Response: Response
+            Notice: RecordNotice option
+        }
+
+
     module Command =
 
         let toString =
@@ -242,7 +260,7 @@ module Api =
     /// to learn more read the docs at https://zaid-ajaj.github.io/Fable.Remoting/src/basics.html
     type IServerApi =
         {
-            processCommand: Command -> Async<Result<Response, string[]>>
+            processCommand: Request -> Async<Result<Reply, string[]>>
             processLaunch: LaunchCommand -> Async<LaunchOutcome>
             processSession: SessionCommand -> Async<SessionResponse>
             processSigning: SigningCommand -> Async<SigningResponse>

--- a/src/Informedica.GenPRES.Shared/Types.fs
+++ b/src/Informedica.GenPRES.Shared/Types.fs
@@ -771,3 +771,13 @@ module Types =
         // step 3: the version committed, and a fresh OpenedToken over it (Rule 34)
         | Submitted of SignedOrderPlan * OpenedToken
         | Refused of SigningRefusal
+
+
+    /// What a reply says about the Session next to its result. Rules 21, 22: a version newer
+    /// than the one the request's OpenedToken names exists, whose and when; it gates nothing.
+    /// Rule 11: the server ended this Session, told at the next request. Lives here, like
+    /// `SigningResponse`: the session port answers it.
+    [<RequireQualifiedAccess>]
+    type RecordNotice =
+        | NewerVersion of OrderPlanHead
+        | Ended of SessionEnding

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -71,6 +71,7 @@ module StubAdapters =
             dropEnrolment = fun _ -> async { return () }
             challenge = fun _ _ -> async { return SigningResponse.Refused SigningRefusal.NoSession }
             submit = fun _ _ -> async { return SigningResponse.Refused SigningRefusal.NoSession }
+            seen = fun _ _ -> async { return None }
         }
 
 
@@ -895,14 +896,14 @@ module SessionStubTests =
                             | CallbackResult.Opened(id, _) -> id
                             | other -> failtest $"{other}"
 
-                        let state, told = Hop.find id1 state
+                        let state, told = Hop.find t0 id1 state
 
                         told
                         |> Expect.equal "told" (SessionLookup.Ended SessionEnding.SupersededByLaunch)
 
                         // the answer was lost, or the tab comes back much later: the cookie came
                         // again, so is the ending
-                        let _, again = Hop.find id1 state
+                        let _, again = Hop.find t0 id1 state
 
                         again
                         |> Expect.equal "told again" (SessionLookup.Ended SessionEnding.SupersededByLaunch)
@@ -1877,6 +1878,191 @@ module SessionStubTests =
                 ]
 
 
+        let seenTests =
+            let t1 = t0.AddMinutes 5.0
+
+            let prescriber =
+                {
+                    UserId = "prescriber"
+                    DisplayName = "Stub Prescriber"
+                    Role = UserRole.Prescriber
+                }
+
+            let other =
+                { prescriber with
+                    UserId = "prescriber-b"
+                    DisplayName = "Stub Prescriber B"
+                }
+
+            let signedBy (user: UserContext) no (at: DateTime) : SignedOrderPlan =
+                {
+                    Head =
+                        {
+                            Id = $"plan-{no}"
+                            No = no
+                            By = user
+                            SignedAt = at
+                        }
+                    PatientId = "pat-1"
+                    Base = if no > 1 then Some $"plan-{no - 1}" else None
+                    Scenarios = [||]
+                    Patient = Shared.Models.Patient.empty
+                    Verified = true
+                }
+
+            let session
+                (user: UserContext option)
+                (patientId: string option)
+                (sid: string)
+                (openedWith: string option)
+                : Hop.SessionRecord
+                =
+                {
+                    Session =
+                        {
+                            User = user
+                            PatientContext =
+                                patientId
+                                |> Option.map (fun pid ->
+                                    {
+                                        PatientId = pid
+                                        Patient = Shared.Models.Patient.empty
+                                    }
+                                )
+                            OpenedToken = Some(OpenedToken $"opened-{sid}")
+                            KeyThumbprint = Some "t"
+                        }
+                    Login = user |> Option.map _.UserId
+                    OpenedWith = openedWith
+                    Seen = t0
+                }
+
+            let withSession (record: Hop.SessionRecord) sid (state: Hop.State) =
+                { state with Sessions = state.Sessions |> Map.add sid record }
+
+            let withRecord patientId (versions: SignedOrderPlan list) (state: Hop.State) =
+                { state with Records = state.Records |> Map.add patientId versions }
+
+            let own sid = Some(OpenedToken $"opened-{sid}")
+
+            let movedOn =
+                Hop.emptyState
+                |> withRecord "pat-1" [ signedBy other 2 t1; signedBy prescriber 1 t0 ]
+                |> withSession (session (Some prescriber) (Some "pat-1") "s-1" (Some "plan-1")) "s-1"
+
+            testList
+                "Hop.seen"
+                [
+                    test "an unknown Session with no ending: nothing to say, nothing touched" {
+                        let state, notice = Hop.emptyState |> Hop.seen t1 "s-1" (own "s-1")
+                        notice |> Expect.isNone "no notice"
+                        state |> Expect.equal "unchanged" Hop.emptyState
+                    }
+
+                    test "an unknown Session with an ending recorded: the ending (Rule 11)" {
+                        let state =
+                            { Hop.emptyState with
+                                Endings = Map.ofList [ "s-1", (SessionEnding.SupersededByLaunch, t0) ]
+                            }
+
+                        let _, notice = state |> Hop.seen t1 "s-1" (own "s-1")
+
+                        notice
+                        |> Expect.equal "ended" (Some(RecordNotice.Ended SessionEnding.SupersededByLaunch))
+                    }
+
+                    test "a Session is touched by every seen request, with or without a token (Rule 9)" {
+                        let state =
+                            Hop.emptyState
+                            |> withSession (session (Some prescriber) (Some "pat-1") "s-1" None) "s-1"
+
+                        let state, _ = state |> Hop.seen t1 "s-1" None
+                        state.Sessions["s-1"].Seen |> Expect.equal "seen now" t1
+
+                        let state, _ = state |> Hop.seen (t1.AddMinutes 1.0) "s-1" (own "s-1")
+                        state.Sessions["s-1"].Seen |> Expect.equal "seen again" (t1.AddMinutes 1.0)
+                    }
+
+                    test "touching an unknown Session changes nothing" {
+                        Hop.emptyState |> Hop.touch t1 "s-9" |> Expect.equal "unchanged" Hop.emptyState
+                    }
+
+                    test "the Session's own token, no head or the head it opened with: nothing to say" {
+                        let fromNothing =
+                            Hop.emptyState
+                            |> withSession (session (Some prescriber) (Some "pat-1") "s-1" None) "s-1"
+
+                        fromNothing |> Hop.seen t1 "s-1" (own "s-1") |> snd |> Expect.isNone "no head"
+
+                        let onHead =
+                            Hop.emptyState
+                            |> withRecord "pat-1" [ signedBy prescriber 1 t0 ]
+                            |> withSession (session (Some prescriber) (Some "pat-1") "s-1" (Some "plan-1")) "s-1"
+
+                        onHead |> Hop.seen t1 "s-1" (own "s-1") |> snd |> Expect.isNone "on the head"
+                    }
+
+                    test "the Session's own token, a newer head: whose and when, nothing opened (Rules 21, 22)" {
+                        let state, notice = movedOn |> Hop.seen t1 "s-1" (own "s-1")
+
+                        notice
+                        |> Expect.equal "newer version" (Some(RecordNotice.NewerVersion (signedBy other 2 t1).Head))
+
+                        state.Sessions["s-1"].OpenedWith
+                        |> Expect.equal "Rule 20 stays the guard" (Some "plan-1")
+                    }
+
+                    test "a Session opened from nothing, a first version signed elsewhere: a notice" {
+                        Hop.emptyState
+                        |> withRecord "pat-1" [ signedBy other 1 t1 ]
+                        |> withSession (session (Some prescriber) (Some "pat-1") "s-1" None) "s-1"
+                        |> Hop.seen t1 "s-1" (own "s-1")
+                        |> snd
+                        |> Expect.isSome "newer version"
+                    }
+
+                    test "a token that is not the Session's, or none: nothing to say, still touched" {
+                        let state, notice = movedOn |> Hop.seen t1 "s-1" (own "s-2")
+                        notice |> Expect.isNone "foreign token"
+                        state.Sessions["s-1"].Seen |> Expect.equal "seen" t1
+
+                        movedOn |> Hop.seen t1 "s-1" None |> snd |> Expect.isNone "no token"
+                    }
+
+                    test "an anonymous Session, or one without a Patient: nothing to say" {
+                        let state =
+                            Hop.emptyState
+                            |> withRecord "pat-1" [ signedBy other 2 t1 ]
+                            |> withSession (session None (Some "pat-1") "s-a" None) "s-a"
+                            |> withSession (session (Some prescriber) None "s-n" None) "s-n"
+
+                        state |> Hop.seen t1 "s-a" (own "s-a") |> snd |> Expect.isNone "anonymous"
+                        state |> Hop.seen t1 "s-n" (own "s-n") |> snd |> Expect.isNone "no patient"
+                    }
+
+                    test "the notice is stateless: the same request says it again" {
+                        let state, first = movedOn |> Hop.seen t1 "s-1" (own "s-1")
+                        let _, second = state |> Hop.seen (t1.AddMinutes 1.0) "s-1" (own "s-1")
+                        second |> Expect.equal "again" first
+                    }
+
+                    test "find touches the Session too; close does not need to (Rule 9)" {
+                        let state =
+                            Hop.emptyState
+                            |> withSession (session (Some prescriber) (Some "pat-1") "s-1" None) "s-1"
+
+                        let state, found = state |> Hop.find t1 "s-1"
+
+                        (match found with
+                         | SessionLookup.Found _ -> true
+                         | _ -> false)
+                        |> Expect.isTrue "found"
+
+                        state.Sessions["s-1"].Seen |> Expect.equal "seen at find" t1
+                    }
+                ]
+
+
         let challengeTests =
             let minutes (n: float) = TimeSpan.FromMinutes n
             let seconds (n: float) = TimeSpan.FromSeconds n
@@ -1915,6 +2101,7 @@ module SessionStubTests =
                         }
                     Login = user |> Option.map _.UserId
                     OpenedWith = openedWith
+                    Seen = t0
                 }
                 : Hop.SessionRecord)
 
@@ -2344,6 +2531,7 @@ module SessionStubTests =
                         }
                     Login = Some user.UserId
                     OpenedWith = openedWith
+                    Seen = t0
                 }
                 : Hop.SessionRecord)
 
@@ -2760,6 +2948,7 @@ module SessionStubTests =
                     findTests
                     supplyTests
                     dropTests
+                    seenTests
                     challengeTests
                     commitTests
                 ]
@@ -3924,6 +4113,116 @@ module SessionStubTests =
             ]
 
 
+    /// `processCommand` over the cookie (plan 635 PR 1): the request computes as before, and
+    /// the reply carries what the Session is told.
+    let computeCompositionTests =
+        let settings =
+            {
+                ServerSettings.Language = Shared.Localization.Dutch
+                IsDemo = true
+            }
+
+        let request opened : Request =
+            {
+                Opened = opened
+                Command = Api.FormularyCmd Formulary.empty
+            }
+
+        let sessionOf env cookie =
+            async {
+                match! CompositionRoot.processSession env cookie (noEnrolment ()) SessionCommand.GetSession with
+                | SessionResponse.SessionResp(Some opened) -> return opened
+                | other -> return failtest $"expected an open Session, got {other}"
+            }
+
+        testList
+            "processCommand in a Session"
+            [
+                testAsync "without a cookie: computed as before, nothing told (UC-7)" {
+                    let _, env = envWithStub ()
+                    let cookie, _ = memoryCookie None
+                    let stateCookie, _ = memoryStateCookie None
+                    let api = CompositionRoot.compose settings env cookie stateCookie (noEnrolment ())
+
+                    match! api.processCommand (request None) with
+                    | Ok reply ->
+                        reply.Notice |> Expect.isNone "nothing told"
+
+                        match reply.Response with
+                        | Api.FormularyResp _ -> ()
+                        | other -> failtest $"expected FormularyResp, got {other}"
+                    | Error errs -> failtest $"expected Ok, got {errs}"
+                }
+
+                testAsync "an open Session with its own token and no head: computed, nothing told" {
+                    let directory, env = envWithStub ()
+                    let cookie, _ = memoryCookie None
+                    let stateCookie, _ = memoryStateCookie None
+
+                    let! _ =
+                        openVia
+                            directory
+                            env
+                            cookie
+                            stateCookie
+                            (noEnrolment ())
+                            (mintFor "n-1" "stub-patient")
+                            keyA
+                            "prescriber"
+
+                    let! opened = sessionOf env cookie
+                    let api = CompositionRoot.compose settings env cookie stateCookie (noEnrolment ())
+
+                    match! api.processCommand (request opened.OpenedToken) with
+                    | Ok reply -> reply.Notice |> Expect.isNone "nothing told"
+                    | Error errs -> failtest $"expected Ok, got {errs}"
+                }
+
+                testAsync "a Session superseded by a newer launch: computed, and the ending told (Rule 11)" {
+                    let directory, env = envWithStub ()
+                    let cookieA, _ = memoryCookie None
+                    let cookieB, _ = memoryCookie None
+                    let stateCookie, _ = memoryStateCookie None
+
+                    let! _ =
+                        openVia
+                            directory
+                            env
+                            cookieA
+                            stateCookie
+                            (noEnrolment ())
+                            (mintFor "n-1" "stub-patient")
+                            keyA
+                            "prescriber"
+
+                    let! openedA = sessionOf env cookieA
+
+                    let! _ =
+                        openVia
+                            directory
+                            env
+                            cookieB
+                            stateCookie
+                            (noEnrolment ())
+                            (mintFor "n-2" "stub-patient")
+                            keyB
+                            "prescriber"
+
+                    let api = CompositionRoot.compose settings env cookieA stateCookie (noEnrolment ())
+
+                    match! api.processCommand (request openedA.OpenedToken) with
+                    | Ok reply ->
+                        reply.Notice
+                        |> Expect.equal "ended" (Some(RecordNotice.Ended SessionEnding.SupersededByLaunch))
+
+                        match reply.Response with
+                        | Api.FormularyResp _ -> ()
+                        | other -> failtest $"still computed, got {other}"
+                    | Error errs -> failtest $"expected Ok, got {errs}"
+                }
+            ]
+
+
     let tests =
         testList
             "Session"
@@ -3935,6 +4234,7 @@ module SessionStubTests =
                 compositionTests
                 enrolmentCompositionTests
                 signingCompositionTests
+                computeCompositionTests
             ]
 
 


### PR DESCRIPTION
## Summary

Plan 635 step 1 of 5 ([plan](https://github.com/informedica/GenPRES/blob/master/docs/implementation-plans/635-session-bound-compute.md)): the request and reply envelopes and the notice. No visible change yet.

- **Wire**: `Request { Opened: OpenedToken option; Command }` and `Reply { Response; Notice: RecordNotice option }` on `processCommand`; `RecordNotice = NewerVersion of OrderPlanHead | Ended of SessionEnding` (Rules 21, 22 and 11).
- **Server**: `SessionRecord.Seen` (Rule 9), set at open and refreshed by `Hop.touch` from every port member that takes the session cookie's id (`find`, `challenge`, `submit`, `seen`; `close` excepted). `Hop.seen`: no Session and an ending recorded, `Ended`; a Session, touched, and when the token is the Session's own, the head compared with the version it opened with, `NewerVersion` whose and when; anonymous, no Patient, no head or a foreign token, nothing. `SessionPort.seen`; `sessionDisabled` answers nothing. `CompositionRoot.processCommand` reads the cookie, asks `seen` before computing, answers both; the log names the notice kind, never the token.
- **Client**: `tokenOf state.Session` sent from the one `createApiMsg` site (the four load helpers and their call sites pass it through); the reply's notice is logged, not shown (step 4).
- **Tests**: 11 over `Hop.seen` and `touch`, 3 over `processCommand` through the composition root (no cookie: computed, nothing told; an open Session with its own token: nothing told; a Session superseded by a newer launch: still computed, `Ended` told). Server tests 252.

Script-first: `Server/Scripts/Compute.fsx` (11 tests), migrated after review.

## Verification

- `dotnet run Build`, server tests 252/252, shared tests 455/455, Fantomas, Fable.
- In the browser: the Network tab shows every `processCommand` call sending `{ Opened; Command }` and receiving `{ Response; Notice: null }`; launched `prescriber` computes and prescribes as before.

Refs #635

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZWjibQUW8uqCVbfV4vDTf
