### PR TITLE
feat(server): open the version the notice named (#635)

### DIFF
--- a/src/Informedica.GenPRES.Client/App.fs
+++ b/src/Informedica.GenPRES.Client/App.fs
@@ -652,15 +652,15 @@ module private Elmish =
                     return SessionMsg(SessionMsg.Resumed(Error ex.Message))
             }
             |> Cmd.fromAsync
-        | SessionEffect.CallOpenVersion id ->
+        | SessionEffect.CallOpenVersion(id, from) ->
             async {
                 try
                     match! serverApi.processSession (Api.SessionCommand.OpenVersion id) with
-                    | Api.SessionResponse.SessionResp opened -> return SessionMsg(SessionMsg.Reopened(Ok opened))
+                    | Api.SessionResponse.SessionResp opened -> return SessionMsg(SessionMsg.Reopened(from, Ok opened))
                     // never an answer to OpenVersion
-                    | _ -> return SessionMsg(SessionMsg.Reopened(Ok None))
+                    | _ -> return SessionMsg(SessionMsg.Reopened(from, Ok None))
                 with ex ->
-                    return SessionMsg(SessionMsg.Reopened(Error ex.Message))
+                    return SessionMsg(SessionMsg.Reopened(from, Error ex.Message))
             }
             |> Cmd.fromAsync
         | SessionEffect.CallCloseSession ->

--- a/src/Informedica.GenPRES.Client/App.fs
+++ b/src/Informedica.GenPRES.Client/App.fs
@@ -652,6 +652,17 @@ module private Elmish =
                     return SessionMsg(SessionMsg.Resumed(Error ex.Message))
             }
             |> Cmd.fromAsync
