### PR TITLE
feat(client): log in, read logs and reload through processAdmin (#654 PR 2)

### DIFF
--- a/src/Informedica.GenPRES.Client/App.fs
+++ b/src/Informedica.GenPRES.Client/App.fs
@@ -51,6 +51,8 @@ module private Elmish =
             AuthToken: string
             LogFiles: Deferred<LogFileInfo[]>
             LogAnalysisReport: Deferred<string>
+            // the resource reload from the settings page: InProgress while the server reloads
+            Reloading: Deferred<unit>
             // the launch Session; Anonymous is the state every URL patient runs in
             Session: Session
             // the signing phase of the open Session; Idle whenever no Session is open
@@ -118,16 +120,21 @@ module private Elmish =
         | LoadSettings of AsyncOperationStatus<Result<Api.ServerSettings, exn>>
 
         | Login of password: string
-        | LoadLoginResult of ApiResponse
+        | LoadLoginResult of AdminResult
         | Logout
 
         | ListLogFiles
-        | LoadLogFilesResult of ApiResponse
+        | LoadLogFilesResult of AdminResult
         | AnalyzeLogFile of string
-        | LoadLogAnalysisResult of ApiResponse
+        | LoadLogAnalysisResult of AdminResult
+        | ReloadResources
+        | LoadReloadResult of AdminResult
 
 
     and ApiResponse = AsyncOperationStatus<Result<Answer, string[]>>
+
+    /// An admin answer: no envelope, so no token it started from and no notice
+    and AdminResult = AsyncOperationStatus<Result<Api.AdminResponse, string[]>>
 
     /// A computing reply with the OpenedToken the request started from, so that what the reply
     /// tells about the Session (moved on, ended) lands only on the Session that asked: a request
@@ -200,6 +207,15 @@ module private Elmish =
         |> Cmd.fromAsync
 
 
+    /// An admin command over the token the login bought; never Session-bound.
+    let createAdminMsg msg cmd =
+        async {
+            let! result = serverApi.processAdmin cmd
+            return result |> Finished |> msg
+        }
+        |> Cmd.fromAsync
+
+
     let processResponse (state: State) (response: Api.Response) =
         match response with
         | Api.OrderContextResp(Api.OrderContextResult ctx) -> { state with OrderContext = Resolved ctx }, Cmd.none
@@ -235,7 +251,16 @@ module private Elmish =
             { newState with Interactions = Resolved interactions }, Cmd.none
         | Api.InteractionResp(Api.DrugNamesLoaded names) ->
             { state with InteractionDrugNames = Resolved names }, Cmd.none
-        | Api.LogAnalyzerResp(Api.PasswordValidated(isValid, token)) ->
+        // the admin family answers processAdmin; nothing arrives here any more
+        | Api.LogAnalyzerResp _ -> state, Cmd.none
+
+
+    /// An admin answer applied. A reload done reloads what the pages show: the order context
+    /// over the patient, which takes the formulary and the parenteralia with it, or those two
+    /// alone when there is no patient.
+    let applyAdmin (state: State) (response: Api.AdminResponse) =
+        match response with
+        | Api.AdminResponse.PasswordValidated(isValid, token) ->
             if isValid then
                 { state with
                     IsAuthenticated = true
@@ -251,9 +276,22 @@ module private Elmish =
                     SnackbarSeverity = "error"
                 },
                 Cmd.none
-        | Api.LogAnalyzerResp(Api.LogFilesListed files) -> { state with LogFiles = Resolved files }, Cmd.none
-        | Api.LogAnalyzerResp(Api.LogFileAnalyzed report) ->
-            { state with LogAnalysisReport = Resolved report }, Cmd.none
+        | Api.AdminResponse.LogFilesListed files -> { state with LogFiles = Resolved files }, Cmd.none
+        | Api.AdminResponse.LogFileAnalyzed report -> { state with LogAnalysisReport = Resolved report }, Cmd.none
+        | Api.AdminResponse.ResourcesReloaded ->
+            let refresh =
+                match state.Patient, state.OrderContext with
+                | Some _, Resolved ctx
+                | Some _, Recalculating ctx -> Cmd.ofMsg (OrderContextMsg(Api.UpdateOrderContext, ctx))
+                | Some _, _ -> Cmd.ofMsg (OrderContextMsg(Api.UpdateOrderContext, OrderContext.empty))
+                | None, _ ->
+                    Cmd.batch
+                        [
+                            Cmd.ofMsg (LoadFormulary Started)
+                            Cmd.ofMsg (LoadParenteralia Started)
+                        ]
+
+            { state with Reloading = Resolved() }, refresh
 
 
     /// The result, and what the Session is told with it: the record moved on or the Session
@@ -549,6 +587,7 @@ module private Elmish =
             AuthToken = ""
             LogFiles = HasNotStartedYet
             LogAnalysisReport = HasNotStartedYet
+            Reloading = HasNotStartedYet
             Session = Session.Anonymous
             Signing = Signing.Idle
             MovedOn = None
@@ -833,6 +872,15 @@ module private Elmish =
             },
             cmd
 
+        // a token the server no longer takes (expired, or a restart): the login is over
+        let tokenError err (state, cmd) =
+            let state, cmd = processError err (state, cmd)
+
+            if err |> Array.contains "Invalid token" then
+                state, Cmd.batch [ cmd; Cmd.ofMsg Logout ]
+            else
+                state, cmd
+
         let selectMedicationItem generic indication route doseType state =
             let nonEmpty s = if s = "" then None else Some s
 
@@ -905,12 +953,9 @@ module private Elmish =
             Logging.error "cannot load the server settings" err
             { state with Settings = HasNotStartedYet }, Cmd.none
 
-        | Login password ->
-            state,
-            Api.LogAnalyzerCmd(Api.ValidatePassword password)
-            |> createApiMsg (tokenOf state.Session) LoadLoginResult
+        | Login password -> state, Api.AdminCommand.ValidatePassword password |> createAdminMsg LoadLoginResult
 
-        | LoadLoginResult(Finished(Ok resp)) -> processOk resp
+        | LoadLoginResult(Finished(Ok resp)) -> applyAdmin state resp
 
         | LoadLoginResult(Finished(Error err)) ->
             ({ state with
@@ -928,34 +973,47 @@ module private Elmish =
                 AuthToken = ""
                 LogFiles = HasNotStartedYet
                 LogAnalysisReport = HasNotStartedYet
+                Reloading = HasNotStartedYet
                 Page = if state.Page = Settings then LifeSupport else state.Page
             },
             Cmd.none
 
         | ListLogFiles ->
             { state with LogFiles = InProgress },
-            Api.LogAnalyzerCmd(Api.ListLogFiles state.AuthToken)
-            |> createApiMsg (tokenOf state.Session) LoadLogFilesResult
+            Api.AdminCommand.ListLogFiles state.AuthToken
+            |> createAdminMsg LoadLogFilesResult
 
-        | LoadLogFilesResult(Finished(Ok resp)) -> processOk resp
+        | LoadLogFilesResult(Finished(Ok resp)) -> applyAdmin state resp
 
         | LoadLogFilesResult(Finished(Error err)) ->
-            ({ state with LogFiles = HasNotStartedYet }, Cmd.none) |> processError err
+            ({ state with LogFiles = HasNotStartedYet }, Cmd.none) |> tokenError err
 
         | LoadLogFilesResult Started -> state, Cmd.none
 
         | AnalyzeLogFile fileName ->
             { state with LogAnalysisReport = InProgress },
-            Api.LogAnalyzerCmd(Api.AnalyzeLogFile(state.AuthToken, fileName))
-            |> createApiMsg (tokenOf state.Session) LoadLogAnalysisResult
+            Api.AdminCommand.AnalyzeLogFile(state.AuthToken, fileName)
+            |> createAdminMsg LoadLogAnalysisResult
 
-        | LoadLogAnalysisResult(Finished(Ok resp)) -> processOk resp
+        | LoadLogAnalysisResult(Finished(Ok resp)) -> applyAdmin state resp
 
         | LoadLogAnalysisResult(Finished(Error err)) ->
             ({ state with LogAnalysisReport = HasNotStartedYet }, Cmd.none)
-            |> processError err
+            |> tokenError err
 
         | LoadLogAnalysisResult Started -> state, Cmd.none
+
+        | ReloadResources ->
+            { state with Reloading = InProgress },
+            Api.AdminCommand.ReloadResources state.AuthToken
+            |> createAdminMsg LoadReloadResult
+
+        | LoadReloadResult(Finished(Ok resp)) -> applyAdmin state resp
+
+        | LoadReloadResult(Finished(Error err)) ->
+            ({ state with Reloading = HasNotStartedYet }, Cmd.none) |> tokenError err
+
+        | LoadReloadResult Started -> state, Cmd.none
 
         | AcceptDisclaimer -> { state with ShowDisclaimer = false }, Cmd.none
 
@@ -1655,8 +1713,8 @@ type private ConcreteAppEnv
         member _.CheckInteractions drugs = CheckInteractions drugs |> dispatch
 
     interface AppEnv.IResources with
-        member _.ReloadResources pw =
-            OrderContextMsg(Api.ReloadResources pw, OrderContext.empty) |> dispatch
+        member _.Reload = state.Reloading
+        member _.ReloadResources() = ReloadResources |> dispatch
 
     interface AppEnv.ISession with
         member _.Session = state.Session

--- a/src/Informedica.GenPRES.Client/App.fs
+++ b/src/Informedica.GenPRES.Client/App.fs
@@ -51,8 +51,11 @@ module private Elmish =
             AuthToken: string
             LogFiles: Deferred<LogFileInfo[]>
             LogAnalysisReport: Deferred<string>
-            // the resource reload from the settings page: InProgress while the server reloads
+            // the resource reload from the settings page: InProgress from the request until the
+            // pages have refreshed over the reloaded resources
             Reloading: Deferred<unit>
+            // counts logins and logouts, so that a login answer of an earlier attempt is dropped
+            LoginAttempt: int
             // the launch Session; Anonymous is the state every URL patient runs in
             Session: Session
             // the signing phase of the open Session; Idle whenever no Session is open
@@ -120,15 +123,17 @@ module private Elmish =
         | LoadSettings of AsyncOperationStatus<Result<Api.ServerSettings, exn>>
 
         | Login of password: string
-        | LoadLoginResult of AdminResult
+        // the attempt the answer belongs to: an answer of an earlier attempt is dropped
+        | LoadLoginResult of attempt: int * AdminResult
         | Logout
 
+        // the token the request was made with: an answer to a token no longer held is dropped
         | ListLogFiles
-        | LoadLogFilesResult of AdminResult
+        | LoadLogFilesResult of token: string * AdminResult
         | AnalyzeLogFile of string
-        | LoadLogAnalysisResult of AdminResult
+        | LoadLogAnalysisResult of token: string * AdminResult
         | ReloadResources
-        | LoadReloadResult of AdminResult
+        | LoadReloadResult of token: string * AdminResult
 
 
     and ApiResponse = AsyncOperationStatus<Result<Answer, string[]>>
@@ -255,9 +260,17 @@ module private Elmish =
         | Api.LogAnalyzerResp _ -> state, Cmd.none
 
 
+    /// A reload settles when the refresh it started has answered: the order context over a
+    /// patient, else the formulary.
+    let settleReload (state: State) =
+        match state.Reloading with
+        | InProgress -> { state with Reloading = Resolved() }
+        | _ -> state
+
+
     /// An admin answer applied. A reload done reloads what the pages show: the order context
     /// over the patient, which takes the formulary and the parenteralia with it, or those two
-    /// alone when there is no patient.
+    /// alone when there is no patient; the reload stays pending until that refresh answered.
     let applyAdmin (state: State) (response: Api.AdminResponse) =
         match response with
         | Api.AdminResponse.PasswordValidated(isValid, token) ->
@@ -291,7 +304,7 @@ module private Elmish =
                             Cmd.ofMsg (LoadParenteralia Started)
                         ]
 
