### PR TITLE
feat(client): tell that the record moved on and offer the newest version (#635)

### DIFF
--- a/src/Informedica.GenPRES.Client/App.fs
+++ b/src/Informedica.GenPRES.Client/App.fs
@@ -127,7 +127,16 @@ module private Elmish =
         | LoadLogAnalysisResult of ApiResponse
 
 
-    and ApiResponse = AsyncOperationStatus<Result<Api.Reply, string[]>>
+    and ApiResponse = AsyncOperationStatus<Result<Answer, string[]>>
+
+    /// A computing reply with the OpenedToken the request started from, so that what the reply
+    /// tells about the Session (Rules 11, 21) lands only on the Session that asked: a request
+    /// of a Session since closed or replaced must not end or warn the current one.
+    and Answer =
+        {
+            From: OpenedToken option
+            Reply: Api.Reply
+        }
 
 
     let serverApi =
@@ -177,7 +186,16 @@ module private Elmish =
                     : Api.Request
                 )
 
-            return Finished result |> msg
+            return
+                result
+                |> Result.map (fun reply ->
+                    {
+                        From = opened
+                        Reply = reply
+                    }
+                )
+                |> Finished
+                |> msg
         }
         |> Cmd.fromAsync
 
@@ -239,15 +257,24 @@ module private Elmish =
 
 
     /// The result, and what the Session is told with it: the record moved on (Rules 21, 22) or
-    /// the Session ended (Rule 11), each as its own message so the machines decide.
-    let processApiMsg (state: State) (reply: Api.Reply) =
+    /// the Session ended (Rule 11), each as its own message so the machines decide. The
+    /// stale-request guard: the notice counts only when the request started from the token the
+    /// open Session holds now; a reply of a Session since closed, replaced or re-minted says
+    /// nothing about this one (the next request repeats what still holds, Rule 21 is stateless).
+    let processApiMsg (state: State) (answer: Answer) =
+        let current =
+            match state.Session with
+            | Session.Open opened -> Some opened.OpenedToken
+            | _ -> None
+
         let told =
-            match reply.Notice with
+            match answer.Reply.Notice with
+            | Some _ when current <> Some answer.From -> Cmd.none
             | Some(RecordNotice.NewerVersion head) -> Cmd.ofMsg (RecordMovedOn head)
             | Some(RecordNotice.Ended ending) -> Cmd.ofMsg (SessionMsg(SessionMsg.EndedByServer ending))
             | None -> Cmd.none
 
-        let state, cmd = processResponse state reply.Response
+        let state, cmd = processResponse state answer.Reply.Response
         state, Cmd.batch [ cmd; told ]
 
 
@@ -1156,7 +1183,8 @@ module private Elmish =
                                 SnackbarOpen = true
                                 SnackbarSeverity = "success"
                             },
-                            None
+                            // a newer notice told meanwhile stays, with its offer
+                            MovedOn.opened movedOn head
                         | _ -> state, movedOn
                     )
                     (state, movedOn)

--- a/src/Informedica.GenPRES.Client/App.fs
+++ b/src/Informedica.GenPRES.Client/App.fs
@@ -55,6 +55,9 @@ module private Elmish =
             Session: Session
             // the signing phase of the open Session (plan 622); Idle whenever no Session is open
             Signing: Signing
+            // Rules 21, 22 (plan 635): the newest version told while the Session is on an older
+            // one; None whenever no Session is open
+            MovedOn: OrderPlanHead option
             // what the server was configured with: the default language, the demo flag
             Settings: Deferred<Api.ServerSettings>
             // the url or the User chose the language (LanguagePolicy); the server default no
@@ -73,6 +76,8 @@ module private Elmish =
         | UpdatePatient of Patient option
         // Rule 19: the version the Session opened with, into the cart over the patient in state
         | LoadCart of SignedOrderPlan
+        // Rules 21, 22: a reply said the record moved on
+        | RecordMovedOn of OrderPlanHead
 
         | LoadNormalValues of AsyncOperationStatus<Result<NormalValues, string>>
 
@@ -177,12 +182,8 @@ module private Elmish =
         |> Cmd.fromAsync
 
 
