### PR TITLE
feat(server): admin command family under the token (#654 PR 1)

### DIFF
--- a/src/Informedica.GenPRES.Server/Informedica.GenPRES.Server.fsproj
+++ b/src/Informedica.GenPRES.Server/Informedica.GenPRES.Server.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="ServerApi.Session.fs" />
     <Compile Include="ServerApi.StubAdapters.fs" />
     <Compile Include="ServerApi.Adapters.fs" />
+    <Compile Include="ServerApi.AdminCommand.fs" />
     <Compile Include="ServerApi.Command.fs" />
     <Compile Include="ServerApi.LaunchCommand.fs" />
     <Compile Include="ServerApi.SessionCommand.fs" />

--- a/src/Informedica.GenPRES.Server/Scripts/Compute.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/Compute.fsx
@@ -214,7 +214,12 @@ module AdminCommand =
 //                     async {
 //                         try
 //                             Informedica.GenForm.Lib.Api.reloadCache logger provider
-//                             return Ok()
+//                             // reloadCache records a failed load and returns normally, so the
+//                             // provider is asked: unloaded is Error with its messages
+//                             return
+//                                 match notLoaded provider with
+//                                 | None -> Ok()
+//                                 | Some msgs -> Error msgs
 //                         with ex ->
 //                             return Error [| ex.Message |]
 //                     }

--- a/src/Informedica.GenPRES.Server/Scripts/Compute.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/Compute.fsx
@@ -1,20 +1,25 @@
-// Compute bound to the Session (plan 635), PR 3: opening the version the notice named
-// (Rules 18 to 20; UC-4 step 4, the model's `OpenOrderPlan of OrderPlanId`). A User told that
-// the record moved on (Rule 21) takes up that version: it becomes what the Session opened
-// with, the OpenedToken is re-minted over it, and a challenge over the old baseline is dropped.
+// The admin command family (plan 654, step 2): ValidatePassword, ListLogFiles, AnalyzeLogFile
+// and ReloadResources as one `IServerApi` member, `processAdmin`, under the HMAC token that the
+// password buys. Never Session-bound (no cookie, no OpenedToken, no record notice) and never
+// behind the formulary being loaded, so a failed initial load can be retried from the
+// settings page. `ReloadResources` no longer carries the password: it carries the token, like
+// the log commands.
 //
 // Script-first draft (script-only policy) of:
-//   - `SessionCommand.OpenVersion of id: string` → `Shared/Api.fs`;
-//   - `Hop.openVersion` → `Adapters.fs`, `SessionPort.openVersion` → `Ports.fs`, both answering
-//     `SessionOpened option` (the adapter does not see `Shared.Api`, as `find` answers a
-//     `SessionLookup`); the `processSession` arm wraps it in `SessionResp` → `CompositionRoot.fs`.
-// The client side (`SessionMsg.OpenVersion`, `Reopened`, `SessionEffect.CallOpenVersion`) is
-// edited directly, as UI code.
+//   - `AdminCommand`, `AdminResponse`, `AdminCommand.toString`, `processAdmin` → `Shared/Api.fs`
+//     (drafted in `Shared/Scripts/Api.fsx`; restated here under `Api654` because a script
+//     cannot extend `Shared.Api`);
+//   - `AdminPort`, replacing `LogAnalyzerPort` as `AppEnv.admin` → `Ports.fs`;
+//   - the port's adapter: the secret read from GENPRES_PASSWORD, the clock, the reload through
+//     `Informedica.GenForm.Lib.Api.reloadCache` → `Adapters.fs`;
+//   - `AdminCommand.processCmd` with the password and token functions moved out of
+//     `Command.fs`, over explicit values instead of the environment → new
+//     `ServerApi.AdminCommand.fs`, compiled before `Command.fs` so the old `LogAnalyzerCmd`
+//     arms share them until they go;
+//   - `processAdmin` in `compose` → `CompositionRoot.fs`.
 //
-// Only what changes is re-stated: the state has the four fields `openVersion` touches. Run:
-// `dotnet fsi Compute.fsx` from this directory (build first).
-//
-// A second section drafts #640, the patient a Session opens on when the platform has none.
+// The script takes the port where the source takes `AppEnv` (a record cannot gain a field in
+// a script). Run: `dotnet fsi Compute.fsx` from this directory (build first).
 
 #I __SOURCE_DIRECTORY__
 #r "nuget: Expecto, 10.2.3"
@@ -23,166 +28,211 @@
 
 open System
 open Shared.Types
-open Shared.Models
-open ServerApi
 
 
 // ---------------------------------------------------------------------------------------------
-// Opening a version (→ ServerApi.Adapters.fs, `Hop`)
+// The wire (→ Shared/Api.fs)
 // ---------------------------------------------------------------------------------------------
 
-module Hop =
+module Api654 =
 
-    open ServerApi.Hop
-
-    /// The state of PR 3: only the fields `openVersion` reads or writes.
-    type State =
-        {
-            Sessions: Map<string, SessionRecord>
-            Records: Map<string, SignedOrderPlan list>
-            Notices: Map<string, Notice>
-            Challenges: Map<string, Challenge>
-        }
+    /// The admin command family: the password once, then the token it bought.
+    [<RequireQualifiedAccess>]
+    type AdminCommand =
+        | ValidatePassword of password: string
+        | ListLogFiles of token: string
+        | AnalyzeLogFile of token: string * fileName: string
+        | ReloadResources of token: string
 
 
-    let emptyState =
-        {
-            Sessions = Map.empty
-            Records = Map.empty
-            Notices = Map.empty
-            Challenges = Map.empty
-        }
+    [<RequireQualifiedAccess>]
+    type AdminResponse =
+        | PasswordValidated of isValid: bool * token: string
+        | LogFilesListed of LogFileInfo[]
+        | LogFileAnalyzed of string
+        | ResourcesReloaded
 
 
-    /// Rule 9, as in the source.
-    let touch (now: DateTime) (sid: string) (state: State) : State =
-        { state with
-            Sessions = state.Sessions |> Map.change sid (Option.map (fun r -> { r with Seen = now }))
-        }
+    module AdminCommand =
 
-
-    /// Rules 18 to 20, UC-4 step 4: version `id` becomes what the Session opened with. No
-    /// Session, an anonymous one or one without a Patient: nothing to open (Rule 13). An id the
-    /// record does not hold for the Session's Patient (a stale button, a restart): nothing
-    /// opens, the Session as it is; the next request tells what the head is (Rule 21). The
-    /// version already open: the token stands. Another version: the OpenedToken is re-minted
-    /// over it (Rule 34) and the standing challenge and notice of this Session are dropped (a
-    /// challenge over the old baseline must not be answerable). Any version may be opened
-    /// (Rule 18); one that is not the head leaves Submission blocked (Rule 20).
-    let openVersion
-        (now: DateTime)
-        (newId: unit -> string)
-        (sid: string)
-        (id: string)
-        (state: State)
-        : State * SessionOpened option
-        =
-        match state.Sessions |> Map.tryFind sid with
-        | None -> state, None
-        | Some record ->
-            let state = touch now sid state
-
-            match record.Session.User, record.Session.PatientContext with
-            | None, _
-            | _, None -> state, None
-            | Some _, Some patient ->
-                let version =
-                    state.Records
-                    |> Map.tryFind patient.PatientId
-                    |> Option.bind (List.tryFind (fun v -> v.Head.Id = id))
-
-                match version with
-                | None -> state, Some record.Session
-                | Some version when record.OpenedWith = Some id ->
-                    let session = { record.Session with Head = Some version }
-
-                    { state with Sessions = state.Sessions |> Map.add sid { record with Session = session } },
-                    Some session
-                | Some version ->
-                    let session =
-                        { record.Session with
-                            OpenedToken = Some(OpenedToken $"opened-{newId ()}")
-                            Head = Some version
-                        }
-
-                    { state with
-                        Sessions =
-                            state.Sessions
-                            |> Map.add
-                                sid
-                                { record with
-                                    Session = session
-                                    OpenedWith = Some id
-                                }
-                        Challenges = state.Challenges |> Map.remove sid
-                        Notices = state.Notices |> Map.remove sid
-                    },
-                    Some session
+        /// For the log. Never the password or the token.
+        let toString cmd =
+            match cmd with
+            | AdminCommand.ValidatePassword _ -> "ValidatePassword"
+            | AdminCommand.ListLogFiles _ -> "ListLogFiles"
+            | AdminCommand.AnalyzeLogFile(_, f) -> $"AnalyzeLogFile %s{f}"
+            | AdminCommand.ReloadResources _ -> "ReloadResources"
 
 
 // ---------------------------------------------------------------------------------------------
-// The patient at open (#640) (→ ServerApi.Adapters.fs, `Hop.sessionPatient` and `StubPatientData`)
+// The port (→ Ports.fs, in place of LogAnalyzerPort; AppEnv.logAnalyzer becomes AppEnv.admin)
 // ---------------------------------------------------------------------------------------------
 
-// Script-first draft of #640: since #639 a Session opens with the head of the record in the
-// cart, but where the PatientDataPlatform has no reading (ext 6a) the Session opened on
-// `Patient.empty`, and the data the head was signed on (`SignedOrderPlan.Patient`, Rule 44)
-// was not shown. At open, in this order: the platform's reading (Concept 2: the source of
-// truth), else the head's patient (Rule 19: the last patient context seen), else empty. The
-// change is one line in `openWith`, made a public pure function so it can be tested alone.
-// `openVersion` is left as it is (plan 635: no SetPatient at a reopen), and Rule 44 is
-// unaffected: the challenge re-reads the platform and compares with what the User saw.
+/// What the admin commands need from the edge. The secret and the clock are values the DMZ
+/// reads and passes in, so the command module never touches the environment.
+type AdminPort =
+    {
+        // GENPRES_PASSWORD; None when unset, empty or whitespace, so every check fails closed
+        secret: unit -> string option
+        now: unit -> DateTimeOffset
+        listLogFiles: unit -> Async<Result<LogFileInfo[], string[]>>
+        analyzeLogFile: string -> Async<Result<string, string[]>>
+        // the resource provider reloaded: the formulary and, later, the knowledge sheets
+        reloadResources: unit -> Async<Result<unit, string[]>>
+    }
+
+
+// ---------------------------------------------------------------------------------------------
+// The command (→ ServerApi.AdminCommand.fs)
+// ---------------------------------------------------------------------------------------------
+
+module AdminCommand =
+
+    open System.Security.Cryptography
+    open System.Text
+    open Api654
+
+
+    let tokenLifetime = TimeSpan.FromHours 1.0
+
+
+    /// An empty or whitespace secret is no secret. `Env.getItem` answers `Some ""` for a
+    /// setting that is set but empty (the Dockerfile's `ENV GENPRES_PASSWORD=`), and an empty
+    /// password compared with an empty secret would match, so blanks fail closed here as well
+    /// as at the port.
+    let private nonBlank (secret: string option) =
+        secret |> Option.filter (String.IsNullOrWhiteSpace >> not)
+
+
+    /// SECURITY: `FixedTimeEquals` so equal-length comparisons do not leak through per-byte
+    /// timing. It short-circuits on a length mismatch; that leak is accepted because production
+    /// enforces a 16-character minimum and the password travels only at ValidatePassword.
+    let validatePassword (secret: string option) (password: string) =
+        match nonBlank secret with
+        | None -> false
+        | Some expected -> CryptographicOperations.FixedTimeEquals(Encoding.UTF8.GetBytes password, Encoding.UTF8.GetBytes expected)
+
+
+    /// `base64(expiresAt:nonce).base64(hmacsha256(secret, expiresAt:nonce))`; empty without a
+    /// secret, so that nothing signed with an empty key can ever verify.
+    let generateToken (secret: string option) (now: DateTimeOffset) =
+        match nonBlank secret with
+        | None -> ""
+        | Some secret ->
+            let expiresAt = now.Add(tokenLifetime).ToUnixTimeSeconds()
+            let nonce = RandomNumberGenerator.GetBytes 32 |> Convert.ToBase64String
+            let payload = Encoding.UTF8.GetBytes $"%d{expiresAt}:%s{nonce}"
+            use hmac = new HMACSHA256(Encoding.UTF8.GetBytes secret)
+            let signature = hmac.ComputeHash payload
+            $"%s{Convert.ToBase64String payload}.%s{Convert.ToBase64String signature}"
+
+
+    let validateToken (secret: string option) (now: DateTimeOffset) (token: string) =
+        match nonBlank secret with
+        | None -> false
+        | Some secret ->
+            if String.IsNullOrWhiteSpace token then
+                false
+            else
+                match token.Split '.' with
+                | [| payload; signature |] ->
+                    try
+                        let payload = Convert.FromBase64String payload
+                        let provided = Convert.FromBase64String signature
+                        use hmac = new HMACSHA256(Encoding.UTF8.GetBytes secret)
+                        let expected = hmac.ComputeHash payload
+
+                        CryptographicOperations.FixedTimeEquals(provided, expected)
+                        && (match (Encoding.UTF8.GetString payload).Split(':', 2) with
+                            | [| expiresAt; _ |] ->
+                                match Int64.TryParse expiresAt with
+                                | true, expiresAt -> now.ToUnixTimeSeconds() <= expiresAt
+                                | false, _ -> false
+                            | _ -> false)
+                    with _ ->
+                        false
+                | _ -> false
+
+
+    /// The source takes `env: AppEnv` and reads `env.admin`.
+    let processCmd (admin: AdminPort) (cmd: AdminCommand) : Async<Result<AdminResponse, string[]>> =
+        let withToken token (run: unit -> Async<Result<AdminResponse, string[]>>) =
+            if validateToken (admin.secret ()) (admin.now ()) token then
+                run ()
+            else
+                async { return Error [| "Invalid token" |] }
+
+        match cmd with
+        | AdminCommand.ValidatePassword password ->
+            async {
+                let secret = admin.secret ()
+
+                return
+                    if validatePassword secret password then
+                        Ok(AdminResponse.PasswordValidated(true, generateToken secret (admin.now ())))
+                    else
+                        Ok(AdminResponse.PasswordValidated(false, ""))
+            }
+        | AdminCommand.ListLogFiles token ->
+            withToken token (fun () ->
+                async {
+                    let! files = admin.listLogFiles ()
+                    return files |> Result.map AdminResponse.LogFilesListed
+                }
+            )
+        | AdminCommand.AnalyzeLogFile(token, fileName) ->
+            withToken token (fun () ->
+                async {
+                    let! report = admin.analyzeLogFile fileName
+                    return report |> Result.map AdminResponse.LogFileAnalyzed
+                }
+            )
+        | AdminCommand.ReloadResources token ->
+            withToken token (fun () ->
+                async {
+                    let! reloaded = admin.reloadResources ()
+                    return reloaded |> Result.map (fun () -> AdminResponse.ResourcesReloaded)
+                }
+            )
+
+
+// ---------------------------------------------------------------------------------------------
+// The adapter (→ Adapters.fs, in makeAppEnvWith)
+// ---------------------------------------------------------------------------------------------
 //
-// The stub platform used to answer `Patient.empty` for every PatientId but `no-data`; an
-// empty record is a reading, so the fallback never applied to `stub-patient`, and a hand
-// entered age was lost at every reload. It now answers a fixed patient, so the panel is filled
-// from the platform at launch and the fallback is exercised with `no-data`.
-
-module Hop640 =
-
-    /// #640: the patient a Session opens on. The platform's reading (Concept 2) wins; without
-    /// one, the patient data of the head of the record, the last seen (Rule 19); from nothing,
-    /// an empty patient (ext 6a).
-    let sessionPatient (patientData: string -> Patient option) (patientId: string) (head: SignedOrderPlan option) : Patient =
-        patientData patientId
-        |> Option.orElse (head |> Option.map _.Patient)
-        |> Option.defaultValue Patient.empty
-
-
-    /// #640, at the commit: the Session's patient after a signature. The platform's reading at
-    /// the challenge (Rule 44; the newest, should it have changed and been accepted at the
-    /// notice), else the data just signed, so a resume in this Session shows what a relaunch
-    /// would.
-    let commitPatient (reading: Patient option) (signed: Patient) : Patient =
-        reading |> Option.defaultValue signed
-
-
-/// The PatientDataPlatform stub: a fixed patient for every PatientId, none at all for
-/// `no-data` (ext 6a).
-module StubPatientData640 =
-
-    /// The stub's reading: ten years, 32 kg, 140 cm, nothing else known.
-    let patient: Patient =
-        Patient.create
-            (Some(Shared.Measures.toYear 10))
-            None
-            None
-            None
-            (Some 32000)
-            (Some 140)
-            None
-            None
-            UnknownGender
-            []
-            None
-            None
-        |> Option.defaultValue Patient.empty
-
-
-    let port: ServerApi.PatientDataPort =
-        {
-            read = fun pid -> if pid = "no-data" then None else Some patient
-        }
+//     admin =
+//         {
+//             secret =
+//                 fun () ->
+//                     Informedica.Utils.Lib.Env.getItem "GENPRES_PASSWORD"
+//                     |> Option.filter (String.IsNullOrWhiteSpace >> not)
+//             now = fun () -> DateTimeOffset.UtcNow
+//             listLogFiles = (as today)
+//             analyzeLogFile = (as today)
+//             reloadResources =
+//                 fun () ->
+//                     async {
+//                         try
+//                             Informedica.GenForm.Lib.Api.reloadCache logger provider
+//                             return Ok()
+//                         with ex ->
+//                             return Error [| ex.Message |]
+//                     }
+//         }
+//
+// and in `compose` (→ CompositionRoot.fs), with the same logging as the session members:
+//
+//     processAdmin =
+//         fun cmd ->
+//             async {
+//                 writeInfoMessage $"Processing admin: {cmd |> AdminCommand.toString}"
+//                 let! response = AdminCommand.processCmd env cmd
+//                 writeInfoMessage $"Finished processing admin: {cmd |> AdminCommand.toString}"
+//                 return response
+//             }
+//
+// `processAdmin` does not consult `requireLoaded`: the reload is what makes a failed load
+// loadable again.
 
 
 // ---------------------------------------------------------------------------------------------
@@ -191,215 +241,177 @@ module StubPatientData640 =
 
 open Expecto
 open Expecto.Flip
+open Api654
 
 
-let t0 = DateTime(2026, 9, 11, 12, 0, 0, DateTimeKind.Utc)
-let t1 = t0.AddMinutes 5.0
+let secret = Some "a-sixteen-char-secret!"
+let t0 = DateTimeOffset(2026, 9, 12, 12, 0, 0, TimeSpan.Zero)
 
-let counter prefix =
-    let n = ref 0
 
-    fun () ->
-        n.Value <- n.Value + 1
-        $"{prefix}-{n.Value}"
+/// A port over a fixed secret and clock that counts its reloads.
+let port (secret: string option) (now: DateTimeOffset) =
+    let reloads = ref 0
 
-let prescriber =
+    reloads,
     {
-        UserId = "prescriber"
-        DisplayName = "Stub Prescriber"
-        Role = UserRole.Prescriber
-    }
-
-let other =
-    { prescriber with
-        UserId = "prescriber-b"
-        DisplayName = "Stub Prescriber B"
-    }
-
-
-let signedBy (user: UserContext) no : SignedOrderPlan =
-    {
-        Head =
-            {
-                Id = $"plan-{no}"
-                No = no
-                By = user
-                SignedAt = t0
-            }
-        PatientId = "pat-1"
-        Base = if no > 1 then Some $"plan-{no - 1}" else None
-        Scenarios = [||]
-        Patient = Patient.empty
-        Verified = true
+        secret = fun () -> secret
+        now = fun () -> now
+        listLogFiles = fun () -> async { return Ok [| { FileName = "server.log"; SizeBytes = 12L; LastModifiedAt = "2026-09-12" } |] }
+        analyzeLogFile = fun name -> async { return Ok $"report of %s{name}" }
+        reloadResources =
+            fun () ->
+                async {
+                    reloads.Value <- reloads.Value + 1
+                    return Ok()
+                }
     }
 
 
-let session (user: UserContext option) (patientId: string option) (sid: string) (openedWith: string option) : ServerApi.Hop.SessionRecord =
-    {
-        Session =
-            {
-                User = user
-                PatientContext =
-                    patientId
-                    |> Option.map (fun pid ->
-                        {
-                            PatientId = pid
-                            Patient = Patient.empty
-                        }
-                    )
-                OpenedToken = Some(OpenedToken $"opened-{sid}")
-                KeyThumbprint = Some "t"
-                Head = None
-            }
-        Login = user |> Option.map _.UserId
-        OpenedWith = openedWith
-        Seen = t0
-    }
+let run admin cmd =
+    AdminCommand.processCmd admin cmd |> Async.RunSynchronously
 
 
-let challenged sid : ServerApi.Hop.Challenge =
-    {
-        Nonce = $"c-{sid}"
-        Patient = Patient.empty
-        Scenarios = [||]
-        Reading = Some Patient.empty
-        Expiry = t0.AddMinutes 2.0
-    }
+let tokenOf admin =
+    match run admin (AdminCommand.ValidatePassword (admin.secret ()).Value) with
+    | Ok(AdminResponse.PasswordValidated(true, token)) -> token
+    | other -> failtest $"expected a token, got {other}"
 
 
-/// A opened on plan-1; B signed plan-2 meanwhile; A has a challenge standing over plan-1.
-let movedOn =
-    { Hop.emptyState with
-        Sessions = Map.ofList [ "s-1", session (Some prescriber) (Some "pat-1") "s-1" (Some "plan-1") ]
-        Records = Map.ofList [ "pat-1", [ signedBy other 2; signedBy prescriber 1 ] ]
-        Challenges = Map.ofList [ "s-1", challenged "s-1" ]
-        Notices = Map.ofList [ "s-1", { Nonce = "n"; Data = None; Expiry = t0.AddMinutes 2.0 } ]
-    }
-
-let openAt sid id state =
-    Hop.openVersion t1 (counter "id") sid id state
+/// The same payload under a different signature.
+let forge (token: string) =
+    match token.Split '.' with
+    | [| payload; signature |] ->
+        let bytes = Convert.FromBase64String signature
+        bytes[0] <- bytes[0] ^^^ 1uy
+        $"%s{payload}.%s{Convert.ToBase64String bytes}"
+    | _ -> failtest "not a token"
 
 
-let tests =
+let passwordTests =
     testList
-        "openVersion (Rules 18 to 20, UC-4 step 4)"
+        "ValidatePassword"
         [
-            test "no Session: nothing to open" {
-                Hop.emptyState |> openAt "s-9" "plan-2" |> snd |> Expect.equal "none" None
+            test "the server's password buys a token that verifies" {
+                let _, admin = port secret t0
+                let token = tokenOf admin
+                token |> Expect.isNotEmpty "a token"
+                AdminCommand.validateToken secret t0 token |> Expect.isTrue "verifies"
             }
 
-            test "an anonymous Session, or one without a Patient: nothing to open (Rule 13)" {
-                let state =
-                    { movedOn with
-                        Sessions =
-                            Map.ofList
-                                [
-                                    "s-a", session None (Some "pat-1") "s-a" None
-                                    "s-n", session (Some prescriber) None "s-n" None
-                                ]
-                    }
+            test "a wrong password: not valid, no token" {
+                let _, admin = port secret t0
 
-                state |> openAt "s-a" "plan-2" |> snd |> Expect.equal "anonymous" None
-                state |> openAt "s-n" "plan-2" |> snd |> Expect.equal "no patient" None
+                run admin (AdminCommand.ValidatePassword "wrong")
+                |> Expect.equal "refused" (Ok(AdminResponse.PasswordValidated(false, "")))
             }
 
-            test "an id the record does not hold: nothing opens, the Session as it is, token kept" {
-                let state, answer = movedOn |> openAt "s-1" "plan-9"
-                answer |> Expect.equal "as it is" (Some movedOn.Sessions["s-1"].Session)
-                state.Sessions["s-1"].OpenedWith |> Expect.equal "unchanged" (Some "plan-1")
-                state.Challenges |> Map.containsKey "s-1" |> Expect.isTrue "challenge kept"
-                state.Sessions["s-1"].Seen |> Expect.equal "touched" t1
-            }
+            test "no password on the server: nothing is valid, not even an empty one" {
+                for none in [ None; Some ""; Some "   " ] do
+                    let _, admin = port none t0
 
-            test "the version already open: the token stands, the version is answered" {
-                let state, answer = movedOn |> openAt "s-1" "plan-1"
+                    run admin (AdminCommand.ValidatePassword "")
+                    |> Expect.equal "refused" (Ok(AdminResponse.PasswordValidated(false, "")))
 
-                match answer with
-                | Some opened ->
-                    opened.OpenedToken |> Expect.equal "kept" (Some(OpenedToken "opened-s-1"))
-                    opened.Head |> Expect.equal "the version" (Some(signedBy prescriber 1))
-                | other -> failtest $"expected the Session, got {other}"
-
-                state.Challenges |> Map.containsKey "s-1" |> Expect.isTrue "challenge kept"
-            }
-
-            test "the head: opened, the token re-minted, the challenge and notice dropped (Rules 19, 34)" {
-                let state, answer = movedOn |> openAt "s-1" "plan-2"
-
-                match answer with
-                | Some opened ->
-                    opened.OpenedToken |> Expect.equal "re-minted" (Some(OpenedToken "opened-id-1"))
-                    opened.Head |> Expect.equal "B's version" (Some(signedBy other 2))
-                | other -> failtest $"expected the Session, got {other}"
-
-                state.Sessions["s-1"].OpenedWith |> Expect.equal "opened with the head" (Some "plan-2")
-                state.Sessions["s-1"].Session.OpenedToken |> Expect.equal "held" (Some(OpenedToken "opened-id-1"))
-                state.Challenges |> Expect.isEmpty "challenge dropped"
-                state.Notices |> Expect.isEmpty "notice dropped"
-
-                // Rule 20 no longer blocks; the old token is stale (Rule 34)
-                ServerApi.Hop.blockedBy state.Sessions["s-1"] "pat-1" { ServerApi.Hop.emptyState with Records = state.Records }
-                |> Expect.isNone "not blocked"
-            }
-
-            test "an older version: opened, still blocked by the head (Rules 18, 20)" {
-                let three =
-                    { movedOn with
-                        Records = Map.ofList [ "pat-1", [ signedBy prescriber 3; signedBy other 2; signedBy prescriber 1 ] ]
-                    }
-
-                let state, answer = three |> openAt "s-1" "plan-2"
-
-                match answer with
-                | Some opened -> opened.Head |> Expect.equal "plan-2" (Some(signedBy other 2))
-                | other -> failtest $"expected the Session, got {other}"
-
-                ServerApi.Hop.blockedBy state.Sessions["s-1"] "pat-1" { ServerApi.Hop.emptyState with Records = state.Records }
-                |> Option.map _.Id
-                |> Expect.equal "the head still blocks" (Some "plan-3")
+                    AdminCommand.generateToken none t0 |> Expect.equal "no token" ""
+                    AdminCommand.validateToken none t0 "" |> Expect.isFalse "empty never verifies"
             }
         ]
 
 
-let patientTests =
-    let signedOn (patient: Patient) = Some { signedBy prescriber 1 with Patient = patient }
-    let entered = { Patient.empty with Department = Some "ICU" }
-    let none (_: string) = None
-
+let tokenTests =
     testList
-        "the patient at open (#640)"
+        "the token"
         [
-            test "a reading wins over the signed patient (Concept 2)" {
-                Hop640.sessionPatient StubPatientData640.port.read "stub-patient" (signedOn entered)
-                |> Expect.equal "the platform's" StubPatientData640.patient
+            test "a valid token lists, analyzes and reloads" {
+                let reloads, admin = port secret t0
+                let token = tokenOf admin
+
+                match run admin (AdminCommand.ListLogFiles token) with
+                | Ok(AdminResponse.LogFilesListed files) -> files.Length |> Expect.equal "one file" 1
+                | other -> failtest $"expected the files, got {other}"
+
+                run admin (AdminCommand.AnalyzeLogFile(token, "server.log"))
+                |> Expect.equal "the report" (Ok(AdminResponse.LogFileAnalyzed "report of server.log"))
+
+                run admin (AdminCommand.ReloadResources token)
+                |> Expect.equal "reloaded" (Ok AdminResponse.ResourcesReloaded)
+
+                reloads.Value |> Expect.equal "the port reloaded once" 1
             }
 
-            test "no reading: the patient the head was signed on (Rule 19)" {
-                Hop640.sessionPatient none "no-data" (signedOn entered)
-                |> Expect.equal "the signed" entered
+            test "a forged, an expired, a malformed and an empty token are refused, and nothing reloads" {
+                let reloads, admin = port secret t0
+                let token = tokenOf admin
+                let later = t0.Add(AdminCommand.tokenLifetime).AddSeconds 1.0
+                let _, expiredAdmin = port secret later
+
+                for admin, token in
+                    [
+                        admin, forge token
+                        expiredAdmin, token
+                        admin, "not.a.token"
+                        admin, "abc"
+                        admin, ""
+                    ] do
+                    run admin (AdminCommand.ReloadResources token) |> Expect.equal "refused" (Error [| "Invalid token" |])
+                    run admin (AdminCommand.ListLogFiles token) |> Expect.equal "refused" (Error [| "Invalid token" |])
+
+                    run admin (AdminCommand.AnalyzeLogFile(token, "server.log"))
+                    |> Expect.equal "refused" (Error [| "Invalid token" |])
+
+                reloads.Value |> Expect.equal "nothing reloaded" 0
             }
 
-            test "no reading, no record: an empty patient (ext 6a)" {
-                Hop640.sessionPatient none "no-data" None |> Expect.equal "empty" Patient.empty
+            test "a token lives an hour" {
+                let _, admin = port secret t0
+                let token = tokenOf admin
+                AdminCommand.validateToken secret (t0.Add AdminCommand.tokenLifetime) token |> Expect.isTrue "at the hour"
+
+                AdminCommand.validateToken secret (t0.Add(AdminCommand.tokenLifetime).AddSeconds 1.0) token
+                |> Expect.isFalse "past it"
             }
 
-            test "at the commit: the reading at the challenge, else the data signed" {
-                Hop640.commitPatient (Some StubPatientData640.patient) entered
-                |> Expect.equal "the reading" StubPatientData640.patient
-
-                Hop640.commitPatient (Some entered) Patient.empty |> Expect.equal "a changed reading, accepted" entered
-                Hop640.commitPatient None entered |> Expect.equal "the signed" entered
+            test "a token of another secret is refused" {
+                let _, other = port (Some "another-secret-of-16!") t0
+                let _, admin = port secret t0
+                run admin (AdminCommand.ReloadResources(tokenOf other)) |> Expect.equal "refused" (Error [| "Invalid token" |])
             }
 
-            test "the stub: a fixed patient for every id, none for no-data" {
-                StubPatientData640.port.read "stub-patient"
-                |> Expect.equal "a reading" (Some StubPatientData640.patient)
+            test "a failing reload answers the port's error" {
+                let _, admin = port secret t0
+                let token = tokenOf admin
 
-                StubPatientData640.patient |> Expect.notEqual "not empty" Patient.empty
-                StubPatientData640.patient.Age |> Option.map _.Years |> Expect.equal "ten" (Some(Shared.Measures.toYear 10))
-                StubPatientData640.port.read "no-data" |> Expect.isNone "no data"
+                let failing =
+                    { admin with
+                        reloadResources = fun () -> async { return Error [| "sheet unreachable" |] }
+                    }
+
+                run failing (AdminCommand.ReloadResources token) |> Expect.equal "the error" (Error [| "sheet unreachable" |])
             }
         ]
 
 
-runTestsWithCLIArgs [] [||] (testList "Compute" [ tests; patientTests ]) |> ignore
+let logTests =
+    testList
+        "AdminCommand.toString"
+        [
+            test "never the password or the token" {
+                let _, admin = port secret t0
+                let token = tokenOf admin
+
+                [
+                    AdminCommand.ValidatePassword secret.Value
+                    AdminCommand.ListLogFiles token
+                    AdminCommand.AnalyzeLogFile(token, "server.log")
+                    AdminCommand.ReloadResources token
+                ]
+                |> List.map AdminCommand.toString
+                |> List.iter (fun line ->
+                    line.Contains secret.Value |> Expect.isFalse "no password"
+                    line.Contains token |> Expect.isFalse "no token"
+                )
+            }
+        ]
+
+
+runTestsWithCLIArgs [] [||] (testList "Admin" [ passwordTests; tokenTests; logTests ]) |> ignore

--- a/src/Informedica.GenPRES.Server/Scripts/load.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/load.fsx
@@ -23,6 +23,7 @@
 #load "../ServerApi.Session.fs"
 #load "../ServerApi.StubAdapters.fs"
 #load "../ServerApi.Adapters.fs"
+#load "../ServerApi.AdminCommand.fs"
 #load "../ServerApi.Command.fs"
 #load "../ServerApi.LaunchCommand.fs"
 #load "../ServerApi.SessionCommand.fs"

--- a/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
@@ -165,6 +165,16 @@ module Adapters =
         }
 
 
+    /// The messages of a provider that did not load; None when it did.
+    let private notLoaded (provider: Resources.IResourceProvider) =
+        let info = provider.GetResourceInfo()
+
+        if info.IsLoaded then
+            None
+        else
+            info.Messages |> Array.map (fun msg -> FormLogging.formatMessage msg) |> Some
+
+
     let makeAppEnvWith
         (launchKey: LaunchSeal.Key)
         (directory: StubDirectory.Directory)
@@ -223,24 +233,23 @@ module Adapters =
                                     return Error [| ex.Message |]
                             }
                     analyzeLogFile = fun fileName -> async { return LogAnalyzer.analyzeFile fileName }
+                    // a reload that leaves the provider unloaded is a failure with its messages,
+                    // not a success: reloadCache records the state and returns normally
                     reloadResources =
                         fun () ->
                             async {
                                 try
                                     Informedica.GenForm.Lib.Api.reloadCache logger provider
-                                    return Ok()
+
+                                    return
+                                        match notLoaded provider with
+                                        | None -> Ok()
+                                        | Some msgs -> Error msgs
                                 with ex ->
                                     return Error [| ex.Message |]
                             }
                 }
-            requireLoaded =
-                fun () ->
-                    let info = provider.GetResourceInfo()
-
-                    if info.IsLoaded then
-                        None
-                    else
-                        info.Messages |> Array.map (fun msg -> FormLogging.formatMessage msg) |> Some
+            requireLoaded = fun () -> notLoaded provider
             // an in-memory stub with a two-minute Launch lifetime; its sessions live as long
             // as this AppEnv
             session =

--- a/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
@@ -206,8 +206,14 @@ module Adapters =
                                     return Error [| ex.Message |]
                             }
                 }
-            logAnalyzer =
+            admin =
                 {
+                    // the setting as the DMZ reads it: blank is no secret
+                    secret =
+                        fun () ->
+                            Informedica.Utils.Lib.Env.getItem "GENPRES_PASSWORD"
+                            |> Option.filter (String.IsNullOrWhiteSpace >> not)
+                    now = fun () -> DateTimeOffset.UtcNow
                     listLogFiles =
                         fun () ->
                             async {
@@ -217,6 +223,15 @@ module Adapters =
                                     return Error [| ex.Message |]
                             }
                     analyzeLogFile = fun fileName -> async { return LogAnalyzer.analyzeFile fileName }
+                    reloadResources =
+                        fun () ->
+                            async {
+                                try
+                                    Informedica.GenForm.Lib.Api.reloadCache logger provider
+                                    return Ok()
+                                with ex ->
+                                    return Error [| ex.Message |]
+                            }
                 }
             requireLoaded =
                 fun () ->

--- a/src/Informedica.GenPRES.Server/ServerApi.AdminCommand.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.AdminCommand.fs
@@ -1,0 +1,125 @@
+namespace ServerApi
+
+
+module AdminCommand =
+
+    open System
+    open System.Security.Cryptography
+    open System.Text
+    open Shared.Api
+
+
+    let tokenLifetime = TimeSpan.FromHours 1.0
+
+
+    /// An empty or whitespace secret is no secret. `Env.getItem` answers `Some ""` for a
+    /// setting that is set but empty (the Dockerfile's `ENV GENPRES_PASSWORD=`), and an empty
+    /// password compared with an empty secret would match, so blanks fail closed here as well
+    /// as at the port.
+    let private nonBlank (secret: string option) =
+        secret |> Option.filter (String.IsNullOrWhiteSpace >> not)
+
+
+    /// SECURITY: `FixedTimeEquals` so equal-length comparisons do not leak through per-byte
+    /// timing. It short-circuits on a length mismatch; that leak is accepted because production
+    /// enforces a 16-character minimum and the password travels only at ValidatePassword.
+    let validatePassword (secret: string option) (password: string) =
+        match nonBlank secret with
+        | None -> false
+        | Some expected ->
+            CryptographicOperations.FixedTimeEquals(Encoding.UTF8.GetBytes password, Encoding.UTF8.GetBytes expected)
+
+
+    /// `base64(expiresAt:nonce).base64(hmacsha256(secret, expiresAt:nonce))`; empty without a
+    /// secret, so that nothing signed with an empty key can ever verify.
+    let generateToken (secret: string option) (now: DateTimeOffset) =
+        match nonBlank secret with
+        | None -> ""
+        | Some secret ->
+            let expiresAt = now.Add(tokenLifetime).ToUnixTimeSeconds()
+            let nonce = RandomNumberGenerator.GetBytes 32 |> Convert.ToBase64String
+            let payload = Encoding.UTF8.GetBytes $"%d{expiresAt}:%s{nonce}"
+            use hmac = new HMACSHA256(Encoding.UTF8.GetBytes secret)
+            let signature = hmac.ComputeHash payload
+            $"%s{Convert.ToBase64String payload}.%s{Convert.ToBase64String signature}"
+
+
+    let validateToken (secret: string option) (now: DateTimeOffset) (token: string) =
+        match nonBlank secret with
+        | None -> false
+        | Some secret ->
+            if String.IsNullOrWhiteSpace token then
+                false
+            else
+                match token.Split '.' with
+                | [| payload; signature |] ->
+                    try
+                        let payload = Convert.FromBase64String payload
+                        let provided = Convert.FromBase64String signature
+                        use hmac = new HMACSHA256(Encoding.UTF8.GetBytes secret)
+                        let expected = hmac.ComputeHash payload
+
+                        CryptographicOperations.FixedTimeEquals(provided, expected)
+                        && (
+                            match (Encoding.UTF8.GetString payload).Split(':', 2) with
+                            | [| expiresAt; _ |] ->
+                                match Int64.TryParse expiresAt with
+                                | true, expiresAt -> now.ToUnixTimeSeconds() <= expiresAt
+                                | false, _ -> false
+                            | _ -> false
+                        )
+                    with _ ->
+                        false
+                | _ -> false
+
+
+    /// The admin commands over the admin port: the password buys a token, the token opens the
+    /// log and the reload. Not behind `requireLoaded`: the reload is what makes a failed load
+    /// loadable again.
+    let processCmd (env: AppEnv) (cmd: AdminCommand) : Async<Result<AdminResponse, string[]>> =
+        let admin = env.admin
+
+        let withToken token (run: unit -> Async<Result<AdminResponse, string[]>>) =
+            if validateToken (admin.secret ()) (admin.now ()) token then
+                run ()
+            else
+                async { return Error [| "Invalid token" |] }
+
+        match cmd with
+        | AdminCommand.ValidatePassword password ->
+            async {
+                let secret = admin.secret ()
+
+                return
+                    if validatePassword secret password then
+                        Ok(AdminResponse.PasswordValidated(true, generateToken secret (admin.now ())))
+                    else
+                        Ok(AdminResponse.PasswordValidated(false, ""))
+            }
+        | AdminCommand.ListLogFiles token ->
+            withToken
+                token
+                (fun () ->
+                    async {
+                        let! files = admin.listLogFiles ()
+                        return files |> Result.map AdminResponse.LogFilesListed
+                    }
+                )
+        | AdminCommand.AnalyzeLogFile(token, fileName) ->
+            withToken
+                token
+                (fun () ->
+                    async {
+                        let! report = admin.analyzeLogFile fileName
+                        return report |> Result.map AdminResponse.LogFileAnalyzed
+                    }
+                )
+        | AdminCommand.ReloadResources token ->
+            withToken
+                token
+                (fun () ->
+                    async {
+                        let! reloaded = admin.reloadResources ()
+                        return reloaded |> Result.map (fun () -> AdminResponse.ResourcesReloaded)
+                    }
+                )

--- a/src/Informedica.GenPRES.Server/ServerApi.Command.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Command.fs
@@ -5,120 +5,8 @@ module Command =
 
     open Shared.Api
 
-    open Informedica.Utils.Lib
-
-
-    // SECURITY: validatePassword uses CryptographicOperations.FixedTimeEquals
-    // so equal-length password comparisons do not leak information through
-    // per-byte timing differences. Per .NET docs, FixedTimeEquals short-
-    // circuits when the byte arrays differ in length; the (small) length-
-    // leak is acceptable here because the production startup check enforces
-    // a minimum 16-character GENPRES_PASSWORD and the proper fix is to
-    // migrate this code path away from raw-password-on-the-wire entirely
-    // (tracked by TODO(D4 follow-up) in ServerApi.Services.fs).
-    //
-    // The `Option.filter (IsNullOrWhiteSpace >> not)` step is essential:
-    // `Env.getItem` returns `Some ""` when an env var is set but empty,
-    // which is what the Dockerfile does with `ENV GENPRES_PASSWORD=` for
-    // Plesk-style runtime injection. Without the filter, `password = ""`
-    // (or `FixedTimeEquals(getBytes(""), getBytes(""))`) would evaluate to
-    // `true` and an empty-password login request would issue a valid
-    // 1-hour HMAC token. The filter coerces empty/whitespace to `None` so
-    // the fail-closed `Option.defaultValue false` branch fires.
-    let private validatePassword (password: string) =
-        Env.getItem "GENPRES_PASSWORD"
-        |> Option.filter (System.String.IsNullOrWhiteSpace >> not)
-        |> Option.map (fun expected ->
-            System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(
-                System.Text.Encoding.UTF8.GetBytes(password),
-                System.Text.Encoding.UTF8.GetBytes(expected)
-            )
-        )
-        |> Option.defaultValue false
-
-
-    let private tokenLifetime = System.TimeSpan.FromHours(1.0)
-
-
-    let private generateToken () =
-        // SECURITY: same `Option.filter` as validatePassword — an empty
-        // GENPRES_PASSWORD must NOT be used as the HMAC key, otherwise the
-        // token would be signed with an attacker-known key and trivially
-        // forgeable. Coerce empty/whitespace to `None` so the empty-string
-        // return path fires and login is impossible.
-        match
-            Env.getItem "GENPRES_PASSWORD"
-            |> Option.filter (System.String.IsNullOrWhiteSpace >> not)
-        with
-        | None -> ""
-        | Some secret ->
-            let expiresAt = System.DateTimeOffset.UtcNow.Add(tokenLifetime).ToUnixTimeSeconds()
-
-            let nonceBytes = Array.zeroCreate<byte> 32
-            System.Security.Cryptography.RandomNumberGenerator.Fill nonceBytes
-            let nonce = System.Convert.ToBase64String(nonceBytes)
-            let payload = $"%d{expiresAt}:%s{nonce}"
-            let payloadBytes = System.Text.Encoding.UTF8.GetBytes(payload)
-
-            use hmac =
-                new System.Security.Cryptography.HMACSHA256(System.Text.Encoding.UTF8.GetBytes(secret))
-
-            let signatureBytes = hmac.ComputeHash(payloadBytes)
-            let encodedPayload = System.Convert.ToBase64String(payloadBytes)
-            let encodedSignature = System.Convert.ToBase64String(signatureBytes)
-            $"%s{encodedPayload}.%s{encodedSignature}"
-
-
-    let private validateToken (token: string) =
-        if System.String.IsNullOrWhiteSpace(token) then
-            false
-        else
-            // SECURITY: same `Option.filter` as validatePassword/generateToken —
-            // an empty/whitespace GENPRES_PASSWORD must NOT be accepted as a
-            // valid HMAC key, otherwise any token signed with the empty key
-            // would verify. Coerce empty to `None` so the fail-closed branch
-            // fires.
-            match
-                Env.getItem "GENPRES_PASSWORD"
-                |> Option.filter (System.String.IsNullOrWhiteSpace >> not)
-            with
-            | None -> false
-            | Some secret ->
-                let parts = token.Split('.')
-
-                if parts.Length <> 2 then
-                    false
-                else
-                    try
-                        let payloadBytes = System.Convert.FromBase64String(parts[0])
-                        let providedSig = System.Convert.FromBase64String(parts[1])
-
-                        use hmac =
-                            new System.Security.Cryptography.HMACSHA256(System.Text.Encoding.UTF8.GetBytes(secret))
-
-                        let expectedSig = hmac.ComputeHash(payloadBytes)
-
-                        if
-                            not (
-                                System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(
-                                    providedSig,
-                                    expectedSig
-                                )
-                            )
-                        then
-                            false
-                        else
-                            let payload = System.Text.Encoding.UTF8.GetString(payloadBytes)
-                            let colonIdx = payload.IndexOf(':')
-
-                            if colonIdx < 0 then
-                                false
-                            else
-                                match System.Int64.TryParse(payload.Substring(0, colonIdx)) with
-                                | true, expiresAt -> System.DateTimeOffset.UtcNow.ToUnixTimeSeconds() <= expiresAt
-                                | false, _ -> false
-                    with _ ->
-                        false
+    // the password and token checks live in AdminCommand until the LogAnalyzerCmd family
+    // leaves this dispatcher (#654)
 
 
     let processCmd (env: AppEnv) cmd =
@@ -130,26 +18,28 @@ module Command =
             }
         | LogAnalyzerCmd(ValidatePassword password) ->
             async {
-                if validatePassword password then
-                    let token = generateToken ()
+                let secret = env.admin.secret ()
+
+                if AdminCommand.validatePassword secret password then
+                    let token = AdminCommand.generateToken secret (env.admin.now ())
                     return Ok(PasswordValidated(true, token) |> LogAnalyzerResp)
                 else
                     return Ok(PasswordValidated(false, "") |> LogAnalyzerResp)
             }
         | LogAnalyzerCmd(ListLogFiles token) ->
-            if not (validateToken token) then
+            if not (AdminCommand.validateToken (env.admin.secret ()) (env.admin.now ()) token) then
                 async { return Error [| "Invalid token" |] }
             else
                 async {
-                    let! result = env.logAnalyzer.listLogFiles ()
+                    let! result = env.admin.listLogFiles ()
                     return result |> Result.map (LogFilesListed >> LogAnalyzerResp)
                 }
         | LogAnalyzerCmd(AnalyzeLogFile(token, fileName)) ->
-            if not (validateToken token) then
+            if not (AdminCommand.validateToken (env.admin.secret ()) (env.admin.now ()) token) then
                 async { return Error [| "Invalid token" |] }
             else
                 async {
-                    let! result = env.logAnalyzer.analyzeLogFile fileName
+                    let! result = env.admin.analyzeLogFile fileName
                     return result |> Result.map (LogFileAnalyzed >> LogAnalyzerResp)
                 }
         | _ ->

--- a/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
@@ -86,6 +86,16 @@ module CompositionRoot =
                         return response
                     }
 
+            // never Session-bound: no cookie read, no notice, and not behind requireLoaded
+            processAdmin =
+                fun cmd ->
+                    async {
+                        writeInfoMessage $"Processing admin: {cmd |> AdminCommand.toString}"
+                        let! response = AdminCommand.processCmd env cmd
+                        writeInfoMessage $"Finished processing admin: {cmd |> AdminCommand.toString}"
+                        return response
+                    }
+
             getSettings =
                 fun () ->
                     async {

--- a/src/Informedica.GenPRES.Server/ServerApi.Ports.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Ports.fs
@@ -40,10 +40,17 @@ type InteractionPort =
     }
 
 
-type LogAnalyzerPort =
+/// What the admin commands need from the edge. The secret and the clock are values the DMZ
+/// reads and passes in, so the command module never touches the environment.
+type AdminPort =
     {
+        // GENPRES_PASSWORD; None when unset, empty or whitespace, so every check fails closed
+        secret: unit -> string option
+        now: unit -> System.DateTimeOffset
         listLogFiles: unit -> Async<Result<LogFileInfo[], string[]>>
         analyzeLogFile: string -> Async<Result<string, string[]>>
+        // the resource provider reloaded: the formulary and, later, the knowledge sheets
+        reloadResources: unit -> Async<Result<unit, string[]>>
     }
 
 
@@ -220,7 +227,7 @@ type AppEnv =
         orderPlan: OrderPlanPort
         nutritionPlan: NutritionPlanPort
         interaction: InteractionPort
-        logAnalyzer: LogAnalyzerPort
+        admin: AdminPort
         requireLoaded: unit -> string[] option
         session: SessionPort
     }

--- a/src/Informedica.GenPRES.Shared/Api.fs
+++ b/src/Informedica.GenPRES.Shared/Api.fs
@@ -246,6 +246,40 @@ module Api =
             | SigningCommand.Submit _ -> "Submit"
 
 
+    /// The admin command family: the password once, then the token it bought. Never
+    /// cookie-authenticated, and never behind the formulary being loaded, so a failed load can
+    /// be retried from the settings page.
+    [<RequireQualifiedAccess>]
+    type AdminCommand =
+        // answered with a token when the password is the server's; with nothing when the
+        // server has no password
+        | ValidatePassword of password: string
+        | ListLogFiles of token: string
+        | AnalyzeLogFile of token: string * fileName: string
+        // reloads everything the resource provider holds
+        | ReloadResources of token: string
+
+
+    [<RequireQualifiedAccess>]
+    type AdminResponse =
+        // isValid false comes with an empty token
+        | PasswordValidated of isValid: bool * token: string
+        | LogFilesListed of LogFileInfo[]
+        | LogFileAnalyzed of string
+        | ResourcesReloaded
+
+
+    module AdminCommand =
+
+        /// For the log. Never the password or the token; the file name is not a secret.
+        let toString cmd =
+            match cmd with
+            | AdminCommand.ValidatePassword _ -> "ValidatePassword"
+            | AdminCommand.ListLogFiles _ -> "ListLogFiles"
+            | AdminCommand.AnalyzeLogFile(_, f) -> $"AnalyzeLogFile %s{f}"
+            | AdminCommand.ReloadResources _ -> "ReloadResources"
+
+
     /// Defines how routes are generated on server and mapped from the client
     let routerPaths typeName method = $"/api/%s{typeName}/%s{method}"
 
@@ -268,6 +302,8 @@ module Api =
             processLaunch: LaunchCommand -> Async<LaunchOutcome>
             processSession: SessionCommand -> Async<SessionResponse>
             processSigning: SigningCommand -> Async<SigningResponse>
+            // no envelope: an admin request has no OpenedToken to send and no notice to receive
+            processAdmin: AdminCommand -> Async<Result<AdminResponse, string[]>>
             getSettings: unit -> Async<ServerSettings>
             testApi: unit -> Async<string>
         }

