### PR TITLE
feat(server): open the Session on the signed patient data (#640)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -76,8 +76,10 @@ every launch as invalid until the scope switch
 1. Start the application with `GENPRES_PROD=0` (the `.env.example` default): `dotnet run`.
 2. Open `http://localhost:5173/stub/launch`. This is the stub LaunchScript page, served by the
    server on port 8085 and reached through the Vite proxy. It has two fields:
-   - **PatientId**, default `stub-patient`. Any text works; `no-data` stands for a patient the
-     PatientDataPlatform has no record for (ext 6a).
+   - **PatientId**, default `stub-patient`, which the stub PatientDataPlatform reads as a
+     ten-year-old of 32 kg. Any text works; `no-data` stands for a patient the platform has no
+     record for (ext 6a): the Session then opens on the data the last version was signed on, or
+     on nothing (#640).
    - **Identity at the browser**: who the stub IdentityProvider will say is signed on. The
      table below lists the choices.
 3. Press **Launch**. The server mints a Launch sealed under a key it made at start-up, valid for
@@ -142,8 +144,8 @@ record ([uc-03](docs/scenarios/integration/uc-03-prescribe-and-sign.md), Rules 4
 demo keeps the record in memory
 ([plan 622](docs/implementation-plans/622-signing-with-server-stubs.md)):
 
-1. Launch with the identity `prescriber`. The stub patient has no data, so give it an age in the
-   patient panel (a weight is estimated from it).
+1. Launch with the identity `prescriber`. The patient panel shows the stub platform's reading, a
+   ten-year-old of 32 kg; change it if you like.
 2. Open **Voorschrijven** from the menu, pick a medication, a route, a form and an indication
    (paracetamol, oral, tablet, mild pain will do), and press **Voorschrijven** on a scenario.
 3. Open **Order Plan**: the order is in the plan, with an **Ondertekenen** button above it.
@@ -158,7 +160,8 @@ Things worth trying here:
   is refused as locked until a time, after that it signs. Every wrong entry past the third
   doubles the delay, up to a day.
 - **Launch again**: the cart opens on the version just signed, before anything is entered
-  (Rule 19); so does a reload.
+  (Rule 19); so does a reload. The patient panel shows the platform's reading again: a hand edit
+  over a reading is not kept (Concept 2), and the next sign tells that the data changed (Rule 44).
 - **Two browsers on one patient** ([uc-04](docs/scenarios/integration/uc-04-two-users.md),
   [plan 635](docs/implementation-plans/635-session-bound-compute.md)): launch `prescriber-b` in
   another browser profile, prescribe and sign there. The first browser's next action that
@@ -176,6 +179,8 @@ Things worth trying here:
 - **The patient without data**: launch with the PatientId `no-data`. The first **Ondertekenen**
   is a notice instead of the dialog: the data could not be verified. **Doorgaan** asks the
   challenge again with the notice accepted, and the version is signed as unverified (Rule 44).
+  Launch `no-data` again, or reload: the panel shows the data the version was signed on, since
+  the platform has none (#640); the first sign of the new Session shows the notice again.
 - **A Reader**: `reader` sees no Sign button.
 - **Watch the wire**: `RequestSignChallenge` answers `ChallengeIssued`, `Submit` answers
   `Submitted` with the version and a fresh OpenedToken; the PIN travels in the Submission and

--- a/docs/scenarios/integration/uc-01-launch.md
+++ b/docs/scenarios/integration/uc-01-launch.md
@@ -279,7 +279,7 @@ will make those calls over the back channel without the port changing shape. The
 | MainEHR LaunchScript (step 1) | the `/stub/launch` page | mints a Launch sealed under a key made at server start, two minutes, and opens the browser on `#/session?launch=…`; the identity choice made on the page travels in a cookie to the stub IdentityProvider |
 | IdentityProvider (4.3, 4.4) | `/authorize` and an in-memory code store | issues a one-time code for the chosen identity, or reports `no-identity`; the code is redeemed on the server's side of the callback and pruned after the Launch lifetime |
 | UserRegistry (5.3, 5.4) | the stub directory | answers Role, active Patient and PIN state per identity choice: `prescriber`, `reader`, `prescriber-other-patient`, `no-pin`, `unknown` |
-| PatientDataPlatform (5.5) | the stub patient data | answers an empty patient for every PatientId, none for `no-data` |
+| PatientDataPlatform (5.5) | the stub patient data | answers one fixed patient (ten years, 32 kg, 140 cm) for every PatientId, none for `no-data` |
 | GenPRES Database | one in-memory state per server start | LaunchRecords by nonce, SessionRecords, endings; every transition is a pure function over it, run under one lock, so 5.2 and 5.7 cannot interleave |
 
 Where the code departs from the text above, on purpose:
@@ -296,7 +296,9 @@ Where the code departs from the text above, on purpose:
   is discharged by the telling.
 - **A Reader needs no PIN.** 5.4 binds Prescribers only (Rule 25, ext 5c).
 - **No patient data is not a refusal.** When 5.5 finds nothing, the Session opens with the
-  Launch's PatientId and an empty patient (ext 6a); a data outage does not block prescribing.
+  Launch's PatientId and the patient data of the head of the record, the last seen (Rule 19), or
+  an empty patient where there is no record (ext 6a); a data outage does not block prescribing
+  ([#640](https://github.com/informedica/GenPRES/issues/640)).
 - **The key pair's thumbprint** is stored in the SessionRecord at 5.7, ready for step 7.
 
 The PIN detour of 5.4 is built too: a Prescriber without a PIN suspends into

--- a/src/Informedica.GenPRES.Server/Scripts/Compute.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/Compute.fsx
@@ -149,11 +149,12 @@ module Hop640 =
         |> Option.defaultValue Patient.empty
 
 
-    /// #640, at the commit: the Session's patient after a signature. With a reading at the
-    /// challenge (`Verified`) the reading stands, as the Session opened on it; without one the
-    /// data just signed, so a resume in this Session shows what a relaunch would.
-    let commitPatient (verified: bool) (opened: Patient) (signed: Patient) : Patient =
-        if verified then opened else signed
+    /// #640, at the commit: the Session's patient after a signature. The platform's reading at
+    /// the challenge (Rule 44; the newest, should it have changed and been accepted at the
+    /// notice), else the data just signed, so a resume in this Session shows what a relaunch
+    /// would.
+    let commitPatient (reading: Patient option) (signed: Patient) : Patient =
+        reading |> Option.defaultValue signed
 
 
 /// The PatientDataPlatform stub: a fixed patient for every PatientId, none at all for
@@ -261,7 +262,7 @@ let challenged sid : ServerApi.Hop.Challenge =
         Nonce = $"c-{sid}"
         Patient = Patient.empty
         Scenarios = [||]
-        Verified = true
+        Reading = Some Patient.empty
         Expiry = t0.AddMinutes 2.0
     }
 
@@ -382,11 +383,12 @@ let patientTests =
                 Hop640.sessionPatient none "no-data" None |> Expect.equal "empty" Patient.empty
             }
 
-            test "at the commit: verified keeps the reading, unverified takes the data signed" {
-                Hop640.commitPatient true StubPatientData640.patient entered
+            test "at the commit: the reading at the challenge, else the data signed" {
+                Hop640.commitPatient (Some StubPatientData640.patient) entered
                 |> Expect.equal "the reading" StubPatientData640.patient
 
-                Hop640.commitPatient false Patient.empty entered |> Expect.equal "the signed" entered
+                Hop640.commitPatient (Some entered) Patient.empty |> Expect.equal "a changed reading, accepted" entered
+                Hop640.commitPatient None entered |> Expect.equal "the signed" entered
             }
 
             test "the stub: a fixed patient for every id, none for no-data" {

--- a/src/Informedica.GenPRES.Server/Scripts/Compute.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/Compute.fsx
@@ -149,6 +149,13 @@ module Hop640 =
         |> Option.defaultValue Patient.empty
 
 
+    /// #640, at the commit: the Session's patient after a signature. With a reading at the
+    /// challenge (`Verified`) the reading stands, as the Session opened on it; without one the
+    /// data just signed, so a resume in this Session shows what a relaunch would.
+    let commitPatient (verified: bool) (opened: Patient) (signed: Patient) : Patient =
+        if verified then opened else signed
+
+
 /// The PatientDataPlatform stub: a fixed patient for every PatientId, none at all for
 /// `no-data` (ext 6a).
 module StubPatientData640 =
@@ -373,6 +380,13 @@ let patientTests =
 
             test "no reading, no record: an empty patient (ext 6a)" {
                 Hop640.sessionPatient none "no-data" None |> Expect.equal "empty" Patient.empty
+            }
+
+            test "at the commit: verified keeps the reading, unverified takes the data signed" {
+                Hop640.commitPatient true StubPatientData640.patient entered
+                |> Expect.equal "the reading" StubPatientData640.patient
+
+                Hop640.commitPatient false Patient.empty entered |> Expect.equal "the signed" entered
             }
 
             test "the stub: a fixed patient for every id, none for no-data" {

--- a/src/Informedica.GenPRES.Server/Scripts/Compute.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/Compute.fsx
@@ -13,6 +13,8 @@
 //
 // Only what changes is re-stated: the state has the four fields `openVersion` touches. Run:
 // `dotnet fsi Compute.fsx` from this directory (build first).
+//
+// A second section drafts #640, the patient a Session opens on when the platform has none.
 
 #I __SOURCE_DIRECTORY__
 #r "nuget: Expecto, 10.2.3"
@@ -116,6 +118,63 @@ module Hop =
                         Notices = state.Notices |> Map.remove sid
                     },
                     Some session
+
+
+// ---------------------------------------------------------------------------------------------
+// The patient at open (#640) (→ ServerApi.Adapters.fs, `Hop.sessionPatient` and `StubPatientData`)
+// ---------------------------------------------------------------------------------------------
+
+// Script-first draft of #640: since #639 a Session opens with the head of the record in the
+// cart, but where the PatientDataPlatform has no reading (ext 6a) the Session opened on
+// `Patient.empty`, and the data the head was signed on (`SignedOrderPlan.Patient`, Rule 44)
+// was not shown. At open, in this order: the platform's reading (Concept 2: the source of
+// truth), else the head's patient (Rule 19: the last patient context seen), else empty. The
+// change is one line in `openWith`, made a public pure function so it can be tested alone.
+// `openVersion` is left as it is (plan 635: no SetPatient at a reopen), and Rule 44 is
+// unaffected: the challenge re-reads the platform and compares with what the User saw.
+//
+// The stub platform used to answer `Patient.empty` for every PatientId but `no-data`; an
+// empty record is a reading, so the fallback never applied to `stub-patient`, and a hand
+// entered age was lost at every reload. It now answers a fixed patient, so the panel is filled
+// from the platform at launch and the fallback is exercised with `no-data`.
+
+module Hop640 =
+
+    /// #640: the patient a Session opens on. The platform's reading (Concept 2) wins; without
+    /// one, the patient data of the head of the record, the last seen (Rule 19); from nothing,
+    /// an empty patient (ext 6a).
+    let sessionPatient (patientData: string -> Patient option) (patientId: string) (head: SignedOrderPlan option) : Patient =
+        patientData patientId
+        |> Option.orElse (head |> Option.map _.Patient)
+        |> Option.defaultValue Patient.empty
+
+
+/// The PatientDataPlatform stub: a fixed patient for every PatientId, none at all for
+/// `no-data` (ext 6a).
+module StubPatientData640 =
+
+    /// The stub's reading: ten years, 32 kg, 140 cm, nothing else known.
+    let patient: Patient =
+        Patient.create
+            (Some(Shared.Measures.toYear 10))
+            None
+            None
+            None
+            (Some 32000)
+            (Some 140)
+            None
+            None
+            UnknownGender
+            []
+            None
+            None
+        |> Option.defaultValue Patient.empty
+
+
+    let port: ServerApi.PatientDataPort =
+        {
+            read = fun pid -> if pid = "no-data" then None else Some patient
+        }
 
 
 // ---------------------------------------------------------------------------------------------
@@ -294,4 +353,37 @@ let tests =
         ]
 
 
-runTestsWithCLIArgs [] [||] tests |> ignore
+let patientTests =
+    let signedOn (patient: Patient) = Some { signedBy prescriber 1 with Patient = patient }
+    let entered = { Patient.empty with Department = Some "ICU" }
+    let none (_: string) = None
+
+    testList
+        "the patient at open (#640)"
+        [
+            test "a reading wins over the signed patient (Concept 2)" {
+                Hop640.sessionPatient StubPatientData640.port.read "stub-patient" (signedOn entered)
+                |> Expect.equal "the platform's" StubPatientData640.patient
+            }
+
+            test "no reading: the patient the head was signed on (Rule 19)" {
+                Hop640.sessionPatient none "no-data" (signedOn entered)
+                |> Expect.equal "the signed" entered
+            }
+
+            test "no reading, no record: an empty patient (ext 6a)" {
+                Hop640.sessionPatient none "no-data" None |> Expect.equal "empty" Patient.empty
+            }
+
+            test "the stub: a fixed patient for every id, none for no-data" {
+                StubPatientData640.port.read "stub-patient"
+                |> Expect.equal "a reading" (Some StubPatientData640.patient)
+
+                StubPatientData640.patient |> Expect.notEqual "not empty" Patient.empty
+                StubPatientData640.patient.Age |> Option.map _.Years |> Expect.equal "ten" (Some(Shared.Measures.toYear 10))
+                StubPatientData640.port.read "no-data" |> Expect.isNone "no data"
+            }
+        ]
+
+
+runTestsWithCLIArgs [] [||] (testList "Compute" [ tests; patientTests ]) |> ignore

--- a/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
@@ -457,7 +457,8 @@ module Hop =
             Nonce: string
             Patient: Patient
             Scenarios: OrderScenario[]
-            Verified: bool
+            // the platform's reading at the challenge, none when it could not be read (Rule 44)
+            Reading: Patient option
             Expiry: DateTime
         }
 
@@ -1129,7 +1130,7 @@ module Hop =
                                             Nonce = nonce
                                             Patient = plan.Patient
                                             Scenarios = plan.Scenarios
-                                            Verified = current.IsSome
+                                            Reading = current
                                             Expiry = now + challengeLifetime
                                         }
                             },
@@ -1143,7 +1144,7 @@ module Hop =
     /// this plan (Rule 43); and last the PIN (Rules 23, 28), so that a Submission that was
     /// never going to land costs no attempt. Then the version is appended, the challenge
     /// spent, the OpenedToken re-minted over the new head, the Session's patient set to the
-    /// data signed where the platform had no reading (#640), and the answer remembered under
+    /// reading at the challenge, else the data signed (#640), and the answer remembered under
     /// the key, refusals too. Three wrong PINs end the Session (`WrongPinLimit`), lock signing and
     /// mail the User (Rule 27); a wrong PIN while locked pushes the lock out; a right PIN while
     /// locked is refused and counts nothing.
@@ -1230,13 +1231,14 @@ module Hop =
                                                 Base = record.OpenedWith
                                                 Scenarios = challenge.Scenarios
                                                 Patient = challenge.Patient
-                                                Verified = challenge.Verified
+                                                Verified = challenge.Reading.IsSome
                                             }
 
                                         let token = OpenedToken $"opened-{newId ()}"
 
-                                        // #640: without a reading, the Session's patient is the data
-                                        // just signed, so a resume shows it as a relaunch would
+                                        // #640: the Session's patient is the platform's reading at the
+                                        // challenge, else the data just signed, so a resume shows what
+                                        // a relaunch would
                                         let opened =
                                             { record with
                                                 Session =
@@ -1247,10 +1249,8 @@ module Hop =
                                                             Some
                                                                 { patient with
                                                                     Patient =
-                                                                        if challenge.Verified then
-                                                                            patient.Patient
-                                                                        else
-                                                                            plan.Patient
+                                                                        challenge.Reading
+                                                                        |> Option.defaultValue plan.Patient
                                                                 }
                                                     }
                                                 OpenedWith = Some id

--- a/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
@@ -1142,8 +1142,9 @@ module Hop =
     /// the record not moved on (Rule 20); the challenge this Session was issued, over exactly
     /// this plan (Rule 43); and last the PIN (Rules 23, 28), so that a Submission that was
     /// never going to land costs no attempt. Then the version is appended, the challenge
-    /// spent, the OpenedToken re-minted over the new head, and the answer remembered under the
-    /// key, refusals too. Three wrong PINs end the Session (`WrongPinLimit`), lock signing and
+    /// spent, the OpenedToken re-minted over the new head, the Session's patient set to the
+    /// data signed where the platform had no reading (#640), and the answer remembered under
+    /// the key, refusals too. Three wrong PINs end the Session (`WrongPinLimit`), lock signing and
     /// mail the User (Rule 27); a wrong PIN while locked pushes the lock out; a right PIN while
     /// locked is refused and counts nothing.
     let commit
@@ -1234,12 +1235,23 @@ module Hop =
 
                                         let token = OpenedToken $"opened-{newId ()}"
 
+                                        // #640: without a reading, the Session's patient is the data
+                                        // just signed, so a resume shows it as a relaunch would
                                         let opened =
                                             { record with
                                                 Session =
                                                     { record.Session with
                                                         OpenedToken = Some token
                                                         Head = Some plan
+                                                        PatientContext =
+                                                            Some
+                                                                { patient with
+                                                                    Patient =
+                                                                        if challenge.Verified then
+                                                                            patient.Patient
+                                                                        else
+                                                                            plan.Patient
+                                                                }
                                                     }
                                                 OpenedWith = Some id
                                             }

--- a/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
@@ -585,9 +585,24 @@ module Hop =
                 { state with Launches = state.Launches |> Map.add claims.Nonce record }, answerOf authorizeUrl record
 
 
+    /// The patient a Session opens on (#640): the PatientDataPlatform's reading (Concept 2, the
+    /// source of truth); without one, the patient data of the head of the record, the last
+    /// seen (Rule 19); from nothing, an empty patient (ext 6a).
+    let sessionPatient
+        (patientData: string -> Patient option)
+        (patientId: string)
+        (head: SignedOrderPlan option)
+        : Patient
+        =
+        patientData patientId
+        |> Option.orElse (head |> Option.map _.Patient)
+        |> Option.defaultValue Shared.Models.Patient.empty
+
+
     /// Step 5.7, one act (Rule 40), from whatever carried the launch this far: a LaunchRecord
     /// at the callback, an Enrolment once the PIN is set. The Session is written from the head
-    /// of the record (Rule 19), the login's other Sessions are closed and marked (Rule 8).
+    /// of the record (Rule 19), on the platform's reading, else the head's patient data (#640);
+    /// the login's other Sessions are closed and marked (Rule 8).
     let private openWith
         (now: DateTime)
         (newId: unit -> string)
@@ -607,7 +622,7 @@ module Hop =
                     Some
                         {
                             PatientId = patientId
-                            Patient = patientData patientId |> Option.defaultValue Shared.Models.Patient.empty
+                            Patient = sessionPatient patientData patientId head
                         }
                 OpenedToken = Some(OpenedToken $"opened-{id}")
                 KeyThumbprint = Some(PublicKey.thumbprint key)
@@ -1510,19 +1525,31 @@ module StubDirectory =
         }
 
 