+        | SessionEffect.CallOpenVersion id ->
+            async {
+                try
+                    match! serverApi.processSession (Api.SessionCommand.OpenVersion id) with
+                    | Api.SessionResponse.SessionResp opened -> return SessionMsg(SessionMsg.Reopened(Ok opened))
+                    // never an answer to OpenVersion
+                    | _ -> return SessionMsg(SessionMsg.Reopened(Ok None))
+                with ex ->
+                    return SessionMsg(SessionMsg.Reopened(Error ex.Message))
+            }
+            |> Cmd.fromAsync
         | SessionEffect.CallCloseSession ->
             async {
                 // the server deletes the cookie whatever its close returns (finally), so an

--- a/src/Informedica.GenPRES.Client/SessionMachine.fs
+++ b/src/Informedica.GenPRES.Client/SessionMachine.fs
@@ -85,6 +85,11 @@ type SessionMsg =
     | EndedByServer of SessionEnding
     // UC-3: a signature re-minted the OpenedToken over the new head (Rule 34)
     | TokenRenewed of OpenedToken
+    // UC-4 step 4: take up the version the notice named (Rules 18 to 20)
+    | OpenVersion of id: string
+    // the answer: the Session as it now is (Some), nothing to open (None), or a transport
+    // failure
+    | Reopened of Result<SessionOpened option, string>
 
 
 [<RequireQualifiedAccess>]
@@ -103,6 +108,8 @@ type SessionEffect =
     // patient as the client holds it after SetPatient (normal values applied); interpreted as
     // a FilterOrderPlan over them
     | LoadCart of SignedOrderPlan
+    // UC-4 step 4: processSession OpenVersion
+    | CallOpenVersion of id: string
 
 
 module Session =
@@ -236,3 +243,20 @@ module Session =
         | SessionMsg.TokenRenewed token, Session.Open session ->
             Session.Open { session with OpenedToken = Some token }, []
         | SessionMsg.TokenRenewed _, _ -> state, []
+
+        // UC-4 step 4: only an open Session has a version to take up
+        | SessionMsg.OpenVersion id, Session.Open _ -> state, [ SessionEffect.CallOpenVersion id ]
+        | SessionMsg.OpenVersion _, _ -> state, []
+
+        // the Session as the server now holds it: the token over the version opened, and its
+        // orders into the cart (Rule 19); the patient is unchanged, so no SetPatient. Nothing to
+        // open, or the request never got there: the Session stays as it was, and the next
+        // request tells what the head is (Rule 21). Lands only on an open Session.
+        | SessionMsg.Reopened(Ok(Some session)), Session.Open _ ->
+            Session.Open session,
+            [
+                match session.PatientContext, session.Head with
+                | Some _, Some head -> SessionEffect.LoadCart head
+                | _ -> ()
+            ]
+        | SessionMsg.Reopened _, _ -> state, []

--- a/src/Informedica.GenPRES.Client/SessionMachine.fs
+++ b/src/Informedica.GenPRES.Client/SessionMachine.fs
@@ -88,8 +88,9 @@ type SessionMsg =
     // UC-4 step 4: take up the version the notice named (Rules 18 to 20)
     | OpenVersion of id: string
     // the answer: the Session as it now is (Some), nothing to open (None), or a transport
-    // failure
-    | Reopened of Result<SessionOpened option, string>
+    // failure; `from` is the OpenedToken the request started from, so that an answer lands
+    // only on the Session that asked (the guard of Outcome and of the signing answers)
+    | Reopened of from: OpenedToken option * Result<SessionOpened option, string>
 
 
 [<RequireQualifiedAccess>]
@@ -108,8 +109,8 @@ type SessionEffect =
     // patient as the client holds it after SetPatient (normal values applied); interpreted as
     // a FilterOrderPlan over them
     | LoadCart of SignedOrderPlan
-    // UC-4 step 4: processSession OpenVersion
-    | CallOpenVersion of id: string
+    // UC-4 step 4: processSession OpenVersion; `from` comes back in Reopened
+    | CallOpenVersion of id: string * from: OpenedToken option
 
 
 module Session =
@@ -244,15 +245,19 @@ module Session =
             Session.Open { session with OpenedToken = Some token }, []
         | SessionMsg.TokenRenewed _, _ -> state, []
 
-        // UC-4 step 4: only an open Session has a version to take up
-        | SessionMsg.OpenVersion id, Session.Open _ -> state, [ SessionEffect.CallOpenVersion id ]
+        // UC-4 step 4: only an open Session has a version to take up; the request remembers
+        // the token it started from
+        | SessionMsg.OpenVersion id, Session.Open session ->
+            state, [ SessionEffect.CallOpenVersion(id, session.OpenedToken) ]
         | SessionMsg.OpenVersion _, _ -> state, []
 
         // the Session as the server now holds it: the token over the version opened, and its
         // orders into the cart (Rule 19); the patient is unchanged, so no SetPatient. Nothing to
         // open, or the request never got there: the Session stays as it was, and the next
-        // request tells what the head is (Rule 21). Lands only on an open Session.
-        | SessionMsg.Reopened(Ok(Some session)), Session.Open _ ->
+        // request tells what the head is (Rule 21). The stale-request guard: an answer lands
+        // only on the open Session that still holds the token the request started from; a
+        // Session closed, relaunched or reopened meanwhile drops it
+        | SessionMsg.Reopened(from, Ok(Some session)), Session.Open current when current.OpenedToken = from ->
             Session.Open session,
             [
                 match session.PatientContext, session.Head with

--- a/src/Informedica.GenPRES.Server/Scripts/Compute.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/Compute.fsx
@@ -1,19 +1,18 @@
-// Compute bound to the Session (plan 635), PR 2: the head of the record into the cart at open
-// (Rule 19, second half). The Session already opens with the head's id (`OpenedWith`, plan 622);
-// now the version itself travels to the client, which loads its orders into the cart at a
-// launch, a resume and an enrolment, and after a signature the version just signed is what a
-// resume opens on.
+// Compute bound to the Session (plan 635), PR 3: opening the version the notice named
+// (Rules 18 to 20; UC-4 step 4, the model's `OpenOrderPlan of OrderPlanId`). A User told that
+// the record moved on (Rule 21) takes up that version: it becomes what the Session opened
+// with, the OpenedToken is re-minted over it, and a challenge over the old baseline is dropped.
 //
 // Script-first draft (script-only policy) of:
-//   - the wire: `SessionOpened.Head: SignedOrderPlan option` → `Shared/Types.fs` (the head
-//     types move above `SessionOpened`, which now refers to them);
-//   - `Hop.openWith` filling `Head` from `headOf`, and `Hop.commit` setting it to the version
-//     appended → `Adapters.fs`.
-// The client side (`SessionEffect.LoadCart`, emitted by `Session.opened`; App.fs loading the
-// cart through `FilterOrderPlan`) is edited directly, as UI code.
+//   - `SessionCommand.OpenVersion of id: string` → `Shared/Api.fs`;
+//   - `Hop.openVersion` → `Adapters.fs`, `SessionPort.openVersion` → `Ports.fs`, both answering
+//     `SessionOpened option` (the adapter does not see `Shared.Api`, as `find` answers a
+//     `SessionLookup`); the `processSession` arm wraps it in `SessionResp` → `CompositionRoot.fs`.
+// The client side (`SessionMsg.OpenVersion`, `Reopened`, `SessionEffect.CallOpenVersion`) is
+// edited directly, as UI code.
 //
-// Only what changes is re-stated: the two places the head is written. Run: `dotnet fsi
-// Compute.fsx` from this directory (build first).
+// Only what changes is re-stated: the state has the four fields `openVersion` touches. Run:
+// `dotnet fsi Compute.fsx` from this directory (build first).
 
 #I __SOURCE_DIRECTORY__
 #r "nuget: Expecto, 10.2.3"
@@ -23,44 +22,100 @@
 open System
 open Shared.Types
 open Shared.Models
+open ServerApi
 
 
 // ---------------------------------------------------------------------------------------------
-// Wire (→ Shared/Types.fs)
-// ---------------------------------------------------------------------------------------------
-
-/// What the client keeps of an open Session (launch step 6), now with the version of the
-/// record it opened with (Rule 19): its orders go into the cart, and Rule 20 is checked against
-/// its id. `None` from nothing.
-type SessionOpened =
-    {
-        User: UserContext option
-        PatientContext: PatientContext option
-        OpenedToken: OpenedToken option
-        KeyThumbprint: string option
-        Head: SignedOrderPlan option
-    }
-
-
-// ---------------------------------------------------------------------------------------------
-// The head written at open and at commit (→ ServerApi.Adapters.fs, `Hop`)
+// Opening a version (→ ServerApi.Adapters.fs, `Hop`)
 // ---------------------------------------------------------------------------------------------
 
 module Hop =
 
-    /// The two fields `openWith` derives from the record (Rule 19): the version and its id.
-    let headAtOpen (headOf: string -> SignedOrderPlan option) (patientId: string) =
-        let head = headOf patientId
-        head, head |> Option.map _.Head.Id
+    open ServerApi.Hop
 
-
-    /// What `commit` writes on the Session once the version is appended (Rule 34): the fresh
-    /// token, and the version just signed as the one the Session opened with.
-    let afterCommit (token: OpenedToken) (plan: SignedOrderPlan) (session: SessionOpened) =
-        { session with
-            OpenedToken = Some token
-            Head = Some plan
+    /// The state of PR 3: only the fields `openVersion` reads or writes.
+    type State =
+        {
+            Sessions: Map<string, SessionRecord>
+            Records: Map<string, SignedOrderPlan list>
+            Notices: Map<string, Notice>
+            Challenges: Map<string, Challenge>
         }
+
+
+    let emptyState =
+        {
+            Sessions = Map.empty
+            Records = Map.empty
+            Notices = Map.empty
+            Challenges = Map.empty
+        }
+
+
+    /// Rule 9, as in the source.
+    let touch (now: DateTime) (sid: string) (state: State) : State =
+        { state with
+            Sessions = state.Sessions |> Map.change sid (Option.map (fun r -> { r with Seen = now }))
+        }
+
+
+    /// Rules 18 to 20, UC-4 step 4: version `id` becomes what the Session opened with. No
+    /// Session, an anonymous one or one without a Patient: nothing to open (Rule 13). An id the
+    /// record does not hold for the Session's Patient (a stale button, a restart): nothing
+    /// opens, the Session as it is; the next request tells what the head is (Rule 21). The
+    /// version already open: the token stands. Another version: the OpenedToken is re-minted
+    /// over it (Rule 34) and the standing challenge and notice of this Session are dropped (a
+    /// challenge over the old baseline must not be answerable). Any version may be opened
+    /// (Rule 18); one that is not the head leaves Submission blocked (Rule 20).
+    let openVersion
+        (now: DateTime)
+        (newId: unit -> string)
+        (sid: string)
+        (id: string)
+        (state: State)
+        : State * SessionOpened option
+        =
+        match state.Sessions |> Map.tryFind sid with
+        | None -> state, None
+        | Some record ->
+            let state = touch now sid state
+
+            match record.Session.User, record.Session.PatientContext with
+            | None, _
+            | _, None -> state, None
+            | Some _, Some patient ->
+                let version =
+                    state.Records
+                    |> Map.tryFind patient.PatientId
+                    |> Option.bind (List.tryFind (fun v -> v.Head.Id = id))
+
+                match version with
+                | None -> state, Some record.Session
+                | Some version when record.OpenedWith = Some id ->
+                    let session = { record.Session with Head = Some version }
+
+                    { state with Sessions = state.Sessions |> Map.add sid { record with Session = session } },
+                    Some session
+                | Some version ->
+                    let session =
+                        { record.Session with
+                            OpenedToken = Some(OpenedToken $"opened-{newId ()}")
+                            Head = Some version
+                        }
+
+                    { state with
+                        Sessions =
+                            state.Sessions
+                            |> Map.add
+                                sid
+                                { record with
+                                    Session = session
+                                    OpenedWith = Some id
+                                }
+                        Challenges = state.Challenges |> Map.remove sid
+                        Notices = state.Notices |> Map.remove sid
+                    },
+                    Some session
 
 
 // ---------------------------------------------------------------------------------------------
@@ -72,6 +127,14 @@ open Expecto.Flip
 
 
 let t0 = DateTime(2026, 9, 11, 12, 0, 0, DateTimeKind.Utc)
+let t1 = t0.AddMinutes 5.0
+
+let counter prefix =
+    let n = ref 0
+
+    fun () ->
+        n.Value <- n.Value + 1
+        $"{prefix}-{n.Value}"
 
 let prescriber =
     {
@@ -80,14 +143,20 @@ let prescriber =
         Role = UserRole.Prescriber
     }
 
+let other =
+    { prescriber with
+        UserId = "prescriber-b"
+        DisplayName = "Stub Prescriber B"
+    }
 
-let signed no : SignedOrderPlan =
+
+let signedBy (user: UserContext) no : SignedOrderPlan =
     {
         Head =
             {
                 Id = $"plan-{no}"
                 No = no
-                By = prescriber
+                By = user
                 SignedAt = t0
             }
         PatientId = "pat-1"
@@ -98,42 +167,129 @@ let signed no : SignedOrderPlan =
     }
 
 
-let records = Map.ofList [ "pat-1", [ signed 2; signed 1 ] ]
-let headOf patientId = records |> Map.tryFind patientId |> Option.bind List.tryHead
-
-let opened: SessionOpened =
+let session (user: UserContext option) (patientId: string option) (sid: string) (openedWith: string option) : ServerApi.Hop.SessionRecord =
     {
-        User = Some prescriber
-        PatientContext =
-            Some
-                {
-                    PatientId = "pat-1"
-                    Patient = Patient.empty
-                }
-        OpenedToken = Some(OpenedToken "opened-1")
-        KeyThumbprint = Some "t"
-        Head = None
+        Session =
+            {
+                User = user
+                PatientContext =
+                    patientId
+                    |> Option.map (fun pid ->
+                        {
+                            PatientId = pid
+                            Patient = Patient.empty
+                        }
+                    )
+                OpenedToken = Some(OpenedToken $"opened-{sid}")
+                KeyThumbprint = Some "t"
+                Head = None
+            }
+        Login = user |> Option.map _.UserId
+        OpenedWith = openedWith
+        Seen = t0
     }
+
+
+let challenged sid : ServerApi.Hop.Challenge =
+    {
+        Nonce = $"c-{sid}"
+        Patient = Patient.empty
+        Scenarios = [||]
+        Verified = true
+        Expiry = t0.AddMinutes 2.0
+    }
+
+
+/// A opened on plan-1; B signed plan-2 meanwhile; A has a challenge standing over plan-1.
+let movedOn =
+    { Hop.emptyState with
+        Sessions = Map.ofList [ "s-1", session (Some prescriber) (Some "pat-1") "s-1" (Some "plan-1") ]
+        Records = Map.ofList [ "pat-1", [ signedBy other 2; signedBy prescriber 1 ] ]
+        Challenges = Map.ofList [ "s-1", challenged "s-1" ]
+        Notices = Map.ofList [ "s-1", { Nonce = "n"; Data = None; Expiry = t0.AddMinutes 2.0 } ]
+    }
+
+let openAt sid id state =
+    Hop.openVersion t1 (counter "id") sid id state
 
 
 let tests =
     testList
-        "the head into the cart (Rule 19)"
+        "openVersion (Rules 18 to 20, UC-4 step 4)"
         [
-            test "a Session over a record opens with the newest version and its id" {
-                Hop.headAtOpen headOf "pat-1"
-                |> Expect.equal "the head" (Some(signed 2), Some "plan-2")
+            test "no Session: nothing to open" {
+                Hop.emptyState |> openAt "s-9" "plan-2" |> snd |> Expect.equal "none" None
             }
 
-            test "a Session over no record opens from nothing" {
-                Hop.headAtOpen headOf "pat-9" |> Expect.equal "nothing" (None, None)
+            test "an anonymous Session, or one without a Patient: nothing to open (Rule 13)" {
+                let state =
+                    { movedOn with
+                        Sessions =
+                            Map.ofList
+                                [
+                                    "s-a", session None (Some "pat-1") "s-a" None
+                                    "s-n", session (Some prescriber) None "s-n" None
+                                ]
+                    }
+
+                state |> openAt "s-a" "plan-2" |> snd |> Expect.equal "anonymous" None
+                state |> openAt "s-n" "plan-2" |> snd |> Expect.equal "no patient" None
             }
 
-            test "after a signature the Session holds the fresh token and the version just signed" {
-                let after = opened |> Hop.afterCommit (OpenedToken "opened-2") (signed 3)
-                after.OpenedToken |> Expect.equal "re-minted" (Some(OpenedToken "opened-2"))
-                after.Head |> Expect.equal "the version signed" (Some(signed 3))
-                after.User |> Expect.equal "the rest untouched" opened.User
+            test "an id the record does not hold: nothing opens, the Session as it is, token kept" {
+                let state, answer = movedOn |> openAt "s-1" "plan-9"
+                answer |> Expect.equal "as it is" (Some movedOn.Sessions["s-1"].Session)
+                state.Sessions["s-1"].OpenedWith |> Expect.equal "unchanged" (Some "plan-1")
+                state.Challenges |> Map.containsKey "s-1" |> Expect.isTrue "challenge kept"
+                state.Sessions["s-1"].Seen |> Expect.equal "touched" t1
+            }
+
+            test "the version already open: the token stands, the version is answered" {
+                let state, answer = movedOn |> openAt "s-1" "plan-1"
+
+                match answer with
+                | Some opened ->
+                    opened.OpenedToken |> Expect.equal "kept" (Some(OpenedToken "opened-s-1"))
+                    opened.Head |> Expect.equal "the version" (Some(signedBy prescriber 1))
+                | other -> failtest $"expected the Session, got {other}"
+
+                state.Challenges |> Map.containsKey "s-1" |> Expect.isTrue "challenge kept"
+            }
+
+            test "the head: opened, the token re-minted, the challenge and notice dropped (Rules 19, 34)" {
+                let state, answer = movedOn |> openAt "s-1" "plan-2"
+
+                match answer with
+                | Some opened ->
+                    opened.OpenedToken |> Expect.equal "re-minted" (Some(OpenedToken "opened-id-1"))
+                    opened.Head |> Expect.equal "B's version" (Some(signedBy other 2))
+                | other -> failtest $"expected the Session, got {other}"
+
+                state.Sessions["s-1"].OpenedWith |> Expect.equal "opened with the head" (Some "plan-2")
+                state.Sessions["s-1"].Session.OpenedToken |> Expect.equal "held" (Some(OpenedToken "opened-id-1"))
+                state.Challenges |> Expect.isEmpty "challenge dropped"
+                state.Notices |> Expect.isEmpty "notice dropped"
+
+                // Rule 20 no longer blocks; the old token is stale (Rule 34)
+                ServerApi.Hop.blockedBy state.Sessions["s-1"] "pat-1" { ServerApi.Hop.emptyState with Records = state.Records }
+                |> Expect.isNone "not blocked"
+            }
+
+            test "an older version: opened, still blocked by the head (Rules 18, 20)" {
+                let three =
+                    { movedOn with
+                        Records = Map.ofList [ "pat-1", [ signedBy prescriber 3; signedBy other 2; signedBy prescriber 1 ] ]
+                    }
+
+                let state, answer = three |> openAt "s-1" "plan-2"
+
+                match answer with
+                | Some opened -> opened.Head |> Expect.equal "plan-2" (Some(signedBy other 2))
+                | other -> failtest $"expected the Session, got {other}"
+
+                ServerApi.Hop.blockedBy state.Sessions["s-1"] "pat-1" { ServerApi.Hop.emptyState with Records = state.Records }
+                |> Option.map _.Id
+                |> Expect.equal "the head still blocks" (Some "plan-3")
             }
         ]
 

--- a/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
@@ -967,6 +967,65 @@ module Hop =
             | _ -> state, None
 
 
+    /// Rules 18 to 20, UC-4 step 4: version `id` becomes what the Session opened with. No
+    /// Session, an anonymous one or one without a Patient: nothing to open (Rule 13). An id the
+    /// record does not hold for the Session's Patient (a stale button, a restart): nothing
+    /// opens, the Session as it is; the next request tells what the head is (Rule 21). The
+    /// version already open: the token stands. Another version: the OpenedToken is re-minted
+    /// over it (Rule 34) and the standing challenge and notice of this Session are dropped (a
+    /// challenge over the old baseline must not be answerable). Any version may be opened
+    /// (Rule 18); one that is not the head leaves Submission blocked (Rule 20).
+    let openVersion
+        (now: DateTime)
+        (newId: unit -> string)
+        (sid: string)
+        (id: string)
+        (state: State)
+        : State * SessionOpened option
+        =
+        match state.Sessions |> Map.tryFind sid with
+        | None -> state, None
+        | Some record ->
+            let state = touch now sid state
+
+            match record.Session.User, record.Session.PatientContext with
+            | None, _
+            | _, None -> state, None
+            | Some _, Some patient ->
+                let version =
+                    state.Records
+                    |> Map.tryFind patient.PatientId
+                    |> Option.bind (List.tryFind (fun v -> v.Head.Id = id))
+
+                match version with
+                | None -> state, Some record.Session
+                | Some version when record.OpenedWith = Some id ->
+                    let session = { record.Session with Head = Some version }
+
+                    { state with Sessions = state.Sessions |> Map.add sid { record with Session = session } },
+                    Some session
+                | Some version ->
+                    let session =
+                        { record.Session with
+                            OpenedToken = Some(OpenedToken $"opened-{newId ()}")
+                            Head = Some version
+                        }
+
+                    { state with
+                        Sessions =
+                            state.Sessions
+                            |> Map.add
+                                sid
+                                { record with
+                                    Session = session
+                                    OpenedWith = Some id
+                                }
+                        Challenges = state.Challenges |> Map.remove sid
+                        Notices = state.Notices |> Map.remove sid
+                    },
+                    Some session
+
+
     /// Concept 10: an order appears once in a plan.
     let duplicateOrders (scenarios: OrderScenario[]) =
         scenarios |> Array.countBy _.Order.Id |> Array.exists (fun (_, n) -> n > 1)
@@ -1309,6 +1368,7 @@ module Hop =
                         return update (fun s -> commit (now ()) newId registry.standing mail.send sid submission s)
                     }
             seen = fun sid opened -> async { return update (seen (now ()) sid opened) }
+            openVersion = fun sid id -> async { return update (openVersion (now ()) newId sid id) }
         }
 
 
@@ -1789,6 +1849,7 @@ module Adapters =
             challenge = fun _ _ -> async { return SigningResponse.Refused SigningRefusal.NoSession }
             submit = fun _ _ -> async { return SigningResponse.Refused SigningRefusal.NoSession }
             seen = fun _ _ -> async { return None }
+            openVersion = fun _ _ -> async { return None }
         }
 
 

--- a/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
@@ -105,6 +105,14 @@ module CompositionRoot =
                         enrolment.delete ()
                         return SessionResponse.PinRefused refusal
                     | SupplyPinResult.Refused refusal -> return SessionResponse.PinRefused refusal
+            // UC-4 step 4: for the Session the cookie names; without a cookie there is nothing to
+            // open. Writes no cookie.
+            | SessionCommand.OpenVersion id ->
+                match cookie.read () with
+                | None -> return SessionResponse.SessionResp None
+                | Some sid ->
+                    let! opened = env.session.openVersion sid id
+                    return SessionResponse.SessionResp opened
             | SessionCommand.CloseSession ->
                 try
                     match cookie.read () with

--- a/src/Informedica.GenPRES.Server/ServerApi.Ports.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Ports.fs
@@ -177,6 +177,8 @@ type SessionPort =
         // uc-03 step 1, every computing request: the Session the cookie names is marked seen
         // (Rule 9) and told whether the record moved on (Rule 21) or the Session ended (Rule 11)
         seen: string -> OpenedToken option -> Async<RecordNotice option>
+        // UC-4 step 4: the version named becomes what the Session the cookie names opened with
+        openVersion: string -> string -> Async<SessionOpened option>
     }
 
 

--- a/src/Informedica.GenPRES.Shared/Api.fs
+++ b/src/Informedica.GenPRES.Shared/Api.fs
@@ -191,6 +191,10 @@ module Api =
         // UC-2: the confirmation code from the mail and the chosen PIN, for the attempt the
         // enrolment cookie names
         | SupplyPin of code: string * pin: string
+        // UC-4 step 4 (Rules 18 to 20): the version named becomes what the Session opened with;
+        // answered with the Session as it then is, `SessionResp None` where there is no Session,
+        // no User or no Patient
+        | OpenVersion of id: string
 
 
     [<RequireQualifiedAccess>]
@@ -231,6 +235,7 @@ module Api =
             | SessionCommand.CloseSession -> "CloseSession"
             // never the code or the PIN
             | SessionCommand.SupplyPin _ -> "SupplyPin"
+            | SessionCommand.OpenVersion _ -> "OpenVersion"
 
 
     module SigningCommand =

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -72,6 +72,7 @@ module StubAdapters =
             challenge = fun _ _ -> async { return SigningResponse.Refused SigningRefusal.NoSession }
             submit = fun _ _ -> async { return SigningResponse.Refused SigningRefusal.NoSession }
             seen = fun _ _ -> async { return None }
+            openVersion = fun _ _ -> async { return None }
         }
 
 
@@ -2068,6 +2069,206 @@ module SessionStubTests =
                 ]
 
 