--- a/src/Informedica.GenPRES.Shared/Scripts/Api.fsx
+++ b/src/Informedica.GenPRES.Shared/Scripts/Api.fsx
@@ -1,0 +1,104 @@
+// The admin command family (plan 654, step 2): the settings page's four operations as one
+// `IServerApi` member, `processAdmin`, token-authenticated and never Session-bound.
+//
+// Script-first draft of what goes to `Shared/Api.fs`: `AdminCommand`, `AdminResponse`,
+// `AdminCommand.toString` and the `IServerApi` member. A script cannot add cases to
+// `Shared.Api` or a field to `IServerApi`, so the types are proposed here under `Api654` and
+// the member is stated as a signature. `ReloadResources` carries the token the login issued,
+// not the password: the password travels once, at `ValidatePassword`.
+//
+// Run: `dotnet fsi Api.fsx` from this directory, or via the FSI MCP after
+// `#I "<this directory>"`.
+
+#I __SOURCE_DIRECTORY__
+#r "nuget: Expecto, 10.2.3"
+
+#load "../Types.fs"
+#load "../Calculations.fs"
+#load "../Utils.fs"
+#load "../Localization.fs"
+#load "../Models.fs"
+#load "../Api.fs"
+
+open Shared.Types
+
+
+/// → `Shared/Api.fs`, after `SigningCommand`.
+module Api654 =
+
+    /// The admin command family: the password once, then the token it bought. Never
+    /// cookie-authenticated, never behind the formulary being loaded, so a failed load can be
+    /// retried from the settings page.
+    [<RequireQualifiedAccess>]
+    type AdminCommand =
+        // answered with a token when the password is the server's; a token nobody can forge
+        // when the server has no password
+        | ValidatePassword of password: string
+        | ListLogFiles of token: string
+        | AnalyzeLogFile of token: string * fileName: string
+        // reloads the formulary and everything else the resource provider holds
+        | ReloadResources of token: string
+
+
+    [<RequireQualifiedAccess>]
+    type AdminResponse =
+        // isValid false comes with an empty token
+        | PasswordValidated of isValid: bool * token: string
+        | LogFilesListed of LogFileInfo[]
+        | LogFileAnalyzed of string
+        | ResourcesReloaded
+
+
+    module AdminCommand =
+
+        /// For the log. Never the password or the token; the file name is not a secret.
+        let toString cmd =
+            match cmd with
+            | AdminCommand.ValidatePassword _ -> "ValidatePassword"
+            | AdminCommand.ListLogFiles _ -> "ListLogFiles"
+            | AdminCommand.AnalyzeLogFile(_, f) -> $"AnalyzeLogFile %s{f}"
+            | AdminCommand.ReloadResources _ -> "ReloadResources"
+
+
+    // `IServerApi` gains, next to `processSigning`:
+    //
+    //     processAdmin: AdminCommand -> Async<Result<AdminResponse, string[]>>
+    //
+    // No `Request`/`Reply` envelope: an admin request has no OpenedToken to send and no
+    // record notice to receive.
+
+
+open Expecto
+open Expecto.Flip
+open Api654
+
+
+let tests =
+    testList
+        "AdminCommand.toString"
+        [
+            test "names the command, never the password" {
+                AdminCommand.ValidatePassword "hunter2-hunter2-1"
+                |> AdminCommand.toString
+                |> Expect.equal "name only" "ValidatePassword"
+            }
+
+            test "names the command, never the token" {
+                let token = "eyJwYXlsb2FkIn0=.c2lnbmF0dXJl"
+
+                AdminCommand.ListLogFiles token
+                |> AdminCommand.toString
+                |> Expect.equal "name only" "ListLogFiles"
+
+                AdminCommand.ReloadResources token
+                |> AdminCommand.toString
+                |> Expect.equal "name only" "ReloadResources"
+
+                let logged = AdminCommand.AnalyzeLogFile(token, "server.log") |> AdminCommand.toString
+                logged |> Expect.equal "name and file" "AnalyzeLogFile server.log"
+                logged.Contains token |> Expect.isFalse "no token"
+            }
+        ]
+
+
+runTestsWithCLIArgs [] [||] tests |> ignore