-/// The PatientDataPlatform stub: nothing to import, except that `no-data` has no record at all
-/// (ext 6a).
+/// The PatientDataPlatform stub: one fixed patient for every PatientId, so a launch fills the
+/// patient panel from the platform, except that `no-data` has no record at all (ext 6a), so
+/// the Session opens on what was signed last, or on nothing (#640).
 module StubPatientData =
 
+    /// The stub's reading: ten years, 32 kg, 140 cm, nothing else known.
+    let patient: Patient =
+        Shared.Models.Patient.create
+            (Some(Shared.Measures.toYear 10))
+            None
+            None
+            None
+            (Some 32000)
+            (Some 140)
+            None
+            None
+            UnknownGender
+            []
+            None
+            None
+        |> Option.defaultValue Shared.Models.Patient.empty
+
+
     let port: PatientDataPort =
-        {
-            read =
-                fun pid ->
-                    if pid = "no-data" then
-                        None
-                    else
-                        Some Shared.Models.Patient.empty
-        }
+        { read = fun pid -> if pid = "no-data" then None else Some patient }
 
 
 /// The credential half of the Database, seeded for the stub logins: the Prescribers that sign

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -703,6 +703,85 @@ module SessionStubTests =
                         | other -> failtest $"expected Opened, got {other}"
                     }
 
