### PR TITLE
docs: record how plan 635 was built (#635)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -157,10 +157,22 @@ Things worth trying here:
   the Sign button and the person menu are gone. Launch again: a right PIN inside the next minute
   is refused as locked until a time, after that it signs. Every wrong entry past the third
   doubles the delay, up to a day.
-- **Two browsers on one patient**: launch `prescriber-b` in another browser profile, prescribe
-  and sign there. The first browser's next **Ondertekenen** is refused: Stub Prescriber B signed
-  a newer version at that time (Rule 20). Launching the first identity again opens on the new
-  head, and signing works again.
+- **Launch again**: the cart opens on the version just signed, before anything is entered
+  (Rule 19); so does a reload.
+- **Two browsers on one patient** ([uc-04](docs/scenarios/integration/uc-04-two-users.md),
+  [plan 635](docs/implementation-plans/635-session-bound-compute.md)): launch `prescriber-b` in
+  another browser profile, prescribe and sign there. The first browser's next action that
+  reaches the server (a change in the patient panel, a scenario) shows a snackbar once: Stub
+  Prescriber B signed a newer version at that time, and the **Order Plan** page a bar with
+  **Open the newest version** (Rule 21). Nothing is blocked by it (Rule 22): pressing
+  **Ondertekenen** instead is refused with the same words (Rule 20) and shows the same bar. The
+  button loads B's orders into the cart, says version N by Stub Prescriber B is now open, and
+  signing works again: version N+1 has B's as its base. A page switch alone sends nothing, so
+  it tells nothing.
+- **The same identity twice**: launch `prescriber` again in another browser profile. The first
+  browser's next action shows the gate: a newer launch ended the Session (Rule 11). In the same
+  profile the second launch replaces the session cookie instead, and the older tab simply
+  continues on the new Session.
 - **The patient without data**: launch with the PatientId `no-data`. The first **Ondertekenen**
   is a notice instead of the dialog: the data could not be verified. **Doorgaan** asks the
   challenge again with the notice accepted, and the version is signed as unverified (Rule 44).
@@ -168,7 +180,9 @@ Things worth trying here:
 - **Watch the wire**: `RequestSignChallenge` answers `ChallengeIssued`, `Submit` answers
   `Submitted` with the version and a fresh OpenedToken; the PIN travels in the Submission and
   nowhere else, and never appears in the log. A Submission sent twice under the same key is
-  answered the same way once.
+  answered the same way once. Every `processCommand` call sends `{ Opened; Command }` and gets
+  `{ Response; Notice }`: the notice names the newer version or the ending, and is empty
+  otherwise; `OpenVersion` answers the Session with a fresh OpenedToken over the version.
 - **Restart the server**: the record is gone with everything else; the next signature is
   version 1 again.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -182,7 +182,8 @@ Things worth trying here:
   nowhere else, and never appears in the log. A Submission sent twice under the same key is
   answered the same way once. Every `processCommand` call sends `{ Opened; Command }` and gets
   `{ Response; Notice }`: the notice names the newer version or the ending, and is empty
-  otherwise; `OpenVersion` answers the Session with a fresh OpenedToken over the version.
+  otherwise; `OpenVersion` answers the Session with a fresh OpenedToken when it switches versions
+  (the token stands when the version named is the one already open).
 - **Restart the server**: the record is gone with everything else; the next signature is
   version 1 again.
 

--- a/docs/implementation-plans/409-client-launch-sequence.md
+++ b/docs/implementation-plans/409-client-launch-sequence.md
@@ -467,13 +467,12 @@ are listed per step with the reason.
 
 ### Still open
 
-- Step 7, the signed request (`Keys.sign`, the DPoP proof, the OpenedToken inside it).
+- Step 7, the signed request: the DPoP proof (`Keys.sign`) over the request envelope that
+  plan 635 built, which already carries the OpenedToken.
 - WorkPlan carry-over (#518); decision D1 (#599).
 - The scope switch (#580), which retires the `IsProd` stop-gap.
 - On a launch URL the gate hides the language switcher; the language itself follows the
   server default since #601.
-- The head's orders into the cart at open (the second half of Rule 19) and Rule 21's notice
-  on every response.
 
 Closed since this list was written: the identity hop (`RedirectTo`, the callback, the `state`
 cookie), the Rule 8 and 11 endings, and the sealed Launch, all against server-hosted stubs
@@ -481,4 +480,6 @@ cookie), the Rule 8 and 11 endings, and the sealed Launch, all against server-ho
 in-memory credential store ([plan 615](615-enrolment-with-server-stubs.md)); UC-3 signing
 against an in-memory record, the OpenedToken checked and re-minted at a signature and the
 Session opened with the head of the record
-([plan 622](622-signing-with-server-stubs.md)).
+([plan 622](622-signing-with-server-stubs.md)); Compute bound to the Session, the head's orders
+into the cart at open, Rule 21's notice on every reply and UC-4 end to end
+([plan 635](635-session-bound-compute.md)).

--- a/docs/implementation-plans/635-session-bound-compute.md
+++ b/docs/implementation-plans/635-session-bound-compute.md
@@ -206,3 +206,51 @@ migration by the maintainer after review.
   `Request { Opened; Command }` answering `Reply { Response; Notice }` with `Notice` empty.
   With `GENPRES_PROD=1` every reply's notice is empty and `OpenVersion` answers no Session.
 - `dotnet run ServerTests`, the Fable compile and Fantomas stay green after every step.
+
+## As built
+
+Script-first for the server and Shared code (`Server/Scripts/Compute.fsx`, rewritten per step,
+and `Shared/Scripts/Localization.fsx`), the client edited directly, every step one PR against
+`master`, migrated after review.
+
+| Step | PR | Landed |
+|---|---|---|
+| plan | #636 | the doc; review: the touch applied by every member that takes the session cookie's id, `OpenVersion of id` in place of an `OpenNewest` |
+| 1 | #637 | `Request { Opened; Command }`, `Reply { Response; Notice }`, `RecordNotice`, `SessionRecord.Seen`, `Hop.touch` and `Hop.seen`, `processCommand` reading the cookie, the client sending the token from its one call site |
+| 2 | #639 | `SessionOpened.Head` filled at open and at the commit, `SessionEffect.LoadCart`, the cart loaded at a launch, a resume and an enrolment; review: the cart built over the patient as `UpdatePatient` left it |
+| 3 | #641 | `SessionCommand.OpenVersion`, `Hop.openVersion`, the port and the arm, the machine's `OpenVersion` and `Reopened`; review: the answer correlated by the token the request started from |
+| 4 | #642 | `MovedOn` next to the Session, the bar and its button, `TellVersionOpened`, an `Ended` notice to the gate, three terms; review: the notice correlated by token, ordered by version number, spent only by a version at least as new |
+| 5 | this PR | the docs |
+
+### Deviations from the text above
+
+- **The touch is every port member's, not `processCommand`'s.** `Hop.touch` is applied by every
+  member that takes the session cookie's id (`find`, `challenge`, `submit`, `openVersion`,
+  `seen`), `close` excepted; `present`, `callback` and `supplyPin` run before a Session exists,
+  and a Session they open starts with `Seen` set.
+- **`OpenVersion of id`, not `OpenNewest`.** The button opens the version the notice named,
+  the model's `OpenOrderPlan of OrderPlanId`; any version may be opened (Rule 18), one that is
+  no longer the head stays blocked (Rule 20) and is told again (Rule 21). An id the record does
+  not hold opens nothing and keeps the token.
+- **The port answers `SessionOpened option`** for `openVersion`, as `find` answers a
+  `SessionLookup`: the adapter does not see `Shared.Api`; the composition root wraps it in
+  `SessionResp`.
+- **`LoadCart of SignedOrderPlan`**, emitted only when the Session has a patient and a head, and
+  built into the cart in `update` over the patient as `UpdatePatient` left it, normal values
+  applied, through `FilterOrderPlan`.
+- **The notice lives in `App.State.MovedOn`**, not inside `Session.Open`, which has 54 match
+  sites. `SessionMachine.MovedOn.receive` and `opened` are the pure helpers: ordered by version
+  number (Rule 20's order), news once per version, spent only by a version at least as new.
+- **Every answer is correlated.** `Reopened` and a reply's notice carry the OpenedToken the
+  request started from and land only on the open Session that still holds it; a Session closed,
+  replaced or re-minted meanwhile drops them.
+- **The Blocked refusal sets the bar**; the dialog closes as before, told once, and the offer to
+  open the newest version is in one place.
+- **No `SetPatient` at a reopen.** The Session's patient is unchanged; which patient data a
+  Session opens on when the platform has none is
+  [#640](https://github.com/informedica/GenPRES/issues/640).
+- **The Ended notice** reaches the gate through the existing `EndedByServer`; a second launch of
+  the same identity from another browser profile shows it at the older browser's next request.
+  In the same profile the second launch replaces the session cookie, so the older tab's
+  requests carry the new cookie and no ending is told there.
+

--- a/docs/scenarios/integration/uc-01-launch.md
+++ b/docs/scenarios/integration/uc-01-launch.md
@@ -304,10 +304,13 @@ The PIN detour of 5.4 is built too: a Prescriber without a PIN suspends into
 
 Since [plan 622](../../implementation-plans/622-signing-with-server-stubs.md) the Session
 opens with the head of the record (5.6, Rule 19) and the OpenedToken is checked and re-minted
-at a signature (Rule 34); the head's orders are not yet loaded into the cart at open.
+at a signature (Rule 34). Since [plan 635](../../implementation-plans/635-session-bound-compute.md)
+the head's orders are loaded into the cart at open and at a resume, every computing request
+carries the OpenedToken and every reply says whether the record moved on (Rule 21) or the
+Session ended (Rule 11), and the Session is marked seen at every request (Rule 9).
 
-Not built: step 7 (the signed request), the audit (Rule 46), and the absolute lifetime and idle
-endings of Rule 10.
+Not built: step 7 itself (the DPoP proof over the request envelope plan 635 built), the audit
+(Rule 46), and the absolute lifetime and idle endings of Rule 10 (nothing acts on `Seen` yet).
 
 ## Left out
 

--- a/docs/scenarios/integration/uc-03-prescribe-and-sign.md
+++ b/docs/scenarios/integration/uc-03-prescribe-and-sign.md
@@ -133,9 +133,10 @@ name: `OrderPlan` is the cart, and a signed version of it a `SignedOrderPlan`.
 
 Where the code departs from the text above, on purpose:
 
-- **Step 1 is not session-bound.** Compute reads no SessionRecord and touches nothing
-  (Rule 9 belongs to the idle lifetime, not built); it keeps working without a launch (UC-7).
-  Only steps 2 and 3 need the Session the cookie names.
+- **Step 1 is session-bound since [plan 635](../../implementation-plans/635-session-bound-compute.md).**
+  Compute marks the Session the cookie names seen (Rule 9; nothing acts on it yet) and its reply
+  says whether the record moved on (Rule 21) or the Session ended (Rule 11); without a cookie it
+  keeps working as before (UC-7). Steps 2 and 3 refuse without the Session.
 - **The challenge is kept, not sealed.** One per Session on the server's state, two minutes,
   replaced by a re-request and dropped by a data notice; a Submission must name its nonce and
   carry exactly the plan it was issued over (Rule 43: the orders and the patient data compared
@@ -160,8 +161,8 @@ Where the code departs from the text above, on purpose:
   PIN or a lock keeps it open, the PIN limit ends the Session and the gate says why, every
   other refusal is told once. An answer lands only on the request it answers.
 
-Not built: the audit (Rule 46), and Rule 21's notice on every response (the record moving on is
-told at the challenge and at the commit only).
+Not built: the audit (Rule 46). Rule 21's notice on every response, and taking up the newer
+version, are [uc-04](uc-04-two-users.md#as-built-against-stubs).
 
 ---
 

--- a/docs/scenarios/integration/uc-04-two-users.md
+++ b/docs/scenarios/integration/uc-04-two-users.md
@@ -72,7 +72,8 @@ lifts because the baseline moved, and for no other reason.
 ## What it leaves out
 
 - **B's next request being the signature** (ext 3a). Refused under Rule 20, and that
-  refusal is the notice. B continues as step 4.
+  refusal is the notice. B continues as step 4. Built: the refusal sets the same bar as
+  the notice (below).
 - **The stamps.** Rule 35 has the Server compute them against the base plan; a stamp
   arriving from a Client is discarded unread.
 - **The audit.** Both Submissions are recorded, committed or refused (Rule 46).
@@ -121,6 +122,40 @@ both challenges name their own WorkPlan. Nothing before the commit can tell them
 What separates them is that Rule 36 makes the head check and the append the same act, so
 the second finds a head the first has already moved. More than one Server may run, and
 this is what makes that safe.
+
+## As built against stubs
+
+Steps 1 to 5 run in the demo server since
+[plan 635](../../implementation-plans/635-session-bound-compute.md), on the stand-ins of
+[uc-01](uc-01-launch.md#as-built-against-stubs) and
+[uc-03](uc-03-prescribe-and-sign.md#as-built-against-stubs): two browser profiles, `prescriber`
+and `prescriber-b`, on one patient. The walkthrough is in
+[DEVELOPMENT.md](../../../DEVELOPMENT.md#signing-an-order-plan).
+
+Where the code departs from the text above, on purpose:
+
+- **Compute is bound to the Session.** Every computing request carries the OpenedToken next to
+  the command, the Session the cookie names is marked seen (Rule 9; nothing acts on it yet) and
+  the reply carries the notice (Rule 21) or the ending of the Session (Rule 11). Without a
+  cookie the request computes as before (UC-7). A token that is not the Session's yields no
+  notice, never a refusal.
+- **The notice is told once per version.** The wire says it on every reply; the client keeps
+  the newest version told, says it once, and shows a bar on the order plan with the offer to
+  open that version. Nothing is blocked by it (Rule 22); Rule 20 stays the only guard, at the
+  signature, and that refusal sets the same bar.
+- **Step 4 opens the version named.** `OpenVersion of id` takes up the version the notice
+  named, the model's `OpenOrderPlan`; the token is re-minted over it, a standing challenge is
+  dropped, and its orders go into the cart. Any version may be opened (Rule 18); one that is no
+  longer the head stays blocked and is told again. A version signed between the notice and the
+  button is never taken up unasked.
+- **The Session opens on the head's orders** (Rule 19, both halves): at a launch, a resume and
+  an enrolment the cart holds the version the Session opened with, and after a signature a
+  resume opens on the version just signed.
+- **Every answer lands only on the Session that asked.** The notice and the reopened Session
+  carry the token their request started from; a Session closed, replaced or re-minted meanwhile
+  drops them, and a notice for an older version landing late is not news.
+
+Not built: the stamps of Rule 35, and the audit (Rule 46).
 
 ---
 


### PR DESCRIPTION
## Summary

Plan 635 step 5 of 5: the docs. Docs only.

- **`docs/implementation-plans/635-session-bound-compute.md`**: the as-built table (#636 to #642 and this PR) and nine deviations from the text: the touch is every cookie-bound port member's; `OpenVersion of id` instead of an `OpenNewest`; the port answers `SessionOpened option`; `LoadCart of SignedOrderPlan` built in `update` over the normalized patient; the notice in `App.State.MovedOn` with pure helpers ordered by version number; every answer correlated by the token; the Blocked refusal sets the bar; no `SetPatient` at a reopen (#640); the same-profile caveat for the ending.
- **`uc-04-two-users.md`**: an "As built against stubs" section with five departures, and the ext 3a bullet marked built. Not built: the stamps of Rule 35 and the audit.
- **`uc-01-launch.md`**, **`uc-03-prescribe-and-sign.md`**: since plan 635 Compute is session-bound, the cart opens on the head, the reply carries Rule 21 and Rule 11; what stays not built (the DPoP proof, Rule 10's lifetimes, the audit).
- **`409-client-launch-sequence.md`**: "Still open" loses the head-into-cart and Rule 21 bullets; step 7 is now the proof over the envelope plan 635 built; plan 635 added to "Closed since".
- **`DEVELOPMENT.md`**: the two-browser walkthrough continued as run in Chrome (the snackbar once, the bar, the button, version N+1 over B's), a relaunch opening on the signed version, the same identity twice, and the wire.

With this PR plan 635 is complete. The three workbook rows of #642 are still to be added on the sheet side.

Refs #635

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZWjibQUW8uqCVbfV4vDTf