--- a/tests/Informedica.GenPRES.Server.Tests/ResourceErrorTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/ResourceErrorTests.fs
@@ -287,6 +287,30 @@ let processCmdGuardTests =
         ]
 
 
+/// The admin reload over a provider whose loader fails: reloadCache records the failed state
+/// and returns normally, so the port must ask the provider and answer its messages.
+let adminReloadTests =
+    testList
+        "admin reload over a failing provider"
+        [
+            test "a reload that leaves the provider unloaded answers its messages, not success" {
+                let provider =
+                    CachedResourceProvider((fun () -> Error [ errMsg "load failed" ]), None)
+
+                let env = ServerApi.Adapters.makeAppEnv provider
+
+                match env.admin.reloadResources () |> Async.RunSynchronously with
+                | Error msgs ->
+                    msgs
+                    |> Array.exists (fun m -> m.Contains "load failed")
+                    |> Expect.isTrue "the loader's message"
+                | Ok() -> failtest "expected Error"
+
+                env.requireLoaded () |> Expect.isSome "still not loaded"
+            }
+        ]
+
+
 [<Tests>]
 let tests =
     testList
@@ -297,4 +321,5 @@ let tests =
             cachedProviderErrorStateTests
             cachingBehaviorTests
             processCmdGuardTests
+            adminReloadTests
         ]

--- a/tests/Informedica.GenPRES.Server.Tests/Scripts/load.fsx
+++ b/tests/Informedica.GenPRES.Server.Tests/Scripts/load.fsx
@@ -20,6 +20,7 @@
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.Session.fs"
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.StubAdapters.fs"
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.Adapters.fs"
+#load "../../../src/Informedica.GenPRES.Server/ServerApi.AdminCommand.fs"
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.Command.fs"
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.LaunchCommand.fs"
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.SessionCommand.fs"

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -76,6 +76,17 @@ module StubAdapters =
         }
 
 
+    /// An admin port without a secret: every password and every token is refused.
+    let adminNone: AdminPort =
+        {
+            secret = fun () -> None
+            now = fun () -> DateTimeOffset.UtcNow
+            listLogFiles = fun () -> async { return Ok [||] }
+            analyzeLogFile = fun _ -> async { return Ok "" }
+            reloadResources = fun () -> async { return Ok() }
+        }
+
+
     let makeEnv
         (formulary: FormularyPort)
         (orderContext: OrderContextPort)
@@ -93,11 +104,7 @@ module StubAdapters =
                     checkInteractions = fun _ -> async { return Ok [] }
                     getDrugNames = fun () -> async { return Ok [] }
                 }
-            logAnalyzer =
-                {
-                    listLogFiles = fun () -> async { return Ok [||] }
-                    analyzeLogFile = fun _ -> async { return Ok "" }
-                }
+            admin = adminNone
             requireLoaded = fun () -> None
             session = sessionNone
         }
@@ -126,11 +133,7 @@ module StubAdapters =
                     checkInteractions = fun _ -> async { return Error [| "not loaded" |] }
                     getDrugNames = fun () -> async { return Error [| "not loaded" |] }
                 }
-            logAnalyzer =
-                {
-                    listLogFiles = fun () -> async { return Ok [||] }
-                    analyzeLogFile = fun _ -> async { return Ok "" }
-                }
+            admin = adminNone
             requireLoaded = fun () -> Some msgs
             session = sessionNone
         }
@@ -4656,6 +4659,232 @@ module SessionStubTests =
             ]
 
 
+/// `processAdmin`: the password buys a token, the token opens the log and the reload; never
+/// behind `requireLoaded`.
+module AdminTests =
+
+    open Shared.Api
+
+    let secret = Some "a-sixteen-char-secret!"
+    let t0 = DateTimeOffset(2026, 9, 12, 12, 0, 0, TimeSpan.Zero)
+
+    /// An admin port over a fixed secret and clock that counts its reloads.
+    let adminPort (secret: string option) (now: DateTimeOffset) =
+        let reloads = ref 0
+
+        reloads,
+        {
+            secret = fun () -> secret
+            now = fun () -> now
+            listLogFiles =
+                fun () ->
+                    async {
+                        return
+                            Ok
+                                [|
+                                    {
+                                        FileName = "server.log"
+                                        SizeBytes = 12L
+                                        LastModifiedAt = "2026-09-12"
+                                    }
+                                |]
+                    }
+            analyzeLogFile = fun name -> async { return Ok $"report of %s{name}" }
+            reloadResources =
+                fun () ->
+                    async {
+                        reloads.Value <- reloads.Value + 1
+                        return Ok()
+                    }
+        }
+
+
+    let envWith admin =
+        { makeEnv
+              (formularyAlwaysOk Formulary.empty)
+              (orderContextAlwaysOk emptyCtx)
+              (orderPlanAlwaysOk emptyPlan)
+              (nutritionPlanAlwaysOk emptyNutritionPlan) with
+            admin = admin
+        }
+
+
+    let run env cmd =
+        AdminCommand.processCmd env cmd |> Async.RunSynchronously
+
+
+    let tokenOf (env: AppEnv) =
+        match run env (AdminCommand.ValidatePassword (env.admin.secret ()).Value) with
+        | Ok(AdminResponse.PasswordValidated(true, token)) -> token
+        | other -> failtest $"expected a token, got {other}"
+
+
+    /// The same payload under a different signature.
+    let forge (token: string) =
+        match token.Split '.' with
+        | [| payload; signature |] ->
+            let bytes = Convert.FromBase64String signature
+            bytes[0] <- bytes[0] ^^^ 1uy
+            $"%s{payload}.%s{Convert.ToBase64String bytes}"
+        | _ -> failtest "not a token"
+
+
+    let tests =
+        testList
+            "processAdmin"
+            [
+                test "the server's password buys a token that verifies" {
+                    let _, admin = adminPort secret t0
+                    let token = tokenOf (envWith admin)
+                    token |> Expect.isNotEmpty "a token"
+                    AdminCommand.validateToken secret t0 token |> Expect.isTrue "verifies"
+                }
+
+                test "a wrong password: not valid, no token" {
+                    let _, admin = adminPort secret t0
+
+                    run (envWith admin) (AdminCommand.ValidatePassword "wrong")
+                    |> Expect.equal "refused" (Ok(AdminResponse.PasswordValidated(false, "")))
+                }
+
+                test "no password on the server: nothing is valid, not even an empty one" {
+                    for none in [ None; Some ""; Some "   " ] do
+                        let _, admin = adminPort none t0
+
+                        run (envWith admin) (AdminCommand.ValidatePassword "")
+                        |> Expect.equal "refused" (Ok(AdminResponse.PasswordValidated(false, "")))
+
+                        AdminCommand.generateToken none t0 |> Expect.equal "no token" ""
+                        AdminCommand.validateToken none t0 "" |> Expect.isFalse "empty never verifies"
+                }
+
+                test "a valid token lists, analyzes and reloads" {
+                    let reloads, admin = adminPort secret t0
+                    let env = envWith admin
+                    let token = tokenOf env
+
+                    match run env (AdminCommand.ListLogFiles token) with
+                    | Ok(AdminResponse.LogFilesListed files) -> files.Length |> Expect.equal "one file" 1
+                    | other -> failtest $"expected the files, got {other}"
+
+                    run env (AdminCommand.AnalyzeLogFile(token, "server.log"))
+                    |> Expect.equal "the report" (Ok(AdminResponse.LogFileAnalyzed "report of server.log"))
+
+                    run env (AdminCommand.ReloadResources token)
+                    |> Expect.equal "reloaded" (Ok AdminResponse.ResourcesReloaded)
+
+                    reloads.Value |> Expect.equal "the port reloaded once" 1
+                }
+
+                test "a forged, an expired, a malformed and an empty token are refused, and nothing reloads" {
+                    let reloads, admin = adminPort secret t0
+                    let env = envWith admin
+                    let token = tokenOf env
+                    let later = t0.Add(AdminCommand.tokenLifetime).AddSeconds 1.0
+                    let _, expiredAdmin = adminPort secret later
+
+                    for env, token in
+                        [
+                            env, forge token
+                            envWith expiredAdmin, token
+                            env, "not.a.token"
+                            env, "abc"
+                            env, ""
+                        ] do
+                        run env (AdminCommand.ReloadResources token)
+                        |> Expect.equal "refused" (Error [| "Invalid token" |])
+
+                        run env (AdminCommand.ListLogFiles token)
+                        |> Expect.equal "refused" (Error [| "Invalid token" |])
+
+                        run env (AdminCommand.AnalyzeLogFile(token, "server.log"))
+                        |> Expect.equal "refused" (Error [| "Invalid token" |])
+
+                    reloads.Value |> Expect.equal "nothing reloaded" 0
+                }
+
+                test "a token lives an hour" {
+                    let _, admin = adminPort secret t0
+                    let token = tokenOf (envWith admin)
+
+                    AdminCommand.validateToken secret (t0.Add AdminCommand.tokenLifetime) token
+                    |> Expect.isTrue "at the hour"
+
+                    AdminCommand.validateToken secret (t0.Add(AdminCommand.tokenLifetime).AddSeconds 1.0) token
+                    |> Expect.isFalse "past it"
+                }
+
+                test "a token of another secret is refused" {
+                    let _, other = adminPort (Some "another-secret-of-16!") t0
+                    let _, admin = adminPort secret t0
+
+                    run (envWith admin) (AdminCommand.ReloadResources(tokenOf (envWith other)))
+                    |> Expect.equal "refused" (Error [| "Invalid token" |])
+                }
+
+                test "a failing reload answers the port's error" {
+                    let _, admin = adminPort secret t0
+                    let token = tokenOf (envWith admin)
+
+                    let failing =
+                        { admin with reloadResources = fun () -> async { return Error [| "sheet unreachable" |] } }
+
+                    run (envWith failing) (AdminCommand.ReloadResources token)
+                    |> Expect.equal "the error" (Error [| "sheet unreachable" |])
+                }
+
+                test "the reload is not behind requireLoaded: a failed load can be retried" {
+                    let reloads, admin = adminPort secret t0
+                    let notLoaded = { makeEnvNotLoaded [| "sheet unreachable" |] with admin = admin }
+                    let token = tokenOf notLoaded
+
+                    run notLoaded (AdminCommand.ReloadResources token)
+                    |> Expect.equal "reloaded" (Ok AdminResponse.ResourcesReloaded)
+
+                    reloads.Value |> Expect.equal "the port reloaded once" 1
+                }
+
+                test "the log line never names the password or the token" {
+                    let _, admin = adminPort secret t0
+                    let token = tokenOf (envWith admin)
+
+                    [
+                        AdminCommand.ValidatePassword secret.Value
+                        AdminCommand.ListLogFiles token
+                        AdminCommand.AnalyzeLogFile(token, "server.log")
+                        AdminCommand.ReloadResources token
+                    ]
+                    |> List.map AdminCommand.toString
+                    |> List.iter (fun line ->
+                        line.Contains secret.Value |> Expect.isFalse "no password"
+                        line.Contains token |> Expect.isFalse "no token"
+                    )
+                }
+
+                testAsync "through the api: the same answers, no cookie read" {
+                    let _, admin = adminPort secret t0
+                    let env = envWith admin
+                    let cookie, _ = SessionStubTests.memoryCookie None
+                    let stateCookie, _ = SessionStubTests.memoryStateCookie None
+
+                    let settings =
+                        {
+                            ServerSettings.Language = Shared.Localization.Dutch
+                            IsDemo = true
+                        }
+
+                    let api =
+                        CompositionRoot.compose settings env cookie stateCookie (SessionStubTests.noEnrolment ())
+
+                    match! api.processAdmin (AdminCommand.ValidatePassword secret.Value) with
+                    | Ok(AdminResponse.PasswordValidated(true, token)) ->
+                        let! reloaded = api.processAdmin (AdminCommand.ReloadResources token)
+                        reloaded |> Expect.equal "reloaded" (Ok AdminResponse.ResourcesReloaded)
+                    | other -> failtest $"expected a token, got {other}"
+                }
+            ]
+
+
 [<Tests>]
 let tests =
     testList
@@ -4665,4 +4894,5 @@ let tests =
             errorPropagationTests
             requireLoadedTests
             SessionStubTests.tests
+            AdminTests.tests
         ]


### PR DESCRIPTION
Step 2 of [plan 654](https://github.com/informedica/GenPRES/blob/master/docs/implementation-plans/654-api-per-use-case.md) (plan PR #655): the admin family on the server, script-first.

**In this PR (scripts, per the script-only policy)**

- `Shared/Scripts/Api.fsx`: `AdminCommand` (`ValidatePassword`, `ListLogFiles`, `AnalyzeLogFile`, `ReloadResources of token`), `AdminResponse`, `AdminCommand.toString` (never the password or the token), and the `IServerApi.processAdmin` signature. 2 tests.
- `Server/Scripts/Compute.fsx` (rewritten): `AdminPort` with the secret and the clock as values the DMZ passes in, the password and token functions over explicit values instead of the environment, `processCmd`, and the adapter and `compose` wiring as comments. 9 tests: right, wrong and absent password; a valid token lists, analyzes and reloads once; forged, expired, malformed and empty tokens refused with nothing reloaded; a one-hour life; a token of another secret; a failing reload; the log line.

**Migration (for the maintainer, `.claude/docs/654-pr1-migration.patch`, 10 files, +324/−133)**

`Shared/Api.fs` (the family after `SigningCommand.toString`, `processAdmin` on `IServerApi`, no envelope); `Ports.fs` (`AdminPort` replaces `LogAnalyzerPort`; `AppEnv.admin`); new `ServerApi.AdminCommand.fs` before `Command.fs` in the fsproj and both `Scripts/load.fsx`; `Command.fs` keeps the `LogAnalyzerCmd` arms on `AdminCommand`'s functions until PR 3 deletes them; `Adapters.fs` reads `GENPRES_PASSWORD` for the port and reloads through `GenForm.Lib.Api.reloadCache`; `CompositionRoot.fs` `processAdmin` with the session-style logging, no cookie read, not behind `requireLoaded`; `StubAdapterTests` gains `adminNone` and 11 `AdminTests`, one of them proving the reload works while `requireLoaded` reports not loaded. Verified in a worktree: build, 275 server tests (264 before), Fantomas, `CheckDependencyRule.fsx`, Fable compile. The client is untouched; it moves to `processAdmin` in PR 2.

Closes the raw-password-on-the-wire half of the security review's D4 once PR 3 removes `OrderContextCommand.ReloadResources`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q228qLAaCzuK9Bhq2pEBGc