+                    test "no-data over a record: the Session opens on the patient the head was signed on (#640)" {
+                        let ids, d = fixture ()
+                        let entered = { Shared.Models.Patient.empty with Department = Some "ICU" }
+
+                        let signed: SignedOrderPlan =
+                            {
+                                Head =
+                                    {
+                                        Id = "plan-1"
+                                        No = 1
+                                        By =
+                                            {
+                                                UserId = "prescriber"
+                                                DisplayName = "prescriber"
+                                                Role = UserRole.Prescriber
+                                            }
+                                        SignedAt = t0
+                                    }
+                                PatientId = "no-data"
+                                Base = None
+                                Scenarios = [||]
+                                Patient = entered
+                                Verified = false
+                            }
+
+                        let record = { seeded with Records = Map.ofList [ "no-data", [ signed ] ] }
+
+                        let launch = mintFor "n-nd" "no-data"
+                        let state, cb = hop ids d record launch keyA "prescriber"
+                        let cb = { cb with Code = Some(d.issue "prescriber" "no-data") }
+                        let state, result = run ids d state cb
+
+                        match result with
+                        | CallbackResult.Opened(id, _) ->
+                            let ctx = state.Sessions[id].Session.PatientContext
+                            ctx |> Option.map _.PatientId |> Expect.equal "patient id" (Some "no-data")
+                            ctx |> Option.map _.Patient |> Expect.equal "the signed patient" (Some entered)
+                            state.Sessions[id].Session.Head |> Expect.equal "the version" (Some signed)
+                        | other -> failtest $"expected Opened, got {other}"
+                    }
+
+                    test "a reading wins over the patient the head was signed on (Concept 2, #640)" {
+                        let ids, d = fixture ()
+                        let entered = { Shared.Models.Patient.empty with Department = Some "ICU" }
+
+                        let signed: SignedOrderPlan =
+                            {
+                                Head =
+                                    {
+                                        Id = "plan-1"
+                                        No = 1
+                                        By =
+                                            {
+                                                UserId = "prescriber"
+                                                DisplayName = "prescriber"
+                                                Role = UserRole.Prescriber
+                                            }
+                                        SignedAt = t0
+                                    }
+                                PatientId = "patient-1"
+                                Base = None
+                                Scenarios = [||]
+                                Patient = entered
+                                Verified = true
+                            }
+
+                        let record = { seeded with Records = Map.ofList [ "patient-1", [ signed ] ] }
+
+                        let state, cb = hop ids d record launch1 keyA "prescriber"
+                        let state, result = run ids d state cb
+
+                        match result with
+                        | CallbackResult.Opened(id, _) ->
+                            state.Sessions[id].Session.PatientContext
+                            |> Option.map _.Patient
+                            |> Expect.equal "the platform's" (Some StubPatientData.patient)
+                        | other -> failtest $"expected Opened, got {other}"
+                    }
+
                     test "reader: opens without a PIN (ext 5c)" {
                         let ids, d = fixture ()
                         let state, cb = hop ids d seeded launch1 keyA "reader"
@@ -2272,7 +2351,7 @@ module SessionStubTests =
         let challengeTests =
             let minutes (n: float) = TimeSpan.FromMinutes n
             let seconds (n: float) = TimeSpan.FromSeconds n
-            let stubPatient = Shared.Models.Patient.empty
+            let stubPatient = StubPatientData.patient
             let otherData = { stubPatient with Department = Some "ICU" }
             let token sid = OpenedToken $"opened-{sid}"
 
@@ -2372,6 +2451,29 @@ module SessionStubTests =
                         <| (OrderPlan.create otherData [||], token "s-1")
                         |> snd
                         |> Expect.equal "entered data: issued" (SigningResponse.ChallengeIssued "n-1")
+                    }
+
+                    test "a Session opened on the signed patient, no reading: told unverified as before (Rule 44, #640)" {
+                        let state, answer =
+                            stateOf
+                                [
+                                    session "s-1" (Some prescriber) (Some("no-data", otherData)) None
+                                ]
+                                []
+                            |> ask t0 (counter "n")
+                            <| "s-1"
+                            <| (OrderPlan.create otherData [||], token "s-1")
+
+                        answer
+                        |> Expect.equal
+                            "unverified: told"
+                            (SigningResponse.DataNotice
+                                {
+                                    Data = None
+                                    Token = "n-1"
+                                })
+
+                        state.Challenges |> Expect.isEmpty "no challenge yet"
                     }
 
                     test "refuses a Reader (Rule 26) before the token is looked at, and a stale token (Rule 34)" {
@@ -2706,7 +2808,7 @@ module SessionStubTests =
         let commitTests =
             let minutes (n: float) = TimeSpan.FromMinutes n
             let seconds (n: float) = TimeSpan.FromSeconds n
-            let stubPatient = Shared.Models.Patient.empty
+            let stubPatient = StubPatientData.patient
             let otherData = { stubPatient with Department = Some "ICU" }
             let token sid = OpenedToken $"opened-{sid}"
             let plan = OrderPlan.create stubPatient [||]
@@ -4139,7 +4241,7 @@ module SessionStubTests =
 
                     let submission pin key : Submission =
                         {
-                            Plan = OrderPlan.create Shared.Models.Patient.empty [||]
+                            Plan = OrderPlan.create StubPatientData.patient [||]
                             Opened = opened.OpenedToken.Value
                             Challenge = challenge
                             Pin = pin
@@ -4241,7 +4343,7 @@ module SessionStubTests =
 
                     let submission (opened: SessionOpened) nonce key : Submission =
                         {
-                            Plan = OrderPlan.create Shared.Models.Patient.empty [||]
+                            Plan = OrderPlan.create StubPatientData.patient [||]
                             Opened = opened.OpenedToken.Value
                             Challenge = nonce
                             Pin = StubCredentials.stubPin

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -2213,7 +2213,7 @@ module SessionStubTests =
                     Nonce = $"c-{sid}"
                     Patient = Shared.Models.Patient.empty
                     Scenarios = [||]
-                    Verified = true
+                    Reading = Some Shared.Models.Patient.empty
                     Expiry = t0.AddMinutes 2.0
                 }
 
@@ -2618,7 +2618,10 @@ module SessionStubTests =
                             askWith "n-1" (t0 + seconds 5.0) nonces state "s-1" (plan, token "s-1")
 
                         answer |> Expect.equal "issued" (SigningResponse.ChallengeIssued "n-2")
-                        state.Challenges["s-1"].Verified |> Expect.isTrue "the platform's reading"
+
+                        state.Challenges["s-1"].Reading
+                        |> Expect.equal "the platform's reading" (Some stubPatient)
+
                         state.Challenges["s-1"].Patient |> Expect.equal "over the data told" stubPatient
                         state.Notices |> Expect.isEmpty "the notice is spent"
 
@@ -2633,7 +2636,7 @@ module SessionStubTests =
                         answer
                         |> Expect.equal "issued unverified" (SigningResponse.ChallengeIssued "n-4")
 
-                        state.Challenges["s-2"].Verified |> Expect.isFalse "unverified"
+                        state.Challenges["s-2"].Reading |> Expect.isNone "unverified"
                     }
 
                     test "a wrong, spent, expired or unfitting notice token is a fresh notice, never a refusal" {
@@ -2770,7 +2773,7 @@ module SessionStubTests =
                                 Nonce = "n-1"
                                 Patient = stubPatient
                                 Scenarios = [||]
-                                Verified = true
+                                Reading = Some stubPatient
                                 Expiry = t0 + minutes 2.0
                             }
                     }