+        let openVersionTests =
+            let t1 = t0.AddMinutes 5.0
+
+            let prescriber =
+                {
+                    UserId = "prescriber"
+                    DisplayName = "Stub Prescriber"
+                    Role = UserRole.Prescriber
+                }
+
+            let other =
+                { prescriber with
+                    UserId = "prescriber-b"
+                    DisplayName = "Stub Prescriber B"
+                }
+
+            let signedBy (user: UserContext) no : SignedOrderPlan =
+                {
+                    Head =
+                        {
+                            Id = $"plan-{no}"
+                            No = no
+                            By = user
+                            SignedAt = t0
+                        }
+                    PatientId = "pat-1"
+                    Base = if no > 1 then Some $"plan-{no - 1}" else None
+                    Scenarios = [||]
+                    Patient = Shared.Models.Patient.empty
+                    Verified = true
+                }
+
+            let session
+                (user: UserContext option)
+                (patientId: string option)
+                (sid: string)
+                (openedWith: string option)
+                : Hop.SessionRecord
+                =
+                {
+                    Session =
+                        {
+                            User = user
+                            PatientContext =
+                                patientId
+                                |> Option.map (fun pid ->
+                                    {
+                                        PatientId = pid
+                                        Patient = Shared.Models.Patient.empty
+                                    }
+                                )
+                            OpenedToken = Some(OpenedToken $"opened-{sid}")
+                            KeyThumbprint = Some "t"
+                            Head = None
+                        }
+                    Login = user |> Option.map _.UserId
+                    OpenedWith = openedWith
+                    Seen = t0
+                }
+
+            let challenged sid : Hop.Challenge =
+                {
+                    Nonce = $"c-{sid}"
+                    Patient = Shared.Models.Patient.empty
+                    Scenarios = [||]
+                    Verified = true
+                    Expiry = t0.AddMinutes 2.0
+                }
+
+            // A opened on plan-1; B signed plan-2 meanwhile; A has a challenge and a notice standing
+            let movedOn =
+                { Hop.emptyState with
+                    Sessions =
+                        Map.ofList
+                            [
+                                "s-1", session (Some prescriber) (Some "pat-1") "s-1" (Some "plan-1")
+                            ]
+                    Records = Map.ofList [ "pat-1", [ signedBy other 2; signedBy prescriber 1 ] ]
+                    Challenges = Map.ofList [ "s-1", challenged "s-1" ]
+                    Notices =
+                        Map.ofList
+                            [
+                                "s-1",
+                                {
+                                    Nonce = "n"
+                                    Data = None
+                                    Expiry = t0.AddMinutes 2.0
+                                }
+                            ]
+                }
+
+            let openAt sid id state =
+                Hop.openVersion t1 (counter "id") sid id state
+
+            testList
+                "Hop.openVersion"
+                [
+                    test "no Session: nothing to open" {
+                        Hop.emptyState |> openAt "s-9" "plan-2" |> snd |> Expect.equal "none" None
+                    }
+
+                    test "an anonymous Session, or one without a Patient: nothing to open (Rule 13)" {
+                        let state =
+                            { movedOn with
+                                Sessions =
+                                    Map.ofList
+                                        [
+                                            "s-a", session None (Some "pat-1") "s-a" None
+                                            "s-n", session (Some prescriber) None "s-n" None
+                                        ]
+                            }
+
+                        state |> openAt "s-a" "plan-2" |> snd |> Expect.equal "anonymous" None
+
+                        state |> openAt "s-n" "plan-2" |> snd |> Expect.equal "no patient" None
+                    }
+
+                    test "an id the record does not hold: nothing opens, the Session as it is, token kept" {
+                        let state, answer = movedOn |> openAt "s-1" "plan-9"
+
+                        answer |> Expect.equal "as it is" (Some movedOn.Sessions["s-1"].Session)
+
+                        state.Sessions["s-1"].OpenedWith |> Expect.equal "unchanged" (Some "plan-1")
+                        state.Challenges |> Map.containsKey "s-1" |> Expect.isTrue "challenge kept"
+                        state.Sessions["s-1"].Seen |> Expect.equal "touched" t1
+                    }
+
+                    test "the version already open: the token stands, the version is answered" {
+                        let state, answer = movedOn |> openAt "s-1" "plan-1"
+
+                        match answer with
+                        | Some opened ->
+                            opened.OpenedToken |> Expect.equal "kept" (Some(OpenedToken "opened-s-1"))
+                            opened.Head |> Expect.equal "the version" (Some(signedBy prescriber 1))
+                        | other -> failtest $"expected the Session, got {other}"
+
+                        state.Challenges |> Map.containsKey "s-1" |> Expect.isTrue "challenge kept"
+                    }
+
+                    test "the head: opened, the token re-minted, the challenge and notice dropped (Rules 19, 34)" {
+                        let state, answer = movedOn |> openAt "s-1" "plan-2"
+
+                        match answer with
+                        | Some opened ->
+                            opened.OpenedToken |> Expect.equal "re-minted" (Some(OpenedToken "opened-id-1"))
+                            opened.Head |> Expect.equal "B's version" (Some(signedBy other 2))
+                        | other -> failtest $"expected the Session, got {other}"
+
+                        state.Sessions["s-1"].OpenedWith
+                        |> Expect.equal "opened with the head" (Some "plan-2")
+
+                        state.Sessions["s-1"].Session.OpenedToken
+                        |> Expect.equal "held" (Some(OpenedToken "opened-id-1"))
+
+                        state.Challenges |> Expect.isEmpty "challenge dropped"
+                        state.Notices |> Expect.isEmpty "notice dropped"
+
+                        Hop.blockedBy state.Sessions["s-1"] "pat-1" state
+                        |> Expect.isNone "Rule 20 no longer blocks"
+
+                        // the notice is gone with it
+                        state
+                        |> Hop.seen t1 "s-1" (Some(OpenedToken "opened-id-1"))
+                        |> snd
+                        |> Expect.isNone "no notice"
+                    }
+
+                    test "an older version: opened, still blocked by the head (Rules 18, 20)" {
+                        let three =
+                            { movedOn with
+                                Records =
+                                    Map.ofList
+                                        [
+                                            "pat-1",
+                                            [
+                                                signedBy prescriber 3
+                                                signedBy other 2
+                                                signedBy prescriber 1
+                                            ]
+                                        ]
+                            }
+
+                        let state, answer = three |> openAt "s-1" "plan-2"
+
+                        match answer with
+                        | Some opened -> opened.Head |> Expect.equal "plan-2" (Some(signedBy other 2))
+                        | other -> failtest $"expected the Session, got {other}"
+
+                        Hop.blockedBy state.Sessions["s-1"] "pat-1" state
+                        |> Option.map _.Id
+                        |> Expect.equal "the head still blocks" (Some "plan-3")
+
+                        state
+                        |> Hop.seen t1 "s-1" state.Sessions["s-1"].Session.OpenedToken
+                        |> snd
+                        |> Expect.isSome "and the notice says so again (Rule 21)"
+                    }
+                ]
+
+
         let challengeTests =
             let minutes (n: float) = TimeSpan.FromMinutes n
             let seconds (n: float) = TimeSpan.FromSeconds n