-    let processApiMsg (state: State) (reply: Api.Reply) =
-        // plan 635 PR 1: the notice is carried and logged, not shown yet
-        reply.Notice
-        |> Option.iter (fun notice -> Logging.warning "record notice" notice)
-
-        match reply.Response with
+    let processResponse (state: State) (response: Api.Response) =
+        match response with
         | Api.OrderContextResp(Api.OrderContextResult ctx) -> { state with OrderContext = Resolved ctx }, Cmd.none
         | Api.OrderPlanResp(Api.OrderPlanFiltered tp)
         | Api.OrderPlanResp(Api.OrderPlanUpdated tp) ->
@@ -235,6 +236,19 @@ module private Elmish =
         | Api.LogAnalyzerResp(Api.LogFilesListed files) -> { state with LogFiles = Resolved files }, Cmd.none
         | Api.LogAnalyzerResp(Api.LogFileAnalyzed report) ->
             { state with LogAnalysisReport = Resolved report }, Cmd.none
+
+
+    /// The result, and what the Session is told with it: the record moved on (Rules 21, 22) or
+    /// the Session ended (Rule 11), each as its own message so the machines decide.
+    let processApiMsg (state: State) (reply: Api.Reply) =
+        let told =
+            match reply.Notice with
+            | Some(RecordNotice.NewerVersion head) -> Cmd.ofMsg (RecordMovedOn head)
+            | Some(RecordNotice.Ended ending) -> Cmd.ofMsg (SessionMsg(SessionMsg.EndedByServer ending))
+            | None -> Cmd.none
+
+        let state, cmd = processResponse state reply.Response
+        state, Cmd.batch [ cmd; told ]
 
 
     let loadOrderContext opened resp =
@@ -510,6 +524,7 @@ module private Elmish =
             LogAnalysisReport = HasNotStartedYet
             Session = Session.Anonymous
             Signing = Signing.Idle
+            MovedOn = None
             Settings = HasNotStartedYet
             LanguageChosen = (LanguagePolicy.Language.initial lang).Chosen
         }
@@ -652,6 +667,8 @@ module private Elmish =
                     return SessionMsg(SessionMsg.Resumed(Error ex.Message))
             }
             |> Cmd.fromAsync
+        // told in update, where the sentence and the notice live
+        | SessionEffect.TellVersionOpened _ -> Cmd.none
         | SessionEffect.CallOpenVersion(id, from) ->
             async {
                 try
@@ -966,6 +983,28 @@ module private Elmish =
 
         // FilterOrderPlan sends the cart through the server so totals and filters are computed
         // as for any cart; the patient is the one every other part of the state uses
+        // told once per version (Rule 22: it gates nothing); the bar on the order plan offers it
+        | RecordMovedOn head ->
+            let movedOn, news = MovedOn.receive state.MovedOn head
+            let state = { state with MovedOn = movedOn }
+
+            if news then
+                let tr term =
+                    Global.getLocalizedTerm
+                        state.Localization
+                        state.Context.Localization
+                        (SigningPolicy.english term)
+                        term
+
+                { state with
+                    SnackbarMsg = SigningPolicy.movedOnSentence tr head
+                    SnackbarOpen = true
+                    SnackbarSeverity = "warning"
+                },
+                Cmd.none
+            else
+                state, Cmd.none
+
         | LoadCart head ->
             match state.Patient with
             | Some pat -> state, Cmd.ofMsg (OrderPlanMsg(Api.FilterOrderPlan(OrderPlan.create pat head.Scenarios)))
@@ -1091,15 +1130,41 @@ module private Elmish =
                     }
                 | _ -> state
 
-            // a signature belongs to an open Session: whatever ends the Session drops it (ext 3e)
-            let signing =
+            // a signature belongs to an open Session: whatever ends the Session drops it (ext 3e);
+            // so does the moved-on notice
+            let signing, movedOn =
                 match session with