@@ -2867,7 +2870,7 @@ module SessionStubTests =
                     Nonce = $"c-{sid}"
                     Patient = stubPatient
                     Scenarios = [||]
-                    Verified = true
+                    Reading = Some stubPatient
                     Expiry = at + Hop.challengeLifetime
                 }
 
@@ -3105,7 +3108,7 @@ module SessionStubTests =
                                     sid,
                                     { unverified with
                                         Patient = otherData
-                                        Verified = false
+                                        Reading = None
                                     }
                                 ]
 
@@ -3128,6 +3131,37 @@ module SessionStubTests =
                                         PatientId = "no-data"
                                         Patient = otherData
                                     })
+                        | other -> failtest $"expected Submitted, got {other}"
+                    }
+
+                    test "a changed reading accepted at the notice: the Session's patient is that reading (#640)" {
+                        let sid, over = challenged "s-1" t0
+
+                        let ready =
+                            stateOf
+                                [ opened ]
+                                []
+                                [
+                                    sid,
+                                    { over with
+                                        Patient = otherData
+                                        Reading = Some otherData
+                                    }
+                                ]
+
+                        let state, answer =
+                            submit
+                                ready
+                                "s-1"
+                                { submission "s-1" "1234" "k-1" with Plan = OrderPlan.create otherData [||] }
+
+                        match answer with
+                        | SigningResponse.Submitted(signed, _) ->
+                            signed.Verified |> Expect.isTrue "the reading"
+
+                            state.Sessions["s-1"].Session.PatientContext
+                            |> Option.map _.Patient
+                            |> Expect.equal "the newer reading, not the one opened on" (Some otherData)
                         | other -> failtest $"expected Submitted, got {other}"
                     }
 

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -2956,6 +2956,12 @@ module SessionStubTests =
                             state.Sessions["s-1"].Session.Head
                             |> Expect.equal "a resume opens on the version just signed" (Some signed)
 