@@ -2960,6 +3161,7 @@ module SessionStubTests =
                     supplyTests
                     dropTests
                     seenTests
+                    openVersionTests
                     challengeTests
                     commitTests
                 ]
@@ -4230,6 +4432,31 @@ module SessionStubTests =
                         | Api.FormularyResp _ -> ()
                         | other -> failtest $"still computed, got {other}"
                     | Error errs -> failtest $"expected Ok, got {errs}"
+                }
+
+                testAsync "OpenVersion without a cookie: no Session; with one and an unknown id: the Session as it is" {
+                    let directory, env = envWithStub ()
+                    let cookie, _ = memoryCookie None
+                    let stateCookie, _ = memoryStateCookie None
+                    let api = CompositionRoot.compose settings env cookie stateCookie (noEnrolment ())
+
+                    let! before = api.processSession (SessionCommand.OpenVersion "plan-1")
+                    before |> Expect.equal "no session" (SessionResponse.SessionResp None)
+
+                    let! _ =
+                        openVia
+                            directory
+                            env
+                            cookie
+                            stateCookie
+                            (noEnrolment ())
+                            (mintFor "n-1" "stub-patient")
+                            keyA
+                            "prescriber"
+
+                    let! opened = sessionOf env cookie
+                    let! answer = api.processSession (SessionCommand.OpenVersion "plan-1")
+                    answer |> Expect.equal "as it is" (SessionResponse.SessionResp(Some opened))
                 }
             ]
 