-            { state with Reloading = Resolved() }, refresh
+            state, refresh
 
 
     /// The result, and what the Session is told with it: the record moved on or the Session
@@ -588,6 +601,7 @@ module private Elmish =
             LogFiles = HasNotStartedYet
             LogAnalysisReport = HasNotStartedYet
             Reloading = HasNotStartedYet
+            LoginAttempt = 0
             Session = Session.Anonymous
             Signing = Signing.Idle
             MovedOn = None
@@ -953,11 +967,19 @@ module private Elmish =
             Logging.error "cannot load the server settings" err
             { state with Settings = HasNotStartedYet }, Cmd.none
 
-        | Login password -> state, Api.AdminCommand.ValidatePassword password |> createAdminMsg LoadLoginResult
+        | Login password ->
+            let attempt = state.LoginAttempt + 1
 
-        | LoadLoginResult(Finished(Ok resp)) -> applyAdmin state resp
+            { state with LoginAttempt = attempt },
+            Api.AdminCommand.ValidatePassword password
+            |> createAdminMsg (fun result -> LoadLoginResult(attempt, result))
 
-        | LoadLoginResult(Finished(Error err)) ->
+        // an answer of an earlier attempt: a login since logged out, or asked again
+        | LoadLoginResult(attempt, Finished _) when attempt <> state.LoginAttempt -> state, Cmd.none
+
+        | LoadLoginResult(_, Finished(Ok resp)) -> applyAdmin state resp
+
+        | LoadLoginResult(_, Finished(Error err)) ->
             ({ state with
                 IsAuthenticated = false
                 AuthToken = ""
@@ -965,12 +987,13 @@ module private Elmish =
              Cmd.none)
             |> processError err
 
-        | LoadLoginResult Started -> state, Cmd.none
+        | LoadLoginResult(_, Started) -> state, Cmd.none
 
         | Logout ->
             { state with
                 IsAuthenticated = false
                 AuthToken = ""
+                LoginAttempt = state.LoginAttempt + 1
                 LogFiles = HasNotStartedYet
                 LogAnalysisReport = HasNotStartedYet
                 Reloading = HasNotStartedYet
@@ -978,42 +1001,54 @@ module private Elmish =
             },
             Cmd.none
 
+        // an answer to a token no longer held (logged out, or logged in again since): dropped,
+        // so a late refusal cannot end the new login and a late answer cannot revive the old
+        | LoadLogFilesResult(token, Finished _)
+        | LoadLogAnalysisResult(token, Finished _)
+        | LoadReloadResult(token, Finished _) when token <> state.AuthToken -> state, Cmd.none
+
         | ListLogFiles ->
+            let token = state.AuthToken
+
             { state with LogFiles = InProgress },
-            Api.AdminCommand.ListLogFiles state.AuthToken
-            |> createAdminMsg LoadLogFilesResult
+            Api.AdminCommand.ListLogFiles token
+            |> createAdminMsg (fun result -> LoadLogFilesResult(token, result))
 
-        | LoadLogFilesResult(Finished(Ok resp)) -> applyAdmin state resp
+        | LoadLogFilesResult(_, Finished(Ok resp)) -> applyAdmin state resp
 
-        | LoadLogFilesResult(Finished(Error err)) ->
+        | LoadLogFilesResult(_, Finished(Error err)) ->
             ({ state with LogFiles = HasNotStartedYet }, Cmd.none) |> tokenError err
 
-        | LoadLogFilesResult Started -> state, Cmd.none
+        | LoadLogFilesResult(_, Started) -> state, Cmd.none
 
         | AnalyzeLogFile fileName ->
+            let token = state.AuthToken
+
             { state with LogAnalysisReport = InProgress },
-            Api.AdminCommand.AnalyzeLogFile(state.AuthToken, fileName)
-            |> createAdminMsg LoadLogAnalysisResult
+            Api.AdminCommand.AnalyzeLogFile(token, fileName)
+            |> createAdminMsg (fun result -> LoadLogAnalysisResult(token, result))
 
-        | LoadLogAnalysisResult(Finished(Ok resp)) -> applyAdmin state resp
+        | LoadLogAnalysisResult(_, Finished(Ok resp)) -> applyAdmin state resp
 
-        | LoadLogAnalysisResult(Finished(Error err)) ->
+        | LoadLogAnalysisResult(_, Finished(Error err)) ->
             ({ state with LogAnalysisReport = HasNotStartedYet }, Cmd.none)
             |> tokenError err
 
-        | LoadLogAnalysisResult Started -> state, Cmd.none
+        | LoadLogAnalysisResult(_, Started) -> state, Cmd.none
 
         | ReloadResources ->
+            let token = state.AuthToken
+
             { state with Reloading = InProgress },
-            Api.AdminCommand.ReloadResources state.AuthToken
-            |> createAdminMsg LoadReloadResult
+            Api.AdminCommand.ReloadResources token
+            |> createAdminMsg (fun result -> LoadReloadResult(token, result))
 
-        | LoadReloadResult(Finished(Ok resp)) -> applyAdmin state resp
+        | LoadReloadResult(_, Finished(Ok resp)) -> applyAdmin state resp
 
-        | LoadReloadResult(Finished(Error err)) ->
+        | LoadReloadResult(_, Finished(Error err)) ->
             ({ state with Reloading = HasNotStartedYet }, Cmd.none) |> tokenError err
 
-        | LoadReloadResult Started -> state, Cmd.none
+        | LoadReloadResult(_, Started) -> state, Cmd.none
 
         | AcceptDisclaimer -> { state with ShowDisclaimer = false }, Cmd.none
 
@@ -1414,9 +1449,10 @@ module private Elmish =
                     (cmd, { ctx with Patient = pat })
                     |> loadOrderContext (tokenOf state.Session) (fun resp -> LoadOrderContextResult(cmd, resp))
 
-        | LoadOrderContextResult(_, Finished(Ok msg)) -> msg |> processOk
+        | LoadOrderContextResult(_, Finished(Ok msg)) -> msg |> processApiMsg (settleReload state)
         | LoadOrderContextResult(_, Finished(Error err)) ->
             Logging.warning "order context error, resetting" err
+            let state = settleReload state
 
             let isNoRulesError = err |> Array.exists _.ToLower().Contains("geen doseerregels")
 
@@ -1538,9 +1574,13 @@ module private Elmish =
 
                 { state with Formulary = InProgress }, cmd
 
-        | LoadFormulary(Finished(Ok msg)) -> processOk msg
+        // without a patient the formulary is what a reload refreshes, so it settles the reload
+        | LoadFormulary(Finished(Ok msg)) ->
+            let state = if state.Patient.IsNone then settleReload state else state
+            processApiMsg state msg
 
         | LoadFormulary(Finished(Error err)) ->
+            let state = if state.Patient.IsNone then settleReload state else state
             ({ state with Formulary = HasNotStartedYet }, Cmd.none) |> processError err
 
         | UpdateFormulary form ->

--- a/src/Informedica.GenPRES.Client/AppEnv.fs
+++ b/src/Informedica.GenPRES.Client/AppEnv.fs
@@ -64,10 +64,12 @@ type IInteractions =
     abstract CheckInteractions: string list -> unit
 
 
-/// Resource reloading (admin/settings)
+/// Resource reloading (admin/settings): under the token the login bought, so no password here
 [<Interface>]
 type IResources =
-    abstract ReloadResources: string -> unit
+    // InProgress while the server reloads; Resolved once it answered
+    abstract Reload: Deferred<unit>
+    abstract ReloadResources: unit -> unit
 
 
 /// The launch Session: its phase, and the actions the UI offers on it

--- a/src/Informedica.GenPRES.Client/Views/Settings.fs
+++ b/src/Informedica.GenPRES.Client/Views/Settings.fs
@@ -4,7 +4,6 @@ namespace Views
 module Settings =
 
     open Fable.Core
-    open Fable.Core.JsInterop
     open Feliz
     open Shared
     open Shared.Types
@@ -21,8 +20,7 @@ module Settings =
 
     [<JSX.Component>]
     let View (props: {| appEnv: obj |}) =
-        let reloadResources = (AppEnv.asEnv<AppEnv.IResources> props.appEnv).ReloadResources
-        let orderContext = (AppEnv.asEnv<AppEnv.IOrderContext> props.appEnv).OrderContext
+        let resources = AppEnv.asEnv<AppEnv.IResources> props.appEnv
 
         let logAnalyzer = (AppEnv.asEnv<AppEnv.ILogAnalyzer> props.appEnv)
         let auth = (AppEnv.asEnv<AppEnv.IAuthentication> props.appEnv)
@@ -37,20 +35,13 @@ module Settings =
 
         let refreshIcon = Mui.Icons.RefreshIcon
 
-        let reloading, setReloading = React.useState false
-        let dialogOpen, setDialogOpen = React.useState false
-        let password, setPassword = React.useState ""
-        let passwordError, setPasswordError = React.useState false
-        let wasInProgress = React.useRef false
-
         // Log analyzer local state
         let reportDialogOpen, setReportDialogOpen = React.useState false
 
         let isLoading =
-            reloading
-            && match orderContext with
-               | Resolved _ -> false
-               | _ -> true
+            match resources.Reload with
+            | InProgress -> true
+            | _ -> false
 
         // Load log files on mount only when authenticated
         React.useEffect (
@@ -58,26 +49,6 @@ module Settings =
                 if auth.IsAuthenticated then
                     logAnalyzer.ListLogFiles()
             , [||]
-        )
-
-        React.useEffect (
-            fun () ->
-                if reloading then
-                    match orderContext with
-                    | InProgress
-                    | Recalculating _ -> wasInProgress.current <- true
-                    | Resolved _ ->
-                        wasInProgress.current <- false
-                        setReloading false
-                        setDialogOpen false
-                        setPassword ""
-                    | HasNotStartedYet when wasInProgress.current ->
-                        wasInProgress.current <- false
-                        setReloading false
-                        setDialogOpen true
-                        setPasswordError true
-                    | _ -> ()
-            , [| box reloading; box orderContext |]
         )
 
         // When analysis report resolves, open the report dialog
@@ -92,31 +63,8 @@ module Settings =
         let backdrop =
             ViewHelpers.backdropProgress isLoading (Terms.``Reload resources`` |> getTerm "Reloading resources...")
 
-        let handleOpen =
-            fun _ ->
-                setPassword ""
-                setPasswordError false
-                setDialogOpen true
-
-        let handleClose =
-            fun _ ->
-                setDialogOpen false
-                setPassword ""
-                setPasswordError false
-
-        let handleConfirm =
-            fun _ ->
-                setReloading true
-                setPasswordError false
-                reloadResources password
-
-        let handleKeyDown (e: Browser.Types.KeyboardEvent) =
-            if e.key = "Enter" then
-                handleConfirm ()
-
-        let handlePasswordChange (e: Browser.Types.Event) =
-            setPassword (e.target?value: string)
-            setPasswordError false
+        // the page is only reached signed in, so the token stands in for the password
+        let handleReload = fun _ -> resources.ReloadResources()
 
         let handleRefreshLogs = fun _ -> logAnalyzer.ListLogFiles()
 
@@ -255,7 +203,6 @@ module Settings =
         import DialogTitle from '@mui/material/DialogTitle';
         import DialogContent from '@mui/material/DialogContent';
         import DialogActions from '@mui/material/DialogActions';
-        import TextField from '@mui/material/TextField';
         import Table from '@mui/material/Table';
         import TableBody from '@mui/material/TableBody';
         import TableCell from '@mui/material/TableCell';
@@ -275,45 +222,12 @@ module Settings =
                     variant="contained"
                     disabled={isLoading}
                     startIcon={refreshIcon}
-                    onClick={handleOpen}>
+                    onClick={handleReload}>
                     {Terms.``Reload resources`` |> getTerm "Reload resources"}
                 </Button>
             </Box>
             {backdrop}
             {analysisBackdrop}
-            <Dialog open={dialogOpen} onClose={handleClose}>
-                <DialogTitle>
-                    {Terms.``Enter password`` |> getTerm "Enter password"}
-                </DialogTitle>
-                <DialogContent>
-                    <TextField
-                        id="settings-password"
-                        name="password"
-                        autoFocus={true}
-                        margin="dense"
-                        label={Terms.Password |> getTerm "Password"}
-                        type="password"
-                        fullWidth={true}
-                        variant="outlined"
-                        value={password}
-                        onChange={handlePasswordChange}
-                        error={passwordError}
-                        helperText={if passwordError then
-                                        Terms.``Invalid password`` |> getTerm "Invalid password"
-                                    else
-                                        ""}
-                        onKeyDown={handleKeyDown}
-                    />
-                </DialogContent>
-                <DialogActions>
-                    <Button onClick={handleClose}>
-                        {Terms.Cancel |> getTerm "Cancel"}
-                    </Button>
-                    <Button onClick={handleConfirm} variant="contained">
-                        {Terms.Confirm |> getTerm "Confirm"}
-                    </Button>
-                </DialogActions>
-            </Dialog>
             <Box sx={logHeaderSx}>
                 <Typography variant="subtitle1">{"Log Files"}</Typography>
                 <IconButton size="small" onClick={handleRefreshLogs} title="Refresh">


### PR DESCRIPTION
Step 3 of [plan 654](https://github.com/informedica/GenPRES/blob/master/docs/implementation-plans/654-api-per-use-case.md). Stacked on #656 (the branch includes its two commits; only the last commit is this PR).

Client only, direct edits:

- `AppEnv.IResources`: `Reload: Deferred<unit>` and `ReloadResources: unit -> unit`; no password on the interface.
- `App.fs`: `AdminResult` and `createAdminMsg` (no envelope, no notice, never `processApiMsg`); `applyAdmin` for the four answers; `ResourcesReloaded` refreshes the order context over the patient, which takes the formulary and the parenteralia with it, or those two alone without a patient; `State.Reloading`; an `Invalid token` error also logs out. `LogAnalyzerResp` becomes a no-op arm until PR 3 deletes the family.
- `Views/Settings.fs`: the password dialog goes; the reload button calls `ReloadResources()` and the backdrop follows `resources.Reload`.

Verified: Fable compile green, generated JSX inspected, Fantomas. Over the wire against `GENPRES_PROD=0 dotnet run` through the Vite proxy: a wrong password answers `PasswordValidated(false, "")`, the right one a token, `ReloadResources token` answers `ResourcesReloaded`, a forged token `Invalid token`, `ListLogFiles token` the files. Not clicked through in a browser yet: the settings page reload and the log list are worth one manual pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q228qLAaCzuK9Bhq2pEBGc