+                            state.Sessions["s-1"].Session.PatientContext
+                            |> Option.map _.Patient
+                            |> Expect.equal
+                                "verified: the Session's patient is the reading, unchanged (#640)"
+                                (Some stubPatient)
+
                             state.Answered[("s-1", "k-1")] |> fst |> Expect.equal "remembered" answer
                         | other -> failtest $"expected Submitted, got {other}"
 
@@ -3085,6 +3091,43 @@ module SessionStubTests =
                             |> snd
                         with
                         | SigningResponse.Submitted(signed, _) -> signed.Scenarios |> Expect.equal "two orders" once
+                        | other -> failtest $"expected Submitted, got {other}"
+                    }
+
+                    test "unverified: the Session's patient becomes the data signed, so a resume shows it (#640)" {
+                        let sid, unverified = challenged "s-1" t0
+
+                        let ready =
+                            stateOf
+                                [ session "s-1" prescriber "no-data" None ]
+                                []
+                                [
+                                    sid,
+                                    { unverified with
+                                        Patient = otherData
+                                        Verified = false
+                                    }
+                                ]
+
+                        let state, answer =
+                            submit
+                                ready
+                                "s-1"
+                                { submission "s-1" "1234" "k-1" with Plan = OrderPlan.create otherData [||] }
+
+                        match answer with
+                        | SigningResponse.Submitted(signed, _) ->
+                            signed.Patient |> Expect.equal "the data signed" otherData
+                            signed.Verified |> Expect.isFalse "no reading"
+
+                            state.Sessions["s-1"].Session.PatientContext
+                            |> Expect.equal
+                                "the Session's patient, for the resume"
+                                (Some
+                                    {
+                                        PatientId = "no-data"
+                                        Patient = otherData
+                                    })
                         | other -> failtest $"expected Submitted, got {other}"
                     }
 


### PR DESCRIPTION
## Summary

Fixes #640. Since #639 a Session opens with the head of the record in the cart, but where the PatientDataPlatform has no reading the Session opened on an empty patient: the age and weight the version was signed on were in `SignedOrderPlan.Patient` (Rule 44) and not shown, at every reload and relaunch.

- **Server, at open**: `Hop.sessionPatient`, the patient a Session opens on, in this order: the platform's reading (Concept 2, the source of truth), else the patient data of the head of the record (Rule 19), else an empty patient (ext 6a). `openWith` uses it, so a launch, a PIN-set and a resume (`GetSession` answers the Session as opened) all carry it.
- **Server, at the commit**: a Session opened before the sign kept its empty patient, so a reload in that Session still showed an empty panel where a relaunch showed the data signed. The challenge now carries the platform's reading itself (`Reading: Patient option` in place of `Verified`), and `Hop.commit` sets the Session's patient to that reading, else the data signed: the same precedence as at open, so a reading that changed and was accepted at the notice is what a resume shows (review).
- **Stub**: the stub platform used to answer an empty record for every PatientId but `no-data`. An empty record is a reading, so the fallback never applied to the default `stub-patient`. It now answers one fixed patient (ten years, 32 kg, 140 cm), none for `no-data`, so a launch fills the panel from the platform and `no-data` exercises the fallback.
- **Tests**: the Session opens on the signed patient for `no-data` over a record; a reading wins over the signed patient; a Session opened on the signed patient with no reading is told unverified at the challenge as before (Rule 44); at the commit, the reading at the challenge stands, a changed reading accepted at the notice becomes the Session's patient, and without one the data signed does. The challenge, commit and signing fixtures use the stub's patient.
- **Docs**: uc-01 as-built table row and departure; DEVELOPMENT.md walkthrough (PatientId bullet, step 1, "Launch again", `no-data`).
- **Client**: no change; the patient reaches it through `SessionOpened.PatientContext` and `SetPatient`, and the cart is built over it.

Two deviations from the issue text: `openVersion` is left as it is (plan 635: no `SetPatient` at a reopen; Concept 2: the platform is read once), so the version taken up does not change the Session's patient; and the stub platform changes, because with the empty record as its reading the `prescriber` observation in the issue could not be fixed without tripping Rule 44 at the next sign.

Script-first: `Server/Scripts/Compute.fsx` (`Hop640.sessionPatient`, `Hop640.commitPatient`, the stub; 5 tests), each migrated in its own commit after review.

## Verification

- `dotnet fsi Compute.fsx`: 11/11.
- Server tests 264/264 (259 + 5), Fantomas clean.
- Browser, `GENPRES_PROD=0`: launch `no-data`, set age 10, prescribe paracetamol, the unverified notice, PIN `1234`, version 1. Reload: the panel shows 10 years / 38 kg and the cart the order; relaunch `no-data`: the same. Launch `stub-patient`: the panel shows the stub's ten-year-old of 32 kg at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PB1StZXyyebzYJepJadc7Z