--- a/tests/Informedica.GenPRES.Shared.Tests/SessionMachineTests.fs
+++ b/tests/Informedica.GenPRES.Shared.Tests/SessionMachineTests.fs
@@ -632,30 +632,49 @@ module SessionMachineTests =
         testList
             "OpenVersion (UC-4 step 4)"
             [
-                test "OpenVersion from Open calls the server; elsewhere it is dropped" {
+                test "OpenVersion from Open calls the server with the token it starts from; elsewhere dropped" {
                     transition (SessionMsg.OpenVersion "plan-2") (Session.Open full)
-                    |> Expect.equal "call" (Session.Open full, [ SessionEffect.CallOpenVersion "plan-2" ])
+                    |> Expect.equal
+                        "call"
+                        (Session.Open full,
+                         [
+                             SessionEffect.CallOpenVersion("plan-2", full.OpenedToken)
+                         ])
 
                     transition (SessionMsg.OpenVersion "plan-2") Session.Anonymous
                     |> Expect.equal "dropped" (Session.Anonymous, [])
                 }
 
                 test "Reopened with the Session replaces it and loads the version into the cart, no SetPatient" {
-                    transition (SessionMsg.Reopened(Ok(Some reopened))) (Session.Open full)
+                    transition (SessionMsg.Reopened(full.OpenedToken, Ok(Some reopened))) (Session.Open full)
                     |> Expect.equal "reopened" (Session.Open reopened, [ SessionEffect.LoadCart head ])
                 }
 
                 test "Reopened with nothing to open, or a transport failure, leaves the Session as it was" {
-                    transition (SessionMsg.Reopened(Ok None)) (Session.Open full)
+                    transition (SessionMsg.Reopened(full.OpenedToken, Ok None)) (Session.Open full)
                     |> Expect.equal "nothing to open" (Session.Open full, [])
 
-                    transition (SessionMsg.Reopened(Error "offline")) (Session.Open full)
+                    transition (SessionMsg.Reopened(full.OpenedToken, Error "offline")) (Session.Open full)
                     |> Expect.equal "failed" (Session.Open full, [])
                 }
 
-                test "Reopened lands only on an open Session" {
-                    transition (SessionMsg.Reopened(Ok(Some reopened))) Session.Anonymous
-                    |> Expect.equal "dropped" (Session.Anonymous, [])
+                test "Reopened lands only on the open Session that still holds the token it started from" {
+                    transition (SessionMsg.Reopened(full.OpenedToken, Ok(Some reopened))) Session.Anonymous
+                    |> Expect.equal "not open: dropped" (Session.Anonymous, [])
+
+                    // a relaunch or an earlier OpenVersion changed the token meanwhile
+                    let newer = { full with OpenedToken = Some(OpenedToken "t-newer") }
+
+                    transition (SessionMsg.Reopened(full.OpenedToken, Ok(Some reopened))) (Session.Open newer)
+                    |> Expect.equal "stale: dropped" (Session.Open newer, [])
+
+                    // two quick selections: the first answer lands, the second started from the same
+                    // token and is dropped, so the User sees the version the first one opened
+                    let afterFirst, _ =
+                        transition (SessionMsg.Reopened(full.OpenedToken, Ok(Some reopened))) (Session.Open full)
+
+                    transition (SessionMsg.Reopened(full.OpenedToken, Ok(Some full))) afterFirst
+                    |> Expect.equal "second dropped" (Session.Open reopened, [])
                 }
             ]
 

--- a/tests/Informedica.GenPRES.Shared.Tests/SessionMachineTests.fs
+++ b/tests/Informedica.GenPRES.Shared.Tests/SessionMachineTests.fs
@@ -606,6 +606,60 @@ module SessionMachineTests =
             ]
 
 
+    let openVersionTests =
+        let head: SignedOrderPlan =
+            {
+                Head =
+                    {
+                        Id = "plan-2"
+                        No = 2
+                        By = full.User.Value
+                        SignedAt = System.DateTime(2026, 9, 11, 12, 0, 0, System.DateTimeKind.Utc)
+                    }
+                PatientId = "p"
+                Base = Some "plan-1"
+                Scenarios = [||]
+                Patient = patient
+                Verified = true
+            }
+
+        let reopened =
+            { full with
+                OpenedToken = Some(OpenedToken "t-2")
+                Head = Some head
+            }
+
+        testList
+            "OpenVersion (UC-4 step 4)"
+            [
+                test "OpenVersion from Open calls the server; elsewhere it is dropped" {
+                    transition (SessionMsg.OpenVersion "plan-2") (Session.Open full)
+                    |> Expect.equal "call" (Session.Open full, [ SessionEffect.CallOpenVersion "plan-2" ])
+
+                    transition (SessionMsg.OpenVersion "plan-2") Session.Anonymous
+                    |> Expect.equal "dropped" (Session.Anonymous, [])
+                }
+
+                test "Reopened with the Session replaces it and loads the version into the cart, no SetPatient" {
+                    transition (SessionMsg.Reopened(Ok(Some reopened))) (Session.Open full)
+                    |> Expect.equal "reopened" (Session.Open reopened, [ SessionEffect.LoadCart head ])
+                }
+
+                test "Reopened with nothing to open, or a transport failure, leaves the Session as it was" {
+                    transition (SessionMsg.Reopened(Ok None)) (Session.Open full)
+                    |> Expect.equal "nothing to open" (Session.Open full, [])
+
+                    transition (SessionMsg.Reopened(Error "offline")) (Session.Open full)
+                    |> Expect.equal "failed" (Session.Open full, [])
+                }
+
+                test "Reopened lands only on an open Session" {
+                    transition (SessionMsg.Reopened(Ok(Some reopened))) Session.Anonymous
+                    |> Expect.equal "dropped" (Session.Anonymous, [])
+                }
+            ]
+
+
     [<Tests>]
     let tests =
         testList
@@ -616,4 +670,5 @@ module SessionMachineTests =
                 retryTests
                 resumeTests
                 endingTests
+                openVersionTests
             ]


