### PR TITLE
refactor(api): generic envelope and Compute.bound, no visible change (#654 PR 4)

### DIFF
--- a/src/Informedica.GenPRES.Server/Informedica.GenPRES.Server.fsproj
+++ b/src/Informedica.GenPRES.Server/Informedica.GenPRES.Server.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="ServerApi.Session.fs" />
     <Compile Include="ServerApi.StubAdapters.fs" />
     <Compile Include="ServerApi.Adapters.fs" />
+    <Compile Include="ServerApi.Compute.fs" />
     <Compile Include="ServerApi.AdminCommand.fs" />
     <Compile Include="ServerApi.Command.fs" />
     <Compile Include="ServerApi.LaunchCommand.fs" />

--- a/src/Informedica.GenPRES.Server/Scripts/Compute.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/Compute.fsx
@@ -1,20 +1,25 @@
-// Deleting the old admin paths (plan 654, step 4): the LogAnalyzerCmd family and
-// OrderContextCommand.ReloadResources leave the shared contract now that the client asks
-// `processAdmin`, and with them the arms that let four commands bypass `requireLoaded`. What
-// remains of `Command.processCmd` is one total match: `GetDrugNames` runs open, every other
-// command runs gated, and there is no arm the compiler demands but nothing reaches.
+// The computing wrapper (plan 654, step 5): what `compose` does around `processCommand` today,
+// as one function every computing member goes through. `bound` logs the command, marks the
+// Session the cookie names seen and takes what it is told (the record moved on, the Session
+// ended), applies the gate (the formulary loaded, or not needed), runs the handler and answers
+// the reply with the notice; an exception is an `Error` with its message. `logged` wraps the
+// members that are not computing (launch, session, signing, admin) with the same two log
+// lines. The gate moves out of `Command.processCmd`, which becomes a plain dispatcher, into a
+// `Command.gate` that `compose` passes: the drug names open, everything else behind the
+// formulary. No visible change.
 //
 // Script-first draft (script-only policy) of:
-//   - `Command.processCmd` as one total match with a `gated` helper → `ServerApi.Command.fs`;
-//   - the deletions are stated, not drafted (a script cannot remove cases): `LogAnalyzerCmd`,
-//     `LogAnalyzerCommand`, `LogAnalyzerResp`, `LogAnalyzerResponse`,
-//     `OrderContextCommand.ReloadResources` and their `toString` arms → `Shared/Api.fs`; the
-//     `ReloadResources` arm and the password guard of `OrderContextService.evaluate` →
-//     `Services.fs`; the dead `ReloadResources` arms of the client → `App.fs`.
+//   - `Gate`, `Compute.bound`, `Compute.logged` → new `ServerApi.Compute.fs`, compiled after
+//     `Adapters.fs`, before `AdminCommand.fs` (fsproj and both `Scripts/load.fsx`);
+//   - `Command.gate` and `processCmd` without its own gating → `ServerApi.Command.fs`;
+//   - `compose` building `processCommand` with `bound` and the four others with `logged`
+//     → `CompositionRoot.fs`;
+//   - `Request<'cmd>` / `Reply<'resp>` with abbreviations → `Shared/Api.fs` (drafted and
+//     round-tripped through Fable.Remoting.Json in `Shared/Scripts/Api.fsx`).
 //
-// The shared DU still has the doomed cases while this script runs, so the draft answers them
-// with an error that the migration removes together with the cases. Run:
-// `dotnet fsi Compute.fsx` from this directory (build first).
+// The shared envelope is not generic while this script runs, so `bound` is drafted over the
+// abbreviated shape with an unbox at each end; the migration makes it generic and the body
+// does not change. Run: `dotnet fsi Compute.fsx` from this directory (build first).
 
 #I __SOURCE_DIRECTORY__
 #r "nuget: Expecto, 10.2.3"
@@ -24,118 +29,106 @@
 open Shared.Types
 open Shared.Api
 open ServerApi
+open Informedica.Utils.Lib.ConsoleWriter.NewLineNoTime
 
 
 // ---------------------------------------------------------------------------------------------
-// The dispatcher (→ ServerApi.Command.fs)
+// The wrapper (→ ServerApi.Compute.fs)
+// ---------------------------------------------------------------------------------------------
+
+/// Whether a command needs the formulary loaded.
+[<RequireQualifiedAccess>]
+type Gate =
+    | RequiresLoaded
+    | Open
+
+
+module Compute =
+
+    /// Every computing member: the Session the cookie names is marked seen and told whether the
+    /// record moved on or the Session ended, before the command is computed; without a cookie
+    /// the request computes as it always did. The gate refuses a command that needs the
+    /// formulary while it is not loaded, with the provider's messages. An exception is an
+    /// Error with its message. The token is never logged.
+    let bound
+        (env: AppEnv)
+        (cookie: SessionCookie)
+        (name: 'cmd -> string)
+        (gate: 'cmd -> Gate)
+        (handler: 'cmd -> Async<Result<'resp, string[]>>)
+        (request: Request)
+        : Async<Result<Reply, string[]>>
+        =
+        // the migration makes the envelope generic: `request: Request<'cmd>`, `Reply<'resp>`
+        let cmd: 'cmd = unbox request.Command
+
+        async {
+            try
+                writeInfoMessage $"Processing command: {name cmd}"
+
+                let! notice =
+                    match cookie.read () with
+                    | None -> async { return None }
+                    | Some id -> env.session.seen id request.Opened
+
+                let! result =
+                    match gate cmd, env.requireLoaded () with
+                    | Gate.RequiresLoaded, Some msgs -> async { return Error msgs }
+                    | _ -> handler cmd
+
+                let told =
+                    match notice with
+                    | Some(RecordNotice.NewerVersion _) -> ", the record moved on"
+                    | Some(RecordNotice.Ended _) -> ", the Session ended"
+                    | None -> ""
+
+                writeInfoMessage $"Finished processing command: {name cmd}{told}"
+
+                return
+                    result
+                    |> Result.map (fun response ->
+                        {
+                            Response = unbox<Response> response
+                            Notice = notice
+                        }
+                    )
+            with ex ->
+                writeErrorMessage $"Error processing command: {name cmd}\n{ex}"
+                return Error [| ex.Message |]
+        }
+
+
+    /// A member that is not computing: the same two log lines around it, nothing else.
+    let logged (what: string) (name: 'cmd -> string) (run: 'cmd -> Async<'resp>) (cmd: 'cmd) =
+        async {
+            writeInfoMessage $"Processing {what}: {name cmd}"
+            let! response = run cmd
+            writeInfoMessage $"Finished processing {what}: {name cmd}"
+            return response
+        }
+
+
+// ---------------------------------------------------------------------------------------------
+// The gate (→ ServerApi.Command.fs; processCmd loses its `gated` and becomes a plain dispatcher)
 // ---------------------------------------------------------------------------------------------
 
 module Command =
 
-    /// A command that needs the formulary: refused with the provider's messages while it is not
-    /// loaded, else run.
-    let private gated (env: AppEnv) (run: unit -> Async<Result<Response, string[]>>) =
-        match env.requireLoaded () with
-        | Some msgs -> async { return Error msgs }
-        | None -> run ()
+    /// The drug names come from the interaction source, not the formulary; everything else
+    /// needs the formulary loaded.
+    let gate =
+        function
+        | InteractionCmd GetDrugNames -> Gate.Open
+        | _ -> Gate.RequiresLoaded
 
 
-    let processCmd (env: AppEnv) cmd =
-        let gated = gated env
-
-        match cmd with
-        // the drug names come from the interaction source, not the formulary
-        | InteractionCmd GetDrugNames ->
-            async {
-                let! result = env.interaction.getDrugNames ()
-                return result |> Result.map (List.toArray >> DrugNamesLoaded >> InteractionResp)
-            }
-        | InteractionCmd(CheckInteractions drugs) ->
-            gated (fun () ->
-                async {
-                    let! result = env.interaction.checkInteractions drugs
-                    return result |> Result.map (List.toArray >> InteractionsChecked >> InteractionResp)
-                }
-            )
-        | OrderContextCmd(ctxCmd, ctx) ->
-            gated (fun () ->
-                async {
-                    let! result = env.orderContext.evaluate ctxCmd ctx
-                    return result |> Result.map (OrderContextResult >> OrderContextResp)
-                }
-            )
-        | OrderPlanCmd(UpdateOrderPlan(tp, cmdOpt)) ->
-            gated (fun () ->
-                async {
-                    let! result = env.orderPlan.updateOrderPlan tp cmdOpt
-                    return result |> Result.map (OrderPlanUpdated >> OrderPlanResp)
-                }
-            )
-        | OrderPlanCmd(FilterOrderPlan tp) ->
-            gated (fun () ->
-                async {
-                    let! result = env.orderPlan.filterOrderPlan tp
-                    return result |> Result.map (OrderPlanFiltered >> OrderPlanResp)
-                }
-            )
-        | FormularyCmd form ->
-            gated (fun () ->
-                async {
-                    let! result = env.formulary.getFormulary form
-                    return result |> Result.map FormularyResp
-                }
-            )
-        | ParenteraliaCmd par ->
-            gated (fun () ->
-                async {
-                    let! result = env.formulary.getParenteralia par
-                    return result |> Result.map ParenteraliaResp
-                }
-            )
-        | NutritionPlanCmd(InitNutritionPlan patient) ->
-            gated (fun () ->
-                async {
-                    let! result = env.nutritionPlan.initNutritionPlan patient
-                    return result |> Result.map (NutritionPlanInitialised >> NutritionPlanResp)
-                }
-            )
-        | NutritionPlanCmd(UpdateNutritionOrderContext(plan, label, ctx)) ->
-            gated (fun () ->
-                async {
-                    let! result = env.nutritionPlan.updateNutritionOrderContext (plan, label, ctx)
-                    return result |> Result.map (NutritionPlanUpdated >> NutritionPlanResp)
-                }
-            )
-        | NutritionPlanCmd(SelectNutritionOrderScenario(plan, label, ctx)) ->
-            gated (fun () ->
-                async {
-                    let! result = env.nutritionPlan.selectNutritionOrderScenario (plan, label, ctx)
-                    return result |> Result.map (NutritionPlanUpdated >> NutritionPlanResp)
-                }
-            )
-        | NutritionPlanCmd(NavigateNutritionOrderContext(plan, label, ctxCmd, ctx)) ->
-            gated (fun () ->
-                async {
-                    let! result = env.nutritionPlan.navigateNutritionOrderContext (plan, label, ctxCmd, ctx)
-                    return result |> Result.map (NutritionPlanUpdated >> NutritionPlanResp)
-                }
-            )
-        | NutritionPlanCmd(AddNutritionContext(plan, category)) ->
-            gated (fun () ->
-                async {
-                    let! result = env.nutritionPlan.addNutritionContext (plan, category)
-                    return result |> Result.map (NutritionPlanUpdated >> NutritionPlanResp)
-                }
-            )
-        | NutritionPlanCmd(RemoveNutritionContext(plan, id)) ->
-            gated (fun () ->
-                async {
-                    let! result = env.nutritionPlan.removeNutritionContext (plan, id)
-                    return result |> Result.map (NutritionPlanUpdated >> NutritionPlanResp)
-                }
-            )
-        // gone with the migration, together with these cases
-        | LogAnalyzerCmd _ -> async { return Error [| "LogAnalyzerCmd answers processAdmin" |] }
+// and in `compose` (→ CompositionRoot.fs):
+//
+//     processCommand = Compute.bound env cookie Command.toString Command.gate (Command.processCmd env)
+//     processLaunch = Compute.logged "launch" LaunchCommand.toString (LaunchCommand.processCmd env cookie stateCookie)
+//     processSession = Compute.logged "session" SessionCommand.toString (SessionCommand.processCmd env cookie enrolment)
+//     processSigning = Compute.logged "signing" SigningCommand.toString (SigningCommand.processCmd env cookie)
+//     processAdmin = Compute.logged "admin" AdminCommand.toString (AdminCommand.processCmd env)
 
 
 // ---------------------------------------------------------------------------------------------
@@ -147,62 +140,125 @@ open Expecto.Flip
 open Informedica.GenForm.Lib
 
 
-/// An env over a provider whose load failed, with the ports stubbed.
-let notLoaded =
-    Adapters.makeAppEnv (Resources.CachedResourceProvider((fun () -> Error [ Informedica.GenForm.Lib.Types.ErrorMsg("load failed", None) ]), None))
+let cookieOf (id: string option) : SessionCookie =
+    {
+        read = fun () -> id
+        write = ignore
+        delete = ignore
+    }
 
 
-let loaded =
-    { notLoaded with
-        requireLoaded = fun () -> None
+/// An env over a provider whose load failed, the formulary stubbed, the Session's answer given.
+let envWith (loaded: bool) (told: RecordNotice option) =
+    let env =
+        Adapters.makeAppEnv (
+            Resources.CachedResourceProvider(
+                (fun () -> Error [ Informedica.GenForm.Lib.Types.ErrorMsg("load failed", None) ]),
+                None
+            )
+        )
+
+    { env with
+        requireLoaded = if loaded then (fun () -> None) else env.requireLoaded
         formulary =
             {
                 getFormulary = fun f -> async { return Ok { f with Markdown = "stubbed" } }
                 getParenteralia = fun _ -> async { return Ok Shared.Models.Parenteralia.empty }
             }
-        interaction =
-            {
-                checkInteractions = fun _ -> async { return Ok [] }
-                getDrugNames = fun () -> async { return Ok [ "paracetamol" ] }
+        session =
+            { env.session with
+                seen = fun _ _ -> async { return told }
             }
     }
 
 
-let run env cmd =
-    Command.processCmd env cmd |> Async.RunSynchronously
+let request cmd : Request = { Opened = None; Command = cmd }
+
+
+/// A handler that is not a dispatcher: the formulary only.
+let formularyOnly (env: AppEnv) cmd =
+    match cmd with
+    | FormularyCmd f ->
+        async {
+            let! result = env.formulary.getFormulary f
+            return result |> Result.map FormularyResp
+        }
+    | other -> failwithf "not under test: %A" other
+
+
+let run env cookie gate handler cmd =
+    Compute.bound env cookie Command.toString gate handler (request cmd)
+    |> Async.RunSynchronously
+
+
+let formulary = FormularyCmd Shared.Models.Formulary.empty
 
 
 let tests =
     testList
-        "Command.processCmd, total"
+        "Compute.bound"
         [
-            test "a loaded provider: the formulary answers" {
-                match run loaded (FormularyCmd Shared.Models.Formulary.empty) with
-                | Ok(FormularyResp f) -> f.Markdown |> Expect.equal "stubbed" "stubbed"
-                | other -> failtest $"expected FormularyResp, got {other}"
+            test "without a cookie: computed, nothing told" {
+                let env = envWith true (Some(RecordNotice.Ended SessionEnding.SupersededByLaunch))
+
+                match run env (cookieOf None) Command.gate (formularyOnly env) formulary with
+                | Ok reply ->
+                    reply.Notice |> Expect.isNone "nothing told without a cookie"
+
+                    match reply.Response with
+                    | FormularyResp f -> f.Markdown |> Expect.equal "computed" "stubbed"
+                    | other -> failtest $"expected FormularyResp, got {other}"
+                | Error errs -> failtest $"expected Ok, got {errs}"
             }
 
-            test "a provider that did not load: the formulary is refused with its messages" {
-                match run notLoaded (FormularyCmd Shared.Models.Formulary.empty) with
+            test "with a cookie: what the Session is told rides on the reply, still computed" {
+                let env = envWith true (Some(RecordNotice.Ended SessionEnding.SupersededByLaunch))
+
+                match run env (cookieOf (Some "s-1")) Command.gate (formularyOnly env) formulary with
+                | Ok reply ->
+                    reply.Notice
+                    |> Expect.equal "the ending" (Some(RecordNotice.Ended SessionEnding.SupersededByLaunch))
+
+                    match reply.Response with
+                    | FormularyResp f -> f.Markdown |> Expect.equal "still computed" "stubbed"
+                    | other -> failtest $"expected FormularyResp, got {other}"
+                | Error errs -> failtest $"expected Ok, got {errs}"
+            }
+
+            test "a command that needs the formulary is refused while it is not loaded" {
+                let env = envWith false None
+
+                match run env (cookieOf None) Command.gate (formularyOnly env) formulary with
                 | Error msgs -> msgs |> Array.exists (fun m -> m.Contains "load failed") |> Expect.isTrue "the messages"
                 | Ok _ -> failtest "expected Error"
             }
 
-            test "the drug names are not behind the formulary" {
-                let env =
-                    { notLoaded with
-                        interaction =
-                            {
-                                checkInteractions = fun _ -> async { return Ok [] }
-                                getDrugNames = fun () -> async { return Ok [ "paracetamol" ] }
-                            }
-                    }
+            test "an open command runs while the formulary is not loaded" {
+                let env = envWith false None
+                let names _ = async { return Ok(InteractionResp(DrugNamesLoaded [| "paracetamol" |])) }
 
-                match run env (InteractionCmd GetDrugNames) with
-                | Ok(InteractionResp(DrugNamesLoaded names)) -> names |> Expect.equal "the names" [| "paracetamol" |]
-                | other -> failtest $"expected the names, got {other}"
+                match run env (cookieOf None) Command.gate names (InteractionCmd GetDrugNames) with
+                | Ok reply ->
+                    reply.Response
+                    |> Expect.equal "the names" (InteractionResp(DrugNamesLoaded [| "paracetamol" |]))
+                | Error errs -> failtest $"expected Ok, got {errs}"
 
-                run env (InteractionCmd(CheckInteractions [ "a"; "b" ])) |> Result.isError |> Expect.isTrue "checking is"
+                Command.gate (InteractionCmd GetDrugNames) |> Expect.equal "open" Gate.Open
+                Command.gate (InteractionCmd(CheckInteractions [])) |> Expect.equal "gated" Gate.RequiresLoaded
+            }
+
+            test "a throwing handler answers an Error with its message" {
+                let env = envWith true None
+                let throwing _ = async { return invalidOp "boom" }
+
+                run env (cookieOf None) Command.gate throwing formulary
+                |> Expect.equal "the message" (Error [| "boom" |])
+            }
+
+            test "logged: the answer passes through" {
+                Compute.logged "admin" AdminCommand.toString (fun _ -> async { return 42 }) (AdminCommand.ValidatePassword "x")
+                |> Async.RunSynchronously
+                |> Expect.equal "through" 42
             }
         ]
 

--- a/src/Informedica.GenPRES.Server/Scripts/Compute.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/Compute.fsx
@@ -71,10 +71,14 @@ module Compute =
                     | None -> async { return None }
                     | Some id -> env.session.seen id request.Opened
 
+                // an open command never asks the provider: asking may load
                 let! result =
-                    match gate cmd, env.requireLoaded () with
-                    | Gate.RequiresLoaded, Some msgs -> async { return Error msgs }
-                    | _ -> handler cmd
+                    match gate cmd with
+                    | Gate.Open -> handler cmd
+                    | Gate.RequiresLoaded ->
+                        match env.requireLoaded () with
+                        | Some msgs -> async { return Error msgs }
+                        | None -> handler cmd
 
                 let told =
                     match notice with

--- a/src/Informedica.GenPRES.Server/Scripts/load.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/load.fsx
@@ -23,6 +23,7 @@
 #load "../ServerApi.Session.fs"
 #load "../ServerApi.StubAdapters.fs"
 #load "../ServerApi.Adapters.fs"
+#load "../ServerApi.Compute.fs"
 #load "../ServerApi.AdminCommand.fs"
 #load "../ServerApi.Command.fs"
 #load "../ServerApi.LaunchCommand.fs"

--- a/src/Informedica.GenPRES.Server/ServerApi.Command.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Command.fs
@@ -6,105 +6,80 @@ module Command =
     open Shared.Api
 
 
-    /// A command that needs the formulary: refused with the provider's messages while it is not
-    /// loaded, else run.
-    let private gated (env: AppEnv) (run: unit -> Async<Result<Response, string[]>>) =
-        match env.requireLoaded () with
-        | Some msgs -> async { return Error msgs }
-        | None -> run ()
+    /// The drug names come from the interaction source, not the formulary; everything else
+    /// needs the formulary loaded. Applied by Compute.bound, not here.
+    let gate =
+        function
+        | InteractionCmd GetDrugNames -> Gate.Open
+        | _ -> Gate.RequiresLoaded
 
 
+    /// The dispatcher: each command to its port. Gating, logging and the Session notice are
+    /// Compute.bound's.
     let processCmd (env: AppEnv) cmd =
-        let gated = gated env
-
         match cmd with
-        // the drug names come from the interaction source, not the formulary
         | InteractionCmd GetDrugNames ->
             async {
                 let! result = env.interaction.getDrugNames ()
                 return result |> Result.map (List.toArray >> DrugNamesLoaded >> InteractionResp)
             }
         | InteractionCmd(CheckInteractions drugs) ->
-            gated (fun () ->
-                async {
-                    let! result = env.interaction.checkInteractions drugs
-                    return result |> Result.map (List.toArray >> InteractionsChecked >> InteractionResp)
-                }
-            )
+            async {
+                let! result = env.interaction.checkInteractions drugs
+                return result |> Result.map (List.toArray >> InteractionsChecked >> InteractionResp)
+            }
         | OrderContextCmd(ctxCmd, ctx) ->
-            gated (fun () ->
-                async {
-                    let! result = env.orderContext.evaluate ctxCmd ctx
-                    return result |> Result.map (OrderContextResult >> OrderContextResp)
-                }
-            )
+            async {
+                let! result = env.orderContext.evaluate ctxCmd ctx
+                return result |> Result.map (OrderContextResult >> OrderContextResp)
+            }
         | OrderPlanCmd(UpdateOrderPlan(tp, cmdOpt)) ->
-            gated (fun () ->
-                async {
-                    let! result = env.orderPlan.updateOrderPlan tp cmdOpt
-                    return result |> Result.map (OrderPlanUpdated >> OrderPlanResp)
-                }
-            )
+            async {
+                let! result = env.orderPlan.updateOrderPlan tp cmdOpt
+                return result |> Result.map (OrderPlanUpdated >> OrderPlanResp)
+            }
         | OrderPlanCmd(FilterOrderPlan tp) ->
-            gated (fun () ->
-                async {
-                    let! result = env.orderPlan.filterOrderPlan tp
-                    return result |> Result.map (OrderPlanFiltered >> OrderPlanResp)
-                }
-            )
+            async {
+                let! result = env.orderPlan.filterOrderPlan tp
+                return result |> Result.map (OrderPlanFiltered >> OrderPlanResp)
+            }
         | FormularyCmd form ->
-            gated (fun () ->
-                async {
-                    let! result = env.formulary.getFormulary form
-                    return result |> Result.map FormularyResp
-                }
-            )
+            async {
+                let! result = env.formulary.getFormulary form
+                return result |> Result.map FormularyResp
+            }
         | ParenteraliaCmd par ->
-            gated (fun () ->
-                async {
-                    let! result = env.formulary.getParenteralia par
-                    return result |> Result.map ParenteraliaResp
-                }
-            )
+            async {
+                let! result = env.formulary.getParenteralia par
+                return result |> Result.map ParenteraliaResp
+            }
         | NutritionPlanCmd(InitNutritionPlan patient) ->
-            gated (fun () ->
-                async {
-                    let! result = env.nutritionPlan.initNutritionPlan patient
-                    return result |> Result.map (NutritionPlanInitialised >> NutritionPlanResp)
-                }
-            )
+            async {
+                let! result = env.nutritionPlan.initNutritionPlan patient
+                return result |> Result.map (NutritionPlanInitialised >> NutritionPlanResp)
+            }
         | NutritionPlanCmd(UpdateNutritionOrderContext(plan, label, ctx)) ->
-            gated (fun () ->
-                async {
-                    let! result = env.nutritionPlan.updateNutritionOrderContext (plan, label, ctx)
-                    return result |> Result.map (NutritionPlanUpdated >> NutritionPlanResp)
-                }
-            )
+            async {
+                let! result = env.nutritionPlan.updateNutritionOrderContext (plan, label, ctx)
+                return result |> Result.map (NutritionPlanUpdated >> NutritionPlanResp)
+            }
         | NutritionPlanCmd(SelectNutritionOrderScenario(plan, label, ctx)) ->
-            gated (fun () ->
-                async {
-                    let! result = env.nutritionPlan.selectNutritionOrderScenario (plan, label, ctx)
-                    return result |> Result.map (NutritionPlanUpdated >> NutritionPlanResp)
-                }
-            )
+            async {
+                let! result = env.nutritionPlan.selectNutritionOrderScenario (plan, label, ctx)
+                return result |> Result.map (NutritionPlanUpdated >> NutritionPlanResp)
+            }
         | NutritionPlanCmd(NavigateNutritionOrderContext(plan, label, ctxCmd, ctx)) ->
-            gated (fun () ->
-                async {
-                    let! result = env.nutritionPlan.navigateNutritionOrderContext (plan, label, ctxCmd, ctx)
-                    return result |> Result.map (NutritionPlanUpdated >> NutritionPlanResp)
-                }
-            )
+            async {
+                let! result = env.nutritionPlan.navigateNutritionOrderContext (plan, label, ctxCmd, ctx)
+                return result |> Result.map (NutritionPlanUpdated >> NutritionPlanResp)
+            }
         | NutritionPlanCmd(AddNutritionContext(plan, category)) ->
-            gated (fun () ->
-                async {
-                    let! result = env.nutritionPlan.addNutritionContext (plan, category)
-                    return result |> Result.map (NutritionPlanUpdated >> NutritionPlanResp)
-                }
-            )
+            async {
+                let! result = env.nutritionPlan.addNutritionContext (plan, category)
+                return result |> Result.map (NutritionPlanUpdated >> NutritionPlanResp)
+            }
         | NutritionPlanCmd(RemoveNutritionContext(plan, id)) ->
-            gated (fun () ->
-                async {
-                    let! result = env.nutritionPlan.removeNutritionContext (plan, id)
-                    return result |> Result.map (NutritionPlanUpdated >> NutritionPlanResp)
-                }
-            )
+            async {
+                let! result = env.nutritionPlan.removeNutritionContext (plan, id)
+                return result |> Result.map (NutritionPlanUpdated >> NutritionPlanResp)
+            }

--- a/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
@@ -4,7 +4,6 @@ namespace ServerApi
 module CompositionRoot =
 
     open Informedica.Utils.Lib.ConsoleWriter.NewLineNoTime
-    open Shared.Types
     open Shared.Api
 
 
@@ -19,82 +18,20 @@ module CompositionRoot =
         : IServerApi
         =
         {
-            // the Session the cookie names is marked seen and told whether the record moved on
-            // or the Session ended, before the command is computed; without a cookie the
-            // request computes as it always did. The token is never logged.
-            processCommand =
-                fun request ->
-                    async {
-                        let cmd = request.Command
-
-                        try
-                            writeInfoMessage $"Processing command: {cmd |> Command.toString}"
-
-                            let! notice =
-                                match cookie.read () with
-                                | None -> async { return None }
-                                | Some id -> env.session.seen id request.Opened
-
-                            let! result = Command.processCmd env cmd
-
-                            let told =
-                                match notice with
-                                | Some(RecordNotice.NewerVersion _) -> ", the record moved on"
-                                | Some(RecordNotice.Ended _) -> ", the Session ended"
-                                | None -> ""
-
-                            writeInfoMessage $"Finished processing command: {cmd |> Command.toString}{told}"
-
-                            return
-                                result
-                                |> Result.map (fun response ->
-                                    ({
-                                        Response = response
-                                        Notice = notice
-                                    }
-                                    : Reply)
-                                )
-                        with ex ->
-                            writeErrorMessage $"Error processing command: {cmd |> Command.toString}\n{ex}"
-                            return Error [| ex.Message |]
-                    }
+            // every computing member goes through Compute.bound: the log, the Session marked seen
+            // and told, the gate, the exception as an Error
+            processCommand = Compute.bound env cookie Command.toString Command.gate (Command.processCmd env)
 
             processLaunch =
-                fun cmd ->
-                    async {
-                        writeInfoMessage $"Processing launch: {cmd |> LaunchCommand.toString}"
-                        let! outcome = LaunchCommand.processCmd env cookie stateCookie cmd
-                        writeInfoMessage $"Finished processing launch: {cmd |> LaunchCommand.toString}"
-                        return outcome
-                    }
+                Compute.logged "launch" LaunchCommand.toString (LaunchCommand.processCmd env cookie stateCookie)
 
             processSession =
-                fun cmd ->
-                    async {
-                        writeInfoMessage $"Processing session: {cmd |> SessionCommand.toString}"
-                        let! response = SessionCommand.processCmd env cookie enrolment cmd
-                        writeInfoMessage $"Finished processing session: {cmd |> SessionCommand.toString}"
-                        return response
-                    }
+                Compute.logged "session" SessionCommand.toString (SessionCommand.processCmd env cookie enrolment)
 
-            processSigning =
-                fun cmd ->
-                    async {
-                        writeInfoMessage $"Processing signing: {cmd |> SigningCommand.toString}"
-                        let! response = SigningCommand.processCmd env cookie cmd
-                        writeInfoMessage $"Finished processing signing: {cmd |> SigningCommand.toString}"
-                        return response
-                    }
+            processSigning = Compute.logged "signing" SigningCommand.toString (SigningCommand.processCmd env cookie)
 
             // never Session-bound: no cookie read, no notice, and not behind requireLoaded
-            processAdmin =
-                fun cmd ->
-                    async {
-                        writeInfoMessage $"Processing admin: {cmd |> AdminCommand.toString}"
-                        let! response = AdminCommand.processCmd env cmd
-                        writeInfoMessage $"Finished processing admin: {cmd |> AdminCommand.toString}"
-                        return response
-                    }
+            processAdmin = Compute.logged "admin" AdminCommand.toString (AdminCommand.processCmd env)
 
             getSettings =
                 fun () ->

--- a/src/Informedica.GenPRES.Server/ServerApi.Compute.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Compute.fs
@@ -40,10 +40,14 @@ module Compute =
                     | None -> async { return None }
                     | Some id -> env.session.seen id request.Opened
 
+                // an open command never asks the provider: asking may load
                 let! result =
-                    match gate cmd, env.requireLoaded () with
-                    | Gate.RequiresLoaded, Some msgs -> async { return Error msgs }
-                    | _ -> handler cmd
+                    match gate cmd with
+                    | Gate.Open -> handler cmd
+                    | Gate.RequiresLoaded ->
+                        match env.requireLoaded () with
+                        | Some msgs -> async { return Error msgs }
+                        | None -> handler cmd
 
                 let told =
                     match notice with

--- a/src/Informedica.GenPRES.Server/ServerApi.Compute.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Compute.fs
@@ -1,0 +1,77 @@
+namespace ServerApi
+
+open Shared.Types
+open Shared.Api
+open Informedica.Utils.Lib.ConsoleWriter.NewLineNoTime
+
+
+/// Whether a command needs the formulary loaded.
+[<RequireQualifiedAccess>]
+type Gate =
+    | RequiresLoaded
+    | Open
+
+
+/// What every computing member goes through, and what the other members share of it.
+module Compute =
+
+    /// Every computing member: the Session the cookie names is marked seen and told whether the
+    /// record moved on or the Session ended, before the command is computed; without a cookie
+    /// the request computes as it always did. The gate refuses a command that needs the
+    /// formulary while it is not loaded, with the provider's messages. An exception is an
+    /// Error with its message. The token is never logged.
+    let bound
+        (env: AppEnv)
+        (cookie: SessionCookie)
+        (name: 'cmd -> string)
+        (gate: 'cmd -> Gate)
+        (handler: 'cmd -> Async<Result<'resp, string[]>>)
+        (request: Request<'cmd>)
+        : Async<Result<Reply<'resp>, string[]>>
+        =
+        let cmd = request.Command
+
+        async {
+            try
+                writeInfoMessage $"Processing command: {name cmd}"
+
+                let! notice =
+                    match cookie.read () with
+                    | None -> async { return None }
+                    | Some id -> env.session.seen id request.Opened
+
+                let! result =
+                    match gate cmd, env.requireLoaded () with
+                    | Gate.RequiresLoaded, Some msgs -> async { return Error msgs }
+                    | _ -> handler cmd
+
+                let told =
+                    match notice with
+                    | Some(RecordNotice.NewerVersion _) -> ", the record moved on"
+                    | Some(RecordNotice.Ended _) -> ", the Session ended"
+                    | None -> ""
+
+                writeInfoMessage $"Finished processing command: {name cmd}{told}"
+
+                return
+                    result
+                    |> Result.map (fun response ->
+                        {
+                            Response = response
+                            Notice = notice
+                        }
+                    )
+            with ex ->
+                writeErrorMessage $"Error processing command: {name cmd}\n{ex}"
+                return Error [| ex.Message |]
+        }
+
+
+    /// A member that is not computing: the same two log lines around it, nothing else.
+    let logged (what: string) (name: 'cmd -> string) (run: 'cmd -> Async<'resp>) (cmd: 'cmd) =
+        async {
+            writeInfoMessage $"Processing {what}: {name cmd}"
+            let! response = run cmd
+            writeInfoMessage $"Finished processing {what}: {name cmd}"
+            return response
+        }

--- a/src/Informedica.GenPRES.Shared/Api.fs
+++ b/src/Informedica.GenPRES.Shared/Api.fs
@@ -87,20 +87,27 @@ module Api =
     /// Every computing request: the command and the OpenedToken the Session holds.
     /// `None` where there is none to send: no Session, an anonymous one, or a client acting
     /// before its first token arrived.
-    type Request =
+    type Request<'cmd> =
         {
             Opened: OpenedToken option
-            Command: Command
+            Command: 'cmd
         }
 
 
-    /// Every computing reply: the result, and what the Session is told with it (the record
+    /// Every computing reply: the answer, and what the Session is told with it (the record
     /// moved on, or the Session ended).
-    type Reply =
+    type Reply<'resp> =
         {
-            Response: Response
+            Response: 'resp
             Notice: RecordNotice option
         }
+
+
+    // until the families move to their own members, processCommand keeps its shape under
+    // these names
+    type Request = Request<Command>
+
+    type Reply = Reply<Response>
 
 
     module Command =

--- a/src/Informedica.GenPRES.Shared/Scripts/Api.fsx
+++ b/src/Informedica.GenPRES.Shared/Scripts/Api.fsx
@@ -1,17 +1,18 @@
-// The admin command family (plan 654, step 2): the settings page's four operations as one
-// `IServerApi` member, `processAdmin`, token-authenticated and never Session-bound.
+// The computing envelope, generic (plan 654, step 5): `Request<'cmd>` and `Reply<'resp>` in
+// place of the `Request`/`Reply` records over `Command`/`Response`, so that every computing
+// member can carry its own command and answer inside the same envelope. Abbreviations keep the
+// client compiling unchanged until the families move.
 //
-// Script-first draft of what goes to `Shared/Api.fs`: `AdminCommand`, `AdminResponse`,
-// `AdminCommand.toString` and the `IServerApi` member. A script cannot add cases to
-// `Shared.Api` or a field to `IServerApi`, so the types are proposed here under `Api654` and
-// the member is stated as a signature. `ReloadResources` carries the token the login issued,
-// not the password: the password travels once, at `ValidatePassword`.
+// Script-first draft of what goes to `Shared/Api.fs`. The one risk is the wire: no generic
+// record crosses it yet. Both sides serialize JSON, the server through Fable.Remoting.Json, so
+// the round trip below runs `Request<Formulary>` and `Result<Reply<Formulary>, string[]>`
+// through that converter, both ways.
 //
-// Run: `dotnet fsi Api.fsx` from this directory, or via the FSI MCP after
-// `#I "<this directory>"`.
+// Run: `dotnet fsi Api.fsx` from this directory.
 
 #I __SOURCE_DIRECTORY__
 #r "nuget: Expecto, 10.2.3"
+#r "nuget: Fable.Remoting.Json, 3.0"
 
 #load "../Types.fs"
 #load "../Calculations.fs"
@@ -23,80 +24,94 @@
 open Shared.Types
 
 
-/// → `Shared/Api.fs`, after `SigningCommand`.
+/// → `Shared/Api.fs`, in place of `Request` and `Reply`.
 module Api654 =
 
-    /// The admin command family: the password once, then the token it bought. Never
-    /// cookie-authenticated, never behind the formulary being loaded, so a failed load can be
-    /// retried from the settings page.
-    [<RequireQualifiedAccess>]
-    type AdminCommand =
-        // answered with a token when the password is the server's; a token nobody can forge
-        // when the server has no password
-        | ValidatePassword of password: string
-        | ListLogFiles of token: string
-        | AnalyzeLogFile of token: string * fileName: string
-        // reloads the formulary and everything else the resource provider holds
-        | ReloadResources of token: string
+    open Shared.Api
+
+    /// Every computing request: the command and the OpenedToken the Session holds. `None`
+    /// where there is none to send: no Session, an anonymous one, or a client acting before
+    /// its first token arrived.
+    type Request<'cmd> =
+        {
+            Opened: OpenedToken option
+            Command: 'cmd
+        }
 
 
-    [<RequireQualifiedAccess>]
-    type AdminResponse =
-        // isValid false comes with an empty token
-        | PasswordValidated of isValid: bool * token: string
-        | LogFilesListed of LogFileInfo[]
-        | LogFileAnalyzed of string
-        | ResourcesReloaded
+    /// Every computing reply: the answer, and what the Session is told with it (the record
+    /// moved on, or the Session ended).
+    type Reply<'resp> =
+        {
+            Response: 'resp
+            Notice: RecordNotice option
+        }
 
 
-    module AdminCommand =
-
-        /// For the log. Never the password or the token; the file name is not a secret.
-        let toString cmd =
-            match cmd with
-            | AdminCommand.ValidatePassword _ -> "ValidatePassword"
-            | AdminCommand.ListLogFiles _ -> "ListLogFiles"
-            | AdminCommand.AnalyzeLogFile(_, f) -> $"AnalyzeLogFile %s{f}"
-            | AdminCommand.ReloadResources _ -> "ReloadResources"
-
-
-    // `IServerApi` gains, next to `processSigning`:
-    //
-    //     processAdmin: AdminCommand -> Async<Result<AdminResponse, string[]>>
-    //
-    // No `Request`/`Reply` envelope: an admin request has no OpenedToken to send and no
-    // record notice to receive.
+    // until the families move, processCommand keeps its shape under these names:
+    type Request = Request<Command>
+    type Reply = Reply<Response>
 
 
 open Expecto
 open Expecto.Flip
+open Newtonsoft.Json
+open Fable.Remoting.Json
 open Api654
+
+
+let converters = [| FableJsonConverter() :> JsonConverter |]
+let toJson (v: 'a) = JsonConvert.SerializeObject(v, converters)
+let ofJson<'a> (json: string) = JsonConvert.DeserializeObject<'a>(json, converters)
 
 
 let tests =
     testList
-        "AdminCommand.toString"
+        "the generic envelope on the wire"
         [
-            test "names the command, never the password" {
-                AdminCommand.ValidatePassword "hunter2-hunter2-1"
-                |> AdminCommand.toString
-                |> Expect.equal "name only" "ValidatePassword"
+            test "Request<Formulary> round-trips and reads as today's Request" {
+                let request: Request<Formulary> =
+                    {
+                        Opened = Some(OpenedToken "opened-1")
+                        Command = { Shared.Models.Formulary.empty with Generics = [| "paracetamol" |] }
+                    }
+
+                let json = toJson request
+                (json.Contains "\"Opened\"" && json.Contains "\"Command\"") |> Expect.isTrue "the same two fields"
+                ofJson<Request<Formulary>> json |> Expect.equal "the same request back" request
             }
 
-            test "names the command, never the token" {
-                let token = "eyJwYXlsb2FkIn0=.c2lnbmF0dXJl"
+            test "Result<Reply<Formulary>, string[]> round-trips with and without a notice" {
+                let reply: Result<Reply<Formulary>, string[]> =
+                    Ok
+                        {
+                            Response = { Shared.Models.Formulary.empty with Generics = [| "paracetamol" |] }
+                            Notice = Some(RecordNotice.Ended SessionEnding.SupersededByLaunch)
+                        }
 
-                AdminCommand.ListLogFiles token
-                |> AdminCommand.toString
-                |> Expect.equal "name only" "ListLogFiles"
+                reply |> toJson |> ofJson<Result<Reply<Formulary>, string[]>> |> Expect.equal "with a notice" reply
 
-                AdminCommand.ReloadResources token
-                |> AdminCommand.toString
-                |> Expect.equal "name only" "ReloadResources"
+                let quiet: Result<Reply<Formulary>, string[]> =
+                    Ok
+                        {
+                            Response = Shared.Models.Formulary.empty
+                            Notice = None
+                        }
 
-                let logged = AdminCommand.AnalyzeLogFile(token, "server.log") |> AdminCommand.toString
-                logged |> Expect.equal "name and file" "AnalyzeLogFile server.log"
-                logged.Contains token |> Expect.isFalse "no token"
+                quiet |> toJson |> ofJson<Result<Reply<Formulary>, string[]>> |> Expect.equal "without" quiet
+
+                let refused: Result<Reply<Formulary>, string[]> = Error [| "not loaded" |]
+                refused |> toJson |> ofJson<Result<Reply<Formulary>, string[]>> |> Expect.equal "an error" refused
+            }
+
+            test "the abbreviation is today's Request over Command" {
+                let request: Request =
+                    {
+                        Opened = None
+                        Command = Shared.Api.FormularyCmd Shared.Models.Formulary.empty
+                    }
+
+                request |> toJson |> ofJson<Request> |> Expect.equal "back" request
             }
         ]
 

--- a/tests/Informedica.GenPRES.Server.Tests/ResourceErrorTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/ResourceErrorTests.fs
@@ -250,9 +250,19 @@ let cachingBehaviorTests =
         ]
 
 
+/// The gate lives in Compute.bound, so the guard is tested through it, over a cookie that
+/// names no Session.
+let noCookie: ServerApi.SessionCookie =
+    {
+        read = fun () -> None
+        write = ignore
+        delete = ignore
+    }
+
+
 let processCmdGuardTests =
     testList
-        "processCmd IsLoaded guard"
+        "Compute.bound IsLoaded guard"
         [
 
             test "FormularyCmd returns Error when provider IsLoaded = false" {
@@ -261,8 +271,19 @@ let processCmdGuardTests =
 
                 let cmd = Shared.Api.FormularyCmd Formulary.empty
 
+                let env = ServerApi.Adapters.makeAppEnv provider
+
                 let result =
-                    ServerApi.Command.processCmd (ServerApi.Adapters.makeAppEnv provider) cmd
+                    ServerApi.Compute.bound
+                        env
+                        noCookie
+                        Shared.Api.Command.toString
+                        ServerApi.Command.gate
+                        (ServerApi.Command.processCmd env)
+                        {
+                            Opened = None
+                            Command = cmd
+                        }
                     |> Async.RunSynchronously
 
                 result
@@ -276,8 +297,19 @@ let processCmdGuardTests =
 
                 let cmd = Shared.Api.ParenteraliaCmd Parenteralia.empty
 
+                let env = ServerApi.Adapters.makeAppEnv provider
+
                 let result =
-                    ServerApi.Command.processCmd (ServerApi.Adapters.makeAppEnv provider) cmd
+                    ServerApi.Compute.bound
+                        env
+                        noCookie
+                        Shared.Api.Command.toString
+                        ServerApi.Command.gate
+                        (ServerApi.Command.processCmd env)
+                        {
+                            Opened = None
+                            Command = cmd
+                        }
                     |> Async.RunSynchronously
 
                 result

--- a/tests/Informedica.GenPRES.Server.Tests/Scripts/load.fsx
+++ b/tests/Informedica.GenPRES.Server.Tests/Scripts/load.fsx
@@ -20,6 +20,7 @@
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.Session.fs"
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.StubAdapters.fs"
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.Adapters.fs"
+#load "../../../src/Informedica.GenPRES.Server/ServerApi.Compute.fs"
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.AdminCommand.fs"
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.Command.fs"
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.LaunchCommand.fs"

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -278,15 +278,36 @@ let errorPropagationTests =
         ]
 
 
+/// The gate is Compute.bound's, so the guard is tested through it, over a cookie that names
+/// no Session.
 let requireLoadedTests =
+    let noCookie: SessionCookie =
+        {
+            read = fun () -> None
+            write = ignore
+            delete = ignore
+        }
+
+    let bound env cmd =
+        Compute.bound
+            env
+            noCookie
+            Api.Command.toString
+            Command.gate
+            (Command.processCmd env)
+            {
+                Opened = None
+                Command = cmd
+            }
+
     testList
-        "Stub adapter requireLoaded guard"
+        "Compute.bound requireLoaded guard"
         [
 
             testAsync "requireLoaded returns Error when not loaded" {
                 let env = makeEnvNotLoaded [| "not ready" |]
 
-                let! result = Command.processCmd env (Api.FormularyCmd Formulary.empty)
+                let! result = bound env (Api.FormularyCmd Formulary.empty)
 
                 match result with
                 | Error msgs -> msgs |> Expect.equal "should return requireLoaded error" [| "not ready" |]
@@ -301,7 +322,7 @@ let requireLoadedTests =
                         (orderPlanAlwaysOk emptyPlan)
                         (nutritionPlanAlwaysOk emptyNutritionPlan)
 
-                let! result = Command.processCmd env (Api.FormularyCmd Formulary.empty)
+                let! result = bound env (Api.FormularyCmd Formulary.empty)
 
                 match result with
                 | Ok _ -> ()
@@ -4885,6 +4906,163 @@ module AdminTests =
             ]
 
 
+/// `Compute.bound`: what every computing member goes through.
+module BoundTests =
+
+    open Shared.Api
+    open Newtonsoft.Json
+    open Fable.Remoting.Json
+
+    let cookieOf (id: string option) : SessionCookie =
+        {
+            read = fun () -> id
+            write = ignore
+            delete = ignore
+        }
+
+    /// A stub env: the formulary answers, the Session's answer given, loaded or not.
+    let envWith (loaded: bool) (told: RecordNotice option) =
+        let env =
+            makeEnv
+                (formularyAlwaysOk { Formulary.empty with Markdown = "stubbed" })
+                (orderContextAlwaysOk emptyCtx)
+                (orderPlanAlwaysOk emptyPlan)
+                (nutritionPlanAlwaysOk emptyNutritionPlan)
+
+        { env with
+            requireLoaded = (fun () -> if loaded then None else Some [| "not loaded" |])
+            session = { env.session with seen = fun _ _ -> async { return told } }
+        }
+
+    let run env cookie handler cmd =
+        Compute.bound
+            env
+            cookie
+            Command.toString
+            Command.gate
+            handler
+            {
+                Opened = None
+                Command = cmd
+            }
+        |> Async.RunSynchronously
+
+    let formulary = Api.FormularyCmd Formulary.empty
+
+    let converters = [| FableJsonConverter() :> JsonConverter |]
+
+    let toJson (v: 'a) =
+        JsonConvert.SerializeObject(v, converters)
+
+    let ofJson<'a> (json: string) =
+        JsonConvert.DeserializeObject<'a>(json, converters)
+
+    let tests =
+        testList
+            "Compute.bound"
+            [
+                test "without a cookie: computed, nothing told" {
+                    let env = envWith true (Some(RecordNotice.Ended SessionEnding.SupersededByLaunch))
+
+                    match run env (cookieOf None) (Command.processCmd env) formulary with
+                    | Ok reply ->
+                        reply.Notice |> Expect.isNone "nothing told without a cookie"
+
+                        match reply.Response with
+                        | Api.FormularyResp f -> f.Markdown |> Expect.equal "computed" "stubbed"
+                        | other -> failtest $"expected FormularyResp, got {other}"
+                    | Error errs -> failtest $"expected Ok, got {errs}"
+                }
+
+                test "with a cookie: what the Session is told rides on the reply, still computed" {
+                    let env = envWith true (Some(RecordNotice.Ended SessionEnding.SupersededByLaunch))
+
+                    match run env (cookieOf (Some "s-1")) (Command.processCmd env) formulary with
+                    | Ok reply ->
+                        reply.Notice
+                        |> Expect.equal "the ending" (Some(RecordNotice.Ended SessionEnding.SupersededByLaunch))
+
+                        match reply.Response with
+                        | Api.FormularyResp f -> f.Markdown |> Expect.equal "still computed" "stubbed"
+                        | other -> failtest $"expected FormularyResp, got {other}"
+                    | Error errs -> failtest $"expected Ok, got {errs}"
+                }
+
+                test "a command that needs the formulary is refused while it is not loaded" {
+                    let env = envWith false None
+
+                    run env (cookieOf None) (Command.processCmd env) formulary
+                    |> Expect.equal "refused with the messages" (Error [| "not loaded" |])
+                }
+
+                test "an open command runs while the formulary is not loaded" {
+                    let env = envWith false None
+
+                    match run env (cookieOf None) (Command.processCmd env) (Api.InteractionCmd Api.GetDrugNames) with
+                    | Ok reply ->
+                        reply.Response
+                        |> Expect.equal "the names" (Api.InteractionResp(Api.DrugNamesLoaded [||]))
+                    | Error errs -> failtest $"expected Ok, got {errs}"
+
+                    Command.gate (Api.InteractionCmd Api.GetDrugNames)
+                    |> Expect.equal "open" Gate.Open
+
+                    Command.gate (Api.InteractionCmd(Api.CheckInteractions []))
+                    |> Expect.equal "gated" Gate.RequiresLoaded
+                }
+
+                test "a throwing handler answers an Error with its message" {
+                    let env = envWith true None
+                    let throwing _ = async { return invalidOp "boom" }
+
+                    run env (cookieOf None) throwing formulary
+                    |> Expect.equal "the message" (Error [| "boom" |])
+                }
+
+                test "logged: the answer passes through" {
+                    Compute.logged
+                        "admin"
+                        AdminCommand.toString
+                        (fun _ -> async { return 42 })
+                        (AdminCommand.ValidatePassword "x")
+                    |> Async.RunSynchronously
+                    |> Expect.equal "through" 42
+                }
+
+                test "the generic envelope round-trips through the server's JSON converter" {
+                    let request: Request<Formulary> =
+                        {
+                            Opened = Some(OpenedToken "opened-1")
+                            Command = { Formulary.empty with Generics = [| "paracetamol" |] }
+                        }
+
+                    request
+                    |> toJson
+                    |> ofJson<Request<Formulary>>
+                    |> Expect.equal "the request" request
+
+                    let reply: Result<Reply<Formulary>, string[]> =
+                        Ok
+                            {
+                                Response = { Formulary.empty with Generics = [| "paracetamol" |] }
+                                Notice = Some(RecordNotice.Ended SessionEnding.SupersededByLaunch)
+                            }
+
+                    reply
+                    |> toJson
+                    |> ofJson<Result<Reply<Formulary>, string[]>>
+                    |> Expect.equal "the reply" reply
+
+                    let refused: Result<Reply<Formulary>, string[]> = Error [| "not loaded" |]
+
+                    refused
+                    |> toJson
+                    |> ofJson<Result<Reply<Formulary>, string[]>>
+                    |> Expect.equal "an error" refused
+                }
+            ]
+
+
 [<Tests>]
 let tests =
     testList
@@ -4895,4 +5073,5 @@ let tests =
             requireLoadedTests
             SessionStubTests.tests
             AdminTests.tests
+            BoundTests.tests
         ]

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -5011,6 +5011,30 @@ module BoundTests =
                     |> Expect.equal "gated" Gate.RequiresLoaded
                 }
 
+                test "an open command never asks the provider whether it is loaded" {
+                    let asked = ref 0
+
+                    let env =
+                        { envWith true None with
+                            requireLoaded =
+                                fun () ->
+                                    asked.Value <- asked.Value + 1
+                                    None
+                        }
+
+                    run env (cookieOf None) (Command.processCmd env) (Api.InteractionCmd Api.GetDrugNames)
+                    |> Result.isOk
+                    |> Expect.isTrue "computed"
+
+                    asked.Value |> Expect.equal "never asked: asking may load" 0
+
+                    run env (cookieOf None) (Command.processCmd env) formulary
+                    |> Result.isOk
+                    |> Expect.isTrue "computed"
+
+                    asked.Value |> Expect.equal "asked once for a gated command" 1
+                }
+
                 test "a throwing handler answers an Error with its message" {
                     let env = envWith true None
                     let throwing _ = async { return invalidOp "boom" }


### PR DESCRIPTION
Step 5 of [plan 654](https://github.com/informedica/GenPRES/blob/master/docs/implementation-plans/654-api-per-use-case.md): the envelope becomes generic and one wrapper owns what every computing member needs. No visible change.

**In this PR (scripts, per the script-only policy)**

- `Shared/Scripts/Api.fsx`: `Request<'cmd>` and `Reply<'resp>` with the abbreviations `Request = Request<Command>` and `Reply = Reply<Response>` that keep `processCommand`'s shape. 3 tests round-trip `Request<Formulary>` and `Result<Reply<Formulary>, string[]>` through `Fable.Remoting.Json`, both ways: the first generic record on this wire, proven before any family moves.
- `Server/Scripts/Compute.fsx` (rewritten): `Gate`, `Compute.bound` (log, the Session the cookie names marked seen and told, the gate, the handler, an exception as `Error`), `Compute.logged` for the members that are not computing, and `Command.gate` so the dispatcher no longer gates itself. 6 tests.

**Migration (for the maintainer, `.claude/docs/654-pr4-migration.patch`, 8 files, +295/−162)**

`Shared/Api.fs` the generic envelope and the abbreviations; new `ServerApi.Compute.fs` (fsproj after `Adapters.fs`, both `Scripts/load.fsx`); `ServerApi.Command.fs` a plain dispatcher plus `Command.gate`; `CompositionRoot.fs` one line per member, `processCommand` on `bound`, the other four on `logged`; tests: the two `requireLoaded` guard suites go through `bound`, plus 7 `BoundTests` (the six of the script and the JSON round trip through the server's converter). Verified in a worktree: build (the client compiles unchanged against the abbreviations), 283 server tests (276 before), Fantomas, Fable, `CheckDependencyRule.fsx`.

Plan 580's scope check becomes one more parameter of `bound` when it is built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q228qLAaCzuK9Bhq2pEBGc