-                | Session.Open _ -> state.Signing
-                | _ -> Signing.Idle
+                | Session.Open _ -> state.Signing, state.MovedOn
+                | _ -> Signing.Idle, None
+
+            // UC-4 step 4: the version is open; said once, and the notice is spent
+            let state, movedOn =
+                effects
+                |> List.fold
+                    (fun (state, movedOn) effect ->
+                        match effect with
+                        | SessionEffect.TellVersionOpened head ->
+                            let tr term =
+                                Global.getLocalizedTerm
+                                    state.Localization
+                                    state.Context.Localization
+                                    (SigningPolicy.english term)
+                                    term
+
+                            { state with
+                                SnackbarMsg = SigningPolicy.versionOpenedSentence tr head
+                                SnackbarOpen = true
+                                SnackbarSeverity = "success"
+                            },
+                            None
+                        | _ -> state, movedOn
+                    )
+                    (state, movedOn)
 
             { state with
                 Session = session
                 Signing = signing
+                MovedOn = movedOn
             },
             effects |> List.map interpretSessionEffect |> Cmd.batch
 
@@ -1123,6 +1188,11 @@ module private Elmish =
                         match effect with
                         | SigningEffect.TellSigned signed ->
                             state |> tell (SigningPolicy.signedSentence tr signed) "success"
+                        // a refusal because the record moved on (Rule 20) is the notice too
+                        // (Rule 22); the sentence is told here, the bar offers the version
+                        | SigningEffect.TellRefused(SigningRefusal.Blocked head as refusal) ->
+                            { state with MovedOn = MovedOn.receive state.MovedOn head |> fst }
+                            |> tell (SigningPolicy.refusalSentence tr refusal) "warning"
                         | SigningEffect.TellRefused refusal ->
                             state |> tell (SigningPolicy.refusalSentence tr refusal) "warning"
                         | SigningEffect.TellError reason ->
@@ -1570,6 +1640,11 @@ type private ConcreteAppEnv
 
         member _.SupplyPin code pin =
             SessionMsg(SessionMsg.SupplyPin(code, pin)) |> dispatch
+
+        member _.MovedOn = state.MovedOn
+
+        member _.OpenVersion id =
+            SessionMsg(SessionMsg.OpenVersion id) |> dispatch
 
     interface AppEnv.ISigning with
         member _.Signing = state.Signing

--- a/src/Informedica.GenPRES.Client/AppEnv.fs
+++ b/src/Informedica.GenPRES.Client/AppEnv.fs
@@ -82,6 +82,10 @@ type ISession =
     abstract OpenAnonymously: unit -> unit
     // UC-2: the confirmation code and the chosen PIN, from the gate's form
     abstract SupplyPin: string -> string -> unit
+    // Rules 21, 22: the newest version the server told of, while the Session is on an older one
+    abstract MovedOn: OrderPlanHead option
+    // UC-4 step 4: take up that version
+    abstract OpenVersion: string -> unit
 
 
 /// The signing phase of the open Session (UC-3, plan 622): its state, and the actions the

--- a/src/Informedica.GenPRES.Client/SessionGatePolicy.fs
+++ b/src/Informedica.GenPRES.Client/SessionGatePolicy.fs
@@ -87,6 +87,9 @@ let english (term: Terms) =
     | Terms.``Session Enrolment Wrong Code`` -> "The code is not right. {0} tries left."
     | Terms.``Session Enrolment Code Void`` -> "The code is void after three wrong tries."
     | Terms.``Session Enrolment Expired`` -> "The enrolment has expired."
+    | Terms.``Session Newer Version`` -> "{0} signed a newer version at {1}."
+    | Terms.``Session Open Newest`` -> "Open the newest version"
+    | Terms.``Session Version Opened`` -> "Version {0} by {1} is now open."
     | _ -> $"{term}"
 
 

--- a/src/Informedica.GenPRES.Client/SessionMachine.fs
+++ b/src/Informedica.GenPRES.Client/SessionMachine.fs
@@ -276,9 +276,20 @@ module Session =
 /// offer that version (UC-4 step 4). Cleared when the version is opened or the Session ends.
 module MovedOn =
 
-    /// A notice arrived: the head to keep, and whether it is news (a version not told before).
-    /// The same head again is not news; a newer one replaces the kept one and is.
+    /// A notice arrived: the head to keep, and whether it is news. Versions are ordered by
+    /// `No` (Rule 20), not by arrival: replies to concurrent requests can land out of order, so
+    /// a notice of a version no newer than the one kept is not news and keeps nothing, and only
+    /// a newer version replaces the kept one.
     let receive (current: OrderPlanHead option) (head: OrderPlanHead) : OrderPlanHead option * bool =
         match current with
-        | Some kept when kept.Id = head.Id -> current, false
+        | Some kept when kept.No >= head.No -> current, false
         | _ -> Some head, true
+
+
+    /// A version was opened (UC-4 step 4): the notice is spent when the version opened is at
+    /// least as new as the one kept; a newer notice, told while the request was in flight,
+    /// stays, so the offer to open it stays too.
+    let opened (current: OrderPlanHead option) (head: OrderPlanHead) : OrderPlanHead option =
+        match current with
+        | Some kept when kept.No > head.No -> current
+        | _ -> None

--- a/src/Informedica.GenPRES.Client/SessionMachine.fs
+++ b/src/Informedica.GenPRES.Client/SessionMachine.fs
@@ -111,6 +111,8 @@ type SessionEffect =
     | LoadCart of SignedOrderPlan
     // UC-4 step 4: processSession OpenVersion; `from` comes back in Reopened
     | CallOpenVersion of id: string * from: OpenedToken option
+    // UC-4 step 4: the version is open; told once, and the moved-on notice is cleared
+    | TellVersionOpened of OrderPlanHead
 
 
 module Session =
@@ -261,7 +263,22 @@ module Session =
             Session.Open session,
             [
                 match session.PatientContext, session.Head with
-                | Some _, Some head -> SessionEffect.LoadCart head
+                | Some _, Some head ->
+                    SessionEffect.LoadCart head
+                    SessionEffect.TellVersionOpened head.Head
                 | _ -> ()
             ]
         | SessionMsg.Reopened _, _ -> state, []
+
+
+/// Rules 21, 22: the notice that the record moved on, as the client keeps it next to its open
+/// Session: the newest head it was told, so that it is told once per version, and the bar can
+/// offer that version (UC-4 step 4). Cleared when the version is opened or the Session ends.
+module MovedOn =
+
+    /// A notice arrived: the head to keep, and whether it is news (a version not told before).
+    /// The same head again is not news; a newer one replaces the kept one and is.
+    let receive (current: OrderPlanHead option) (head: OrderPlanHead) : OrderPlanHead option * bool =
+        match current with
+        | Some kept when kept.Id = head.Id -> current, false
+        | _ -> Some head, true

--- a/src/Informedica.GenPRES.Client/SigningPolicy.fs
+++ b/src/Informedica.GenPRES.Client/SigningPolicy.fs
@@ -66,6 +66,18 @@ let signedSentence (tr: Terms -> string) (signed: SignedOrderPlan) =
     |> SessionGatePolicy.fill [ string signed.Head.No; signed.Head.By.DisplayName ]
 
 
+/// Rules 21, 22: the record moved on; whose version, and when.
+let movedOnSentence (tr: Terms -> string) (head: OrderPlanHead) =
+    tr Terms.``Session Newer Version``
+    |> SessionGatePolicy.fill [ head.By.DisplayName; time head.SignedAt ]
+
+
+/// UC-4 step 4: the version taken up is open.
+let versionOpenedSentence (tr: Terms -> string) (head: OrderPlanHead) =
+    tr Terms.``Session Version Opened``
+    |> SessionGatePolicy.fill [ string head.No; head.By.DisplayName ]
+
+
 /// Rule 44: what the notice says, with or without a reading.
 let noticeSentence (tr: Terms -> string) (notice: DataNotice) =
     match notice.Data with

--- a/src/Informedica.GenPRES.Client/Views/OrderPlan.fs
+++ b/src/Informedica.GenPRES.Client/Views/OrderPlan.fs
@@ -382,6 +382,36 @@ module OrderPlan =
                 """
             | _ -> null
 
+        // Rules 21, 22 (plan 635): the record moved on while this Session is on an older version;
+        // the bar says whose and when, and offers the newest version (UC-4 step 4). Rule 20 stays
+        // the guard: nothing is blocked here
+        let movedOnBar =
+            match session.MovedOn with
+            | Some head ->
+                let onOpenNewest = fun _ -> session.OpenVersion head.Id
+
+                let openNewest =
+                    JSX.jsx
+                        $"""
+                    import Button from '@mui/material/Button';
+
+                    <Button color="inherit" size="small" onClick={onOpenNewest}>
+                        {tr Terms.``Session Open Newest``}
+                    </Button>
+                    """
+
+                JSX.jsx
+                    $"""
+                import Alert from '@mui/material/Alert';
+
+                <Box sx={ {| marginTop = 2 |} }>
+                    <Alert severity="warning" action={openNewest}>
+                        {SigningPolicy.movedOnSentence tr head}
+                    </Alert>
+                </Box>
+                """
+            | None -> null
+
         let signDialog = SignDialog.View {| appEnv = props.appEnv |}
 
         let responsiveTable =
@@ -420,7 +450,7 @@ module OrderPlan =
         import Modal from '@mui/material/Modal';
 
         <Box sx={ {| height = "100%" |} }>
-            {signBtn}
+            {movedOnBar}{signBtn}
             {deleteBtn}
             {responsiveTable}
             <Modal open={modalOpen} onClose={handleModalClose} >

--- a/src/Informedica.GenPRES.Shared/Localization.fs
+++ b/src/Informedica.GenPRES.Shared/Localization.fs
@@ -199,6 +199,11 @@ type Terms =
     | ``Signing Refusal Pin Limit``
     | ``Signing Refusal Locked``
     | ``Signing Send Failed``
+    // Rules 21, 22 (plan 635): the record moved on, told once per version; the button that
+    // takes the version up (UC-4 step 4); what is told once it is open
+    | ``Session Newer Version``
+    | ``Session Open Newest``
+    | ``Session Version Opened``
 
 
 module Localization =

--- a/src/Informedica.GenPRES.Shared/Scripts/Localization.fsx
+++ b/src/Informedica.GenPRES.Shared/Scripts/Localization.fsx
@@ -92,6 +92,12 @@ type SessionTerms =
     | ``Signing Refusal Pin Limit``
     | ``Signing Refusal Locked``
     | ``Signing Send Failed``
+    // Rules 21, 22 (plan 635 PR 4): the record moved on, told once per version with {0} who
+    // signed it and {1} when; the button that takes the version up (UC-4 step 4); and what
+    // is told once it is open, {0} the version number and {1} who signed it
+    | ``Session Newer Version``
+    | ``Session Open Newest``
+    | ``Session Version Opened``
 
 
 /// The English defaults: the strings the client shows today, verbatim.
@@ -161,6 +167,9 @@ let english term =
         "The PIN was entered wrong three times. Your session was ended and signing is locked for a while."
     | ``Signing Refusal Locked`` -> "Signing is locked until {0}."
     | ``Signing Send Failed`` -> "The signature could not be sent. Try again."
+    | ``Session Newer Version`` -> "{0} signed a newer version at {1}."
+    | ``Session Open Newest`` -> "Open the newest version"
+    | ``Session Version Opened`` -> "Version {0} by {1} is now open."
 
 
 /// Dutch, for the sheet; the other four languages stay empty and fall back to English.
@@ -232,6 +241,9 @@ let dutch term =
         "De pincode is drie keer verkeerd ingevoerd. Uw sessie is beëindigd en ondertekenen is een tijdje geblokkeerd."
     | ``Signing Refusal Locked`` -> "Ondertekenen is geblokkeerd tot {0}."
     | ``Signing Send Failed`` -> "De handtekening kon niet worden verstuurd. Probeer het opnieuw."
+    | ``Session Newer Version`` -> "{0} heeft om {1} een nieuwere versie ondertekend."
+    | ``Session Open Newest`` -> "Open de nieuwste versie"
+    | ``Session Version Opened`` -> "Versie {0} van {1} is nu geopend."
 
 
 let all =
@@ -378,6 +390,8 @@ let tests =
                         ``Signing Refusal Blocked``
                         ``Signing Refusal Pin Wrong``
                         ``Signing Refusal Locked``
+                        ``Session Newer Version``
+                        ``Session Version Opened``
                      |]
                      |> Array.sort)
 
@@ -387,6 +401,8 @@ let tests =
                         ``Session Gate Enrolment Text``
                         ``Signing Signed``
                         ``Signing Refusal Blocked``
+                        ``Session Newer Version``
+                        ``Session Version Opened``
                     ] do
                     (english t).Contains "{1}" |> Expect.isTrue $"{{1}} en {t}"
                     (dutch t).Contains "{1}" |> Expect.isTrue $"{{1}} nl {t}"

--- a/tests/Informedica.GenPRES.Shared.Tests/SessionMachineTests.fs
+++ b/tests/Informedica.GenPRES.Shared.Tests/SessionMachineTests.fs
@@ -645,9 +645,37 @@ module SessionMachineTests =
                     |> Expect.equal "dropped" (Session.Anonymous, [])
                 }
 
-                test "Reopened with the Session replaces it and loads the version into the cart, no SetPatient" {
+                test
+                    "Reopened with the Session replaces it, loads the version into the cart and tells it, no SetPatient" {
                     transition (SessionMsg.Reopened(full.OpenedToken, Ok(Some reopened))) (Session.Open full)
-                    |> Expect.equal "reopened" (Session.Open reopened, [ SessionEffect.LoadCart head ])
+                    |> Expect.equal
+                        "reopened"
+                        (Session.Open reopened,
+                         [
+                             SessionEffect.LoadCart head
+                             SessionEffect.TellVersionOpened head.Head
+                         ])
+                }
+
+                test "MovedOn.receive: news once per version, a newer version replaces the kept one (Rules 21, 22)" {
+                    let first = head.Head
+
+                    let second =
+                        { first with
+                            Id = "plan-3"
+                            No = 3
+                        }
+
+                    MovedOn.receive None first |> Expect.equal "first: news" (Some first, true)
+
+                    MovedOn.receive (Some first) first
+                    |> Expect.equal "again: not news" (Some first, false)
+
+                    MovedOn.receive (Some first) second
+                    |> Expect.equal "newer: news" (Some second, true)
+
+                    MovedOn.receive (Some second) first
+                    |> Expect.equal "another id: news too" (Some first, true)
                 }
 
                 test "Reopened with nothing to open, or a transport failure, leaves the Session as it was" {

--- a/tests/Informedica.GenPRES.Shared.Tests/SessionMachineTests.fs
+++ b/tests/Informedica.GenPRES.Shared.Tests/SessionMachineTests.fs
@@ -657,7 +657,7 @@ module SessionMachineTests =
                          ])
                 }
 
-                test "MovedOn.receive: news once per version, a newer version replaces the kept one (Rules 21, 22)" {
+                test "MovedOn.receive: news once per version, ordered by No, not by arrival (Rules 20 to 22)" {
                     let first = head.Head
 
                     let second =
@@ -674,8 +674,26 @@ module SessionMachineTests =
                     MovedOn.receive (Some first) second
                     |> Expect.equal "newer: news" (Some second, true)
 
+                    // replies land out of order: an older version told last is not news and is not kept
                     MovedOn.receive (Some second) first
-                    |> Expect.equal "another id: news too" (Some first, true)
+                    |> Expect.equal "older: nothing" (Some second, false)
+                }
+
+                test "MovedOn.opened: the notice is spent by a version at least as new, a newer notice stays" {
+                    let two = head.Head
+
+                    let three =
+                        { two with
+                            Id = "plan-3"
+                            No = 3
+                        }
+
+                    MovedOn.opened (Some two) two |> Expect.isNone "the version told is open"
+                    MovedOn.opened (Some two) three |> Expect.isNone "a newer one is open"
+                    MovedOn.opened None two |> Expect.isNone "nothing kept"
+
+                    MovedOn.opened (Some three) two
+                    |> Expect.equal "version 3 told while 2 was opening: the offer stays" (Some three)
                 }
 
                 test "Reopened with nothing to open, or a transport failure, leaves the Session as it was" {

--- a/tests/Informedica.GenPRES.Shared.Tests/SigningPolicyTests.fs
+++ b/tests/Informedica.GenPRES.Shared.Tests/SigningPolicyTests.fs
@@ -88,6 +88,38 @@ let tests =
                 |> Expect.equal
                     "the session terms fall through"
                     (SessionGatePolicy.english Terms.``Session Ending Pin Limit``)
+
+                for term in
+                    [
+                        Terms.``Session Newer Version``
+                        Terms.``Session Open Newest``
+                        Terms.``Session Version Opened``
+                    ] do
+                    english term |> Expect.notEqual $"default for {term}" $"{term}"
+            }
+
+            test
+                "the moved-on and version-opened sentences name whose version, when and which (Rules 21, 22; UC-4 step 4)" {
+                let at = System.DateTime(2026, 9, 11, 12, 30, 0, System.DateTimeKind.Utc)
+
+                let head: OrderPlanHead =
+                    {
+                        Id = "plan-2"
+                        No = 2
+                        By =
+                            {
+                                UserId = "b"
+                                DisplayName = "Stub Prescriber B"
+                                Role = UserRole.Prescriber
+                            }
+                        SignedAt = at
+                    }
+
+                movedOnSentence english head
+                |> Expect.equal "moved on" $"Stub Prescriber B signed a newer version at {time at}."
+
+                versionOpenedSentence english head
+                |> Expect.equal "opened" "Version 2 by Stub Prescriber B is now open."
             }
 
             test "one term per refusal; the block names the signer and the time, the tries and the lock are filled" {


### PR DESCRIPTION
## Summary

Plan 635 step 4 of 5 ([plan](https://github.com/informedica/GenPRES/blob/master/docs/implementation-plans/635-session-bound-compute.md)): the notice in the client. UC-4 now runs end to end in two browsers.

- **The notice** (Rules 21, 22): a reply's `NewerVersion` becomes `RecordMovedOn`; it is told once per version, as a snackbar with whose version and when, and kept as `MovedOn` next to the Session in App state, cleared when the Session leaves Open or a version opens. It gates nothing.
- **The bar** on the order plan: a warning with the sentence and a button, "Open the newest version", which sends `OpenVersion` through the session machine (step 3); the reopened Session loads the version into the cart and says which version is open (`TellVersionOpened`).
- **A Blocked refusal** (Rule 20) closes the dialog as before, tells its sentence once, and sets the same bar, so the offer is in one place.
- **An ended Session** told on a reply (Rule 11) becomes `SessionMsg.EndedByServer`: the client shows the gate as it does after `GetSession`.
- **Terms**: `Session Newer Version`, `Session Open Newest`, `Session Version Opened`, English and Dutch; the English defaults in `SessionGatePolicy.english`, the sentences in `SigningPolicy`.
- **Tests**: the machine's reopened effects and `MovedOn.receive` (news once per version); the three defaults and both sentences. Shared tests 462.

Script-first for the terms: `Shared/Scripts/Localization.fsx` (20 tests), migrated after review; the client edited directly.

Two deviations from the plan text, to be recorded in step 5: the notice lives in App state with pure helpers in `SessionMachine.fs` rather than inside the `Session.Open` case, which has 54 match sites; and the Blocked refusal gets no button of its own, the bar is the offer.

## The workbook rows

Tab-separated, English and Dutch, the other four empty (they fall back to English); also in the local `data/localization/*.tsv`:

```text
Session Newer Version	{0} signed a newer version at {1}.	{0} heeft om {1} een nieuwere versie ondertekend.
Session Open Newest	Open the newest version	Open de nieuwste versie
Session Version Opened	Version {0} by {1} is now open.	Versie {0} van {1} is nu geopend.
```

## Verification

- `dotnet run Build`, shared tests 462/462, server tests 259/259, Fantomas, Fable.
- In two browsers on one patient: A (`prescriber`) and B (`prescriber-b`) both open; B prescribes and signs; A's next action shows the notice once and the bar; A presses the button: B's orders are in A's cart, "Version 2 by Stub Prescriber B is now open", and A signs version 3 over it. A launch of the same identity in a second tab: the first tab's next action shows the gate with the superseded ending.

Refs #635

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZWjibQUW8uqCVbfV4vDTf