### PR DESCRIPTION
## Summary

Plan 635 step 3 of 5 ([plan](https://github.com/informedica/GenPRES/blob/master/docs/implementation-plans/635-session-bound-compute.md)): opening the version the notice named, UC-4 step 4, the model's `OpenOrderPlan of OrderPlanId`. No visible change yet: the button, the notice bar and the terms are step 4.

- **Wire**: `SessionCommand.OpenVersion of id: string`, answered with the existing `SessionResp of SessionOpened option`.
- **Server**: `Hop.openVersion` (Rules 18 to 20, 34). No Session, an anonymous one or one without a Patient: nothing to open (Rule 13). An id the record does not hold for the Session's Patient (a stale button, a restart): nothing opens, the Session as it is, and the next request tells what the head is (Rule 21). The version already open: the token stands. Another version: it becomes `OpenedWith`, the OpenedToken is re-minted over it, the standing challenge and notice of this Session are dropped (a challenge over the old baseline must not be answerable). Any version may be opened (Rule 18); one that is not the head leaves Submission blocked (Rule 20) and is told again (Rule 21). The Session is touched (Rule 9). `SessionPort.openVersion` answers `SessionOpened option`, as `find` answers a `SessionLookup`, since the adapter does not see `Shared.Api`; the composition root wraps it, and answers no Session without a cookie. `sessionDisabled` answers nothing.
- **Client**: `SessionMsg.OpenVersion of id` (from an open Session only) → `SessionEffect.CallOpenVersion` → `processSession`; `SessionMsg.Reopened` with the Session replaces it and loads the version into the cart through `LoadCart`, with no `SetPatient`, the patient being unchanged; nothing to open or a transport failure leaves the Session as it was.
- **Tests**: seven on the server (six over the ladder, including that after opening the head Rule 20 no longer blocks and the notice is gone, that an older version stays blocked and is told again, and one through the composition root: no cookie, then an unknown id); four over the machine. Server tests 259, shared 460.

Script-first: `Server/Scripts/Compute.fsx` (6 tests), migrated after review.

## Verification

- `dotnet run Build`, server tests 259/259, shared tests 460/460, Fantomas, Fable.
- In the browser (wire only, no button yet): as `prescriber` on a signed record, `processSession` with `OpenVersion <head id>` answers the Session with `Head` set to that version and a fresh `OpenedToken`; with an unknown id, the Session unchanged; without a cookie, no Session.

Refs #635

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZWjibQUW8uqCVbfV4vDTf
