### PR TITLE
refactor(api): formulary and parenteralia as their own members (#654 PR 5)

### DIFF
--- a/src/Informedica.GenPRES.Client/App.fs
+++ b/src/Informedica.GenPRES.Client/App.fs
@@ -95,23 +95,23 @@ module private Elmish =
         | UpdateContinuousMedsFilter of string[]
 
         | OrderContextMsg of Api.OrderContextCommand * OrderContext
-        | LoadOrderContextResult of Api.OrderContextCommand * ApiResponse
+        | LoadOrderContextResult of Api.OrderContextCommand * ApiResponse<Api.Response>
 
         | OrderPlanMsg of Api.OrderPlanCommand
-        | LoadOrderPlanResult of Api.OrderPlanCommand * ApiResponse
+        | LoadOrderPlanResult of Api.OrderPlanCommand * ApiResponse<Api.Response>
 
         | NutritionPlanMsg of Api.NutritionPlanCommand
-        | LoadNutritionPlanResult of Api.NutritionPlanCommand * ApiResponse
+        | LoadNutritionPlanResult of Api.NutritionPlanCommand * ApiResponse<Api.Response>
 
         | UpdateFormulary of Formulary
-        | LoadFormulary of ApiResponse
+        | LoadFormulary of ApiResponse<Formulary>
 
         | UpdateParenteralia of Parenteralia
-        | LoadParenteralia of ApiResponse
+        | LoadParenteralia of ApiResponse<Parenteralia>
 
         | CheckInteractions of string list
-        | LoadInteractionsResult of ApiResponse
-        | LoadInteractionDrugNames of ApiResponse
+        | LoadInteractionsResult of ApiResponse<Api.Response>
+        | LoadInteractionDrugNames of ApiResponse<Api.Response>
 
         | UpdateLanguage of Localization.Locales
         | LoadLocalization of AsyncOperationStatus<Result<string[][], string>>
@@ -136,7 +136,8 @@ module private Elmish =
         | LoadReloadResult of token: string * AdminResult
 
 
-    and ApiResponse = AsyncOperationStatus<Result<Answer, string[]>>
+    /// A computing answer of a member, typed by what the member answers
+    and ApiResponse<'r> = AsyncOperationStatus<Result<Answer<'r>, string[]>>
 
     /// An admin answer: no envelope, so no token it started from and no notice
     and AdminResult = AsyncOperationStatus<Result<Api.AdminResponse, string[]>>
@@ -144,10 +145,10 @@ module private Elmish =
     /// A computing reply with the OpenedToken the request started from, so that what the reply
     /// tells about the Session (moved on, ended) lands only on the Session that asked: a request
     /// of a Session since closed or replaced must not end or warn the current one.
-    and Answer =
+    and Answer<'r> =
         {
             From: OpenedToken option
-            Reply: Api.Reply
+            Reply: Api.Reply<'r>
         }
 
 
@@ -187,16 +188,21 @@ module private Elmish =
         | _ -> None
 
 
-    let createApiMsg (opened: OpenedToken option) msg cmd =
+    /// A computing request through the member given, with the OpenedToken the Session holds;
+    /// the answer comes back with the token it started from.
+    let createApiMsg
+        (call: Api.Request<'cmd> -> Async<Result<Api.Reply<'resp>, string[]>>)
+        (opened: OpenedToken option)
+        msg
+        (cmd: 'cmd)
+        =
         async {
             let! result =
-                serverApi.processCommand (
+                call
                     {
                         Opened = opened
                         Command = cmd
                     }
-                    : Api.Request
-                )
 
             return
                 result
@@ -235,8 +241,6 @@ module private Elmish =
                     Cmd.none
 
             { state with OrderPlan = Resolved tp }, cmd
-        | Api.FormularyResp form -> { state with Formulary = Resolved form }, Cmd.none
-        | Api.ParenteraliaResp par -> { state with Parenteralia = Resolved par }, Cmd.none
         | Api.NutritionPlanResp(Api.NutritionPlanInitialised plan)
         | Api.NutritionPlanResp(Api.NutritionPlanUpdated plan) -> { state with NutritionPlan = Resolved plan }, Cmd.none
         | Api.InteractionResp(Api.InteractionsChecked interactions) ->
@@ -310,7 +314,7 @@ module private Elmish =
     /// stale-request guard: the notice counts only when the request started from the token the
     /// open Session holds now; a reply of a Session since closed, replaced or re-minted says
     /// nothing about this one (the next request repeats what still holds; the notice is stateless).
-    let processApiMsg (state: State) (answer: Answer) =
+    let processApiMsg (state: State) (answer: Answer<'r>) (apply: State -> 'r -> State * Cmd<Msg>) =
         let current =
             match state.Session with
             | Session.Open opened -> Some opened.OpenedToken
@@ -323,24 +327,32 @@ module private Elmish =
             | Some(RecordNotice.Ended ending) -> Cmd.ofMsg (SessionMsg(SessionMsg.EndedByServer ending))
             | None -> Cmd.none
 
-        let state, cmd = processResponse state answer.Reply.Response
+        let state, cmd = apply state answer.Reply.Response
         state, Cmd.batch [ cmd; told ]
 
 
+    let applyFormulary (state: State) (form: Formulary) =
+        { state with Formulary = Resolved form }, Cmd.none
+
+
+    let applyParenteralia (state: State) (par: Parenteralia) =
+        { state with Parenteralia = Resolved par }, Cmd.none
+
+
     let loadOrderContext opened resp =
-        Api.OrderContextCmd >> createApiMsg opened resp
+        Api.OrderContextCmd >> createApiMsg serverApi.processCommand opened resp
 
 
     let loadOrderPlan opened resp =
-        Api.OrderPlanCmd >> createApiMsg opened resp
+        Api.OrderPlanCmd >> createApiMsg serverApi.processCommand opened resp
 
 
-    let loadFormuarly opened =
-        Api.FormularyCmd >> createApiMsg opened LoadFormulary
+    let loadFormulary opened =
+        createApiMsg serverApi.processFormulary opened LoadFormulary
 
 
     let loadParenteralia opened =
-        Api.ParenteraliaCmd >> createApiMsg opened LoadParenteralia
+        createApiMsg serverApi.processParenteralia opened LoadParenteralia
 
 
     // url needs to be in format: http://localhost:8080/#patient?by=2&bm=0&bd=1
@@ -864,7 +876,8 @@ module private Elmish =
 
 
     let update (msg: Msg) (state: State) =
-        let processOk = processApiMsg state
+        let processOk answer =
+            processApiMsg state answer processResponse
 
         let processError err (state, cmd) =
             let errMsg =
@@ -1440,7 +1453,7 @@ module private Elmish =
                     (cmd, { ctx with Patient = pat })
                     |> loadOrderContext (tokenOf state.Session) (fun resp -> LoadOrderContextResult(cmd, resp))
 
-        | LoadOrderContextResult(_, Finished(Ok msg)) -> msg |> processApiMsg (settleReload state)
+        | LoadOrderContextResult(_, Finished(Ok msg)) -> processApiMsg (settleReload state) msg processResponse
         | LoadOrderContextResult(_, Finished(Error err)) ->
             Logging.warning "order context error, resetting" err
             let state = settleReload state
@@ -1469,7 +1482,10 @@ module private Elmish =
                 | _ ->
                     { state with OrderPlan = Recalculating tp },
                     Api.OrderPlanCmd(Api.UpdateOrderPlan(tp, Some(ctxCmd, ctx)))
-                    |> createApiMsg (tokenOf state.Session) (fun resp -> LoadOrderPlanResult(tpCmd, resp))
+                    |> createApiMsg
+                        serverApi.processCommand
+                        (tokenOf state.Session)
+                        (fun resp -> LoadOrderPlanResult(tpCmd, resp))
             | Api.UpdateOrderPlan(tp, None) ->
                 let onlySetOrderContext =
                     state.OrderPlan
@@ -1545,7 +1561,10 @@ module private Elmish =
 
             { state with NutritionPlan = planState },
             Api.NutritionPlanCmd npCmd
-            |> createApiMsg (tokenOf state.Session) (fun resp -> LoadNutritionPlanResult(npCmd, resp))
+            |> createApiMsg
+                serverApi.processCommand
+                (tokenOf state.Session)
+                (fun resp -> LoadNutritionPlanResult(npCmd, resp))
 
         | LoadNutritionPlanResult(_, Started) -> state, Cmd.none
         | LoadNutritionPlanResult(_, Finished(Ok msg)) -> msg |> processOk
@@ -1561,14 +1580,14 @@ module private Elmish =
                     | Resolved form -> { form with Patient = state.Patient }
                     | _ -> Formulary.empty
 
-                let cmd = form |> loadFormuarly (tokenOf state.Session)
+                let cmd = form |> loadFormulary (tokenOf state.Session)
 
                 { state with Formulary = InProgress }, cmd
 
         // without a patient the formulary is what a reload refreshes, so it settles the reload
         | LoadFormulary(Finished(Ok msg)) ->
             let state = if state.Patient.IsNone then settleReload state else state
-            processApiMsg state msg
+            processApiMsg state msg applyFormulary
 
         | LoadFormulary(Finished(Error err)) ->
             let state = if state.Patient.IsNone then settleReload state else state
@@ -1609,7 +1628,7 @@ module private Elmish =
 
                 { state with Parenteralia = InProgress }, cmd
 
-        | LoadParenteralia(Finished(Ok msg)) -> msg |> processOk
+        | LoadParenteralia(Finished(Ok msg)) -> processApiMsg state msg applyParenteralia
 
         | LoadParenteralia(Finished(Error err)) ->
             ({ state with Parenteralia = HasNotStartedYet }, Cmd.none) |> processError err
@@ -1651,7 +1670,7 @@ module private Elmish =
             else
                 { state with Interactions = InProgress },
                 Api.InteractionCmd(Api.CheckInteractions drugs)
-                |> createApiMsg (tokenOf state.Session) LoadInteractionsResult
+                |> createApiMsg serverApi.processCommand (tokenOf state.Session) LoadInteractionsResult
 
         | LoadInteractionsResult(Finished(Ok msg)) -> msg |> processOk
         | LoadInteractionsResult(Finished(Error err)) ->
@@ -1664,7 +1683,7 @@ module private Elmish =
             | _ ->
                 { state with InteractionDrugNames = InProgress },
                 Api.InteractionCmd Api.GetDrugNames
-                |> createApiMsg (tokenOf state.Session) LoadInteractionDrugNames
+                |> createApiMsg serverApi.processCommand (tokenOf state.Session) LoadInteractionDrugNames
 
         | LoadInteractionDrugNames(Finished(Ok msg)) ->
             let state, cmd = msg |> processOk

--- a/src/Informedica.GenPRES.Server/Informedica.GenPRES.Server.fsproj
+++ b/src/Informedica.GenPRES.Server/Informedica.GenPRES.Server.fsproj
@@ -16,6 +16,7 @@
     <Compile Include="ServerApi.StubAdapters.fs" />
     <Compile Include="ServerApi.Adapters.fs" />
     <Compile Include="ServerApi.Compute.fs" />
+    <Compile Include="ServerApi.FormularyCommand.fs" />
     <Compile Include="ServerApi.AdminCommand.fs" />
     <Compile Include="ServerApi.Command.fs" />
     <Compile Include="ServerApi.LaunchCommand.fs" />

--- a/src/Informedica.GenPRES.Server/Scripts/Compute.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/Compute.fsx
@@ -1,25 +1,22 @@
-// The computing wrapper (plan 654, step 5): what `compose` does around `processCommand` today,
-// as one function every computing member goes through. `bound` logs the command, marks the
-// Session the cookie names seen and takes what it is told (the record moved on, the Session
-// ended), applies the gate (the formulary loaded, or not needed), runs the handler and answers
-// the reply with the notice; an exception is an `Error` with its message. `logged` wraps the
-// members that are not computing (launch, session, signing, admin) with the same two log
-// lines. The gate moves out of `Command.processCmd`, which becomes a plain dispatcher, into a
-// `Command.gate` that `compose` passes: the drug names open, everything else behind the
-// formulary. No visible change.
+// The first two members peeled off processCommand (plan 654, step 6): `processFormulary` and
+// `processParenteralia`, each a `Request<_>` of its own command answered with a `Reply<_>` of
+// its own answer, built through `Compute.bound` like every computing member. The smallest
+// families first, so the generic envelope is seen on the browser's wire before the big ones
+// move. `FormularyCmd`, `ParenteraliaCmd`, `FormularyResp` and `ParenteraliaResp` leave
+// `Command` and `Response` with the migration.
 //
 // Script-first draft (script-only policy) of:
-//   - `Gate`, `Compute.bound`, `Compute.logged` → new `ServerApi.Compute.fs`, compiled after
-//     `Adapters.fs`, before `AdminCommand.fs` (fsproj and both `Scripts/load.fsx`);
-//   - `Command.gate` and `processCmd` without its own gating → `ServerApi.Command.fs`;
-//   - `compose` building `processCommand` with `bound` and the four others with `logged`
-//     → `CompositionRoot.fs`;
-//   - `Request<'cmd>` / `Reply<'resp>` with abbreviations → `Shared/Api.fs` (drafted and
-//     round-tripped through Fable.Remoting.Json in `Shared/Scripts/Api.fsx`).
+//   - `FormularyCommand` and `ParenteraliaCommand` (`toString`, `processCmd`) → new
+//     `ServerApi.FormularyCommand.fs`, compiled after `Compute.fs` (fsproj, both loaders);
+//   - `processFormulary` and `processParenteralia` on `IServerApi` → `Shared/Api.fs`, the four
+//     cases and their `toString` arms deleted there and the two arms in `Command.fs`;
+//   - the two members in `compose` → `CompositionRoot.fs`;
+//   - the client: `createApiMsg` over the member, `Answer<'r>`/`ApiResponse<'r>`,
+//     `processApiMsg` with an `apply` per family, `LoadFormulary`/`LoadParenteralia` on the new
+//     members (in the migration patch, since the client cannot compile against members that do
+//     not exist yet).
 //
-// The shared envelope is not generic while this script runs, so `bound` is drafted over the
-// abbreviated shape with an unbox at each end; the migration makes it generic and the body
-// does not change. Run: `dotnet fsi Compute.fsx` from this directory (build first).
+// Run: `dotnet fsi Compute.fsx` from this directory (build first).
 
 #I __SOURCE_DIRECTORY__
 #r "nuget: Expecto, 10.2.3"
@@ -29,110 +26,39 @@
 open Shared.Types
 open Shared.Api
 open ServerApi
-open Informedica.Utils.Lib.ConsoleWriter.NewLineNoTime
 
 
 // ---------------------------------------------------------------------------------------------
-// The wrapper (→ ServerApi.Compute.fs)
+// The members (→ ServerApi.FormularyCommand.fs)
 // ---------------------------------------------------------------------------------------------
 
-/// Whether a command needs the formulary loaded.
-[<RequireQualifiedAccess>]
-type Gate =
-    | RequiresLoaded
-    | Open
+module FormularyCommand =
+
+    /// For the log: the record is long and says nothing a log needs.
+    let toString (_: Formulary) = "Formulary"
+
+    let processCmd (env: AppEnv) (form: Formulary) = env.formulary.getFormulary form
 
 
-module Compute =
+module ParenteraliaCommand =
 
-    /// Every computing member: the Session the cookie names is marked seen and told whether the
-    /// record moved on or the Session ended, before the command is computed; without a cookie
-    /// the request computes as it always did. The gate refuses a command that needs the
-    /// formulary while it is not loaded, with the provider's messages. An exception is an
-    /// Error with its message. The token is never logged.
-    let bound
-        (env: AppEnv)
-        (cookie: SessionCookie)
-        (name: 'cmd -> string)
-        (gate: 'cmd -> Gate)
-        (handler: 'cmd -> Async<Result<'resp, string[]>>)
-        (request: Request)
-        : Async<Result<Reply, string[]>>
-        =
-        // the migration makes the envelope generic: `request: Request<'cmd>`, `Reply<'resp>`
-        let cmd: 'cmd = unbox request.Command
+    let toString (_: Parenteralia) = "Parenteralia"
 
-        async {
-            try
-                writeInfoMessage $"Processing command: {name cmd}"
-
-                let! notice =
-                    match cookie.read () with
-                    | None -> async { return None }
-                    | Some id -> env.session.seen id request.Opened
-
-                // an open command never asks the provider: asking may load
-                let! result =
-                    match gate cmd with
-                    | Gate.Open -> handler cmd
-                    | Gate.RequiresLoaded ->
-                        match env.requireLoaded () with
-                        | Some msgs -> async { return Error msgs }
-                        | None -> handler cmd
-
-                let told =
-                    match notice with
-                    | Some(RecordNotice.NewerVersion _) -> ", the record moved on"
-                    | Some(RecordNotice.Ended _) -> ", the Session ended"
-                    | None -> ""
-
-                writeInfoMessage $"Finished processing command: {name cmd}{told}"
-
-                return
-                    result
-                    |> Result.map (fun response ->
-                        {
-                            Response = unbox<Response> response
-                            Notice = notice
-                        }
-                    )
-            with ex ->
-                writeErrorMessage $"Error processing command: {name cmd}\n{ex}"
-                return Error [| ex.Message |]
-        }
+    let processCmd (env: AppEnv) (par: Parenteralia) = env.formulary.getParenteralia par
 
 
-    /// A member that is not computing: the same two log lines around it, nothing else.
-    let logged (what: string) (name: 'cmd -> string) (run: 'cmd -> Async<'resp>) (cmd: 'cmd) =
-        async {
-            writeInfoMessage $"Processing {what}: {name cmd}"
-            let! response = run cmd
-            writeInfoMessage $"Finished processing {what}: {name cmd}"
-            return response
-        }
-
-
-// ---------------------------------------------------------------------------------------------
-// The gate (→ ServerApi.Command.fs; processCmd loses its `gated` and becomes a plain dispatcher)
-// ---------------------------------------------------------------------------------------------
-
-module Command =
-
-    /// The drug names come from the interaction source, not the formulary; everything else
-    /// needs the formulary loaded.
-    let gate =
-        function
-        | InteractionCmd GetDrugNames -> Gate.Open
-        | _ -> Gate.RequiresLoaded
-
-
-// and in `compose` (→ CompositionRoot.fs):
+// and in `compose` (→ CompositionRoot.fs), next to processCommand:
 //
-//     processCommand = Compute.bound env cookie Command.toString Command.gate (Command.processCmd env)
-//     processLaunch = Compute.logged "launch" LaunchCommand.toString (LaunchCommand.processCmd env cookie stateCookie)
-//     processSession = Compute.logged "session" SessionCommand.toString (SessionCommand.processCmd env cookie enrolment)
-//     processSigning = Compute.logged "signing" SigningCommand.toString (SigningCommand.processCmd env cookie)
-//     processAdmin = Compute.logged "admin" AdminCommand.toString (AdminCommand.processCmd env)
+//     processFormulary =
+//         Compute.bound env cookie FormularyCommand.toString (fun _ -> Gate.RequiresLoaded) (FormularyCommand.processCmd env)
+//
+//     processParenteralia =
+//         Compute.bound env cookie ParenteraliaCommand.toString (fun _ -> Gate.RequiresLoaded) (ParenteraliaCommand.processCmd env)
+//
+// on `IServerApi` (→ Shared/Api.fs):
+//
+//     processFormulary: Request<Formulary> -> Async<Result<Reply<Formulary>, string[]>>
+//     processParenteralia: Request<Parenteralia> -> Async<Result<Reply<Parenteralia>, string[]>>
 
 
 // ---------------------------------------------------------------------------------------------
@@ -152,7 +78,7 @@ let cookieOf (id: string option) : SessionCookie =
     }
 
 
-/// An env over a provider whose load failed, the formulary stubbed, the Session's answer given.
+/// An env over a provider whose load failed, the formulary port stubbed, the Session's answer given.
 let envWith (loaded: bool) (told: RecordNotice option) =
     let env =
         Adapters.makeAppEnv (
@@ -167,7 +93,7 @@ let envWith (loaded: bool) (told: RecordNotice option) =
         formulary =
             {
                 getFormulary = fun f -> async { return Ok { f with Markdown = "stubbed" } }
-                getParenteralia = fun _ -> async { return Ok Shared.Models.Parenteralia.empty }
+                getParenteralia = fun p -> async { return Ok { p with Generic = Some "stubbed" } }
             }
         session =
             { env.session with
@@ -176,93 +102,64 @@ let envWith (loaded: bool) (told: RecordNotice option) =
     }
 
 
-let request cmd : Request = { Opened = None; Command = cmd }
-
-
-/// A handler that is not a dispatcher: the formulary only.
-let formularyOnly (env: AppEnv) cmd =
-    match cmd with
-    | FormularyCmd f ->
-        async {
-            let! result = env.formulary.getFormulary f
-            return result |> Result.map FormularyResp
-        }
-    | other -> failwithf "not under test: %A" other
-
-
-let run env cookie gate handler cmd =
-    Compute.bound env cookie Command.toString gate handler (request cmd)
+let processFormulary env cookie (request: Request<Formulary>) =
+    Compute.bound env cookie FormularyCommand.toString (fun _ -> Gate.RequiresLoaded) (FormularyCommand.processCmd env) request
     |> Async.RunSynchronously
 
 
-let formulary = FormularyCmd Shared.Models.Formulary.empty
+let processParenteralia env cookie (request: Request<Parenteralia>) =
+    Compute.bound env cookie ParenteraliaCommand.toString (fun _ -> Gate.RequiresLoaded) (ParenteraliaCommand.processCmd env) request
+    |> Async.RunSynchronously
 
 
 let tests =
     testList
-        "Compute.bound"
+        "processFormulary and processParenteralia"
         [
-            test "without a cookie: computed, nothing told" {
-                let env = envWith true (Some(RecordNotice.Ended SessionEnding.SupersededByLaunch))
-
-                match run env (cookieOf None) Command.gate (formularyOnly env) formulary with
-                | Ok reply ->
-                    reply.Notice |> Expect.isNone "nothing told without a cookie"
-
-                    match reply.Response with
-                    | FormularyResp f -> f.Markdown |> Expect.equal "computed" "stubbed"
-                    | other -> failtest $"expected FormularyResp, got {other}"
-                | Error errs -> failtest $"expected Ok, got {errs}"
-            }
-
-            test "with a cookie: what the Session is told rides on the reply, still computed" {
-                let env = envWith true (Some(RecordNotice.Ended SessionEnding.SupersededByLaunch))
-
-                match run env (cookieOf (Some "s-1")) Command.gate (formularyOnly env) formulary with
-                | Ok reply ->
-                    reply.Notice
-                    |> Expect.equal "the ending" (Some(RecordNotice.Ended SessionEnding.SupersededByLaunch))
-
-                    match reply.Response with
-                    | FormularyResp f -> f.Markdown |> Expect.equal "still computed" "stubbed"
-                    | other -> failtest $"expected FormularyResp, got {other}"
-                | Error errs -> failtest $"expected Ok, got {errs}"
-            }
-
-            test "a command that needs the formulary is refused while it is not loaded" {
-                let env = envWith false None
-
-                match run env (cookieOf None) Command.gate (formularyOnly env) formulary with
-                | Error msgs -> msgs |> Array.exists (fun m -> m.Contains "load failed") |> Expect.isTrue "the messages"
-                | Ok _ -> failtest "expected Error"
-            }
-
-            test "an open command runs while the formulary is not loaded" {
-                let env = envWith false None
-                let names _ = async { return Ok(InteractionResp(DrugNamesLoaded [| "paracetamol" |])) }
-
-                match run env (cookieOf None) Command.gate names (InteractionCmd GetDrugNames) with
-                | Ok reply ->
-                    reply.Response
-                    |> Expect.equal "the names" (InteractionResp(DrugNamesLoaded [| "paracetamol" |]))
-                | Error errs -> failtest $"expected Ok, got {errs}"
-
-                Command.gate (InteractionCmd GetDrugNames) |> Expect.equal "open" Gate.Open
-                Command.gate (InteractionCmd(CheckInteractions [])) |> Expect.equal "gated" Gate.RequiresLoaded
-            }
-
-            test "a throwing handler answers an Error with its message" {
+            test "the formulary answers its own envelope, typed" {
                 let env = envWith true None
-                let throwing _ = async { return invalidOp "boom" }
 
-                run env (cookieOf None) Command.gate throwing formulary
-                |> Expect.equal "the message" (Error [| "boom" |])
+                match processFormulary env (cookieOf None) { Opened = None; Command = Shared.Models.Formulary.empty } with
+                | Ok reply ->
+                    // no family to match on: the answer is a Formulary
+                    reply.Response.Markdown |> Expect.equal "computed" "stubbed"
+                    reply.Notice |> Expect.isNone "nothing told"
+                | Error errs -> failtest $"expected Ok, got {errs}"
             }
 
-            test "logged: the answer passes through" {
-                Compute.logged "admin" AdminCommand.toString (fun _ -> async { return 42 }) (AdminCommand.ValidatePassword "x")
-                |> Async.RunSynchronously
-                |> Expect.equal "through" 42
+            test "the parenteralia answers its own envelope, typed" {
+                let env = envWith true None
+
+                match processParenteralia env (cookieOf None) { Opened = None; Command = Shared.Models.Parenteralia.empty } with
+                | Ok reply -> reply.Response.Generic |> Expect.equal "computed" (Some "stubbed")
+                | Error errs -> failtest $"expected Ok, got {errs}"
+            }
+
+            test "with a cookie: what the Session is told rides on the reply" {
+                let env = envWith true (Some(RecordNotice.Ended SessionEnding.SupersededByLaunch))
+
+                match processFormulary env (cookieOf (Some "s-1")) { Opened = None; Command = Shared.Models.Formulary.empty } with
+                | Ok reply ->
+                    reply.Notice |> Expect.equal "the ending" (Some(RecordNotice.Ended SessionEnding.SupersededByLaunch))
+                    reply.Response.Markdown |> Expect.equal "still computed" "stubbed"
+                | Error errs -> failtest $"expected Ok, got {errs}"
+            }
+
+            test "both are behind the formulary being loaded" {
+                let env = envWith false None
+
+                processFormulary env (cookieOf None) { Opened = None; Command = Shared.Models.Formulary.empty }
+                |> Result.isError
+                |> Expect.isTrue "formulary refused"
+
+                processParenteralia env (cookieOf None) { Opened = None; Command = Shared.Models.Parenteralia.empty }
+                |> Result.isError
+                |> Expect.isTrue "parenteralia refused"
+            }
+
+            test "the log names the family, never the record" {
+                FormularyCommand.toString Shared.Models.Formulary.empty |> Expect.equal "name" "Formulary"
+                ParenteraliaCommand.toString Shared.Models.Parenteralia.empty |> Expect.equal "name" "Parenteralia"
             }
         ]
 

--- a/src/Informedica.GenPRES.Server/Scripts/load.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/load.fsx
@@ -24,6 +24,7 @@
 #load "../ServerApi.StubAdapters.fs"
 #load "../ServerApi.Adapters.fs"
 #load "../ServerApi.Compute.fs"
+#load "../ServerApi.FormularyCommand.fs"
 #load "../ServerApi.AdminCommand.fs"
 #load "../ServerApi.Command.fs"
 #load "../ServerApi.LaunchCommand.fs"

--- a/src/Informedica.GenPRES.Server/ServerApi.Command.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Command.fs
@@ -43,16 +43,6 @@ module Command =
                 let! result = env.orderPlan.filterOrderPlan tp
                 return result |> Result.map (OrderPlanFiltered >> OrderPlanResp)
             }
-        | FormularyCmd form ->
-            async {
-                let! result = env.formulary.getFormulary form
-                return result |> Result.map FormularyResp
-            }
-        | ParenteraliaCmd par ->
-            async {
-                let! result = env.formulary.getParenteralia par
-                return result |> Result.map ParenteraliaResp
-            }
         | NutritionPlanCmd(InitNutritionPlan patient) ->
             async {
                 let! result = env.nutritionPlan.initNutritionPlan patient

--- a/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
@@ -22,6 +22,22 @@ module CompositionRoot =
             // and told, the gate, the exception as an Error
             processCommand = Compute.bound env cookie Command.toString Command.gate (Command.processCmd env)
 
+            processFormulary =
+                Compute.bound
+                    env
+                    cookie
+                    FormularyCommand.toString
+                    (fun _ -> Gate.RequiresLoaded)
+                    (FormularyCommand.processCmd env)
+
+            processParenteralia =
+                Compute.bound
+                    env
+                    cookie
+                    ParenteraliaCommand.toString
+                    (fun _ -> Gate.RequiresLoaded)
+                    (ParenteraliaCommand.processCmd env)
+
             processLaunch =
                 Compute.logged "launch" LaunchCommand.toString (LaunchCommand.processCmd env cookie stateCookie)
 

--- a/src/Informedica.GenPRES.Server/ServerApi.FormularyCommand.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.FormularyCommand.fs
@@ -1,0 +1,22 @@
+namespace ServerApi
+
+open Shared.Types
+
+
+/// The formulary view's member: the formulary port over the request's filter.
+module FormularyCommand =
+
+    /// For the log: the record is long and says nothing a log needs.
+    let toString (_: Formulary) = "Formulary"
+
+
+    let processCmd (env: AppEnv) (form: Formulary) = env.formulary.getFormulary form
+
+
+/// The parenteralia view's member, over the same port.
+module ParenteraliaCommand =
+
+    let toString (_: Parenteralia) = "Parenteralia"
+
+
+    let processCmd (env: AppEnv) (par: Parenteralia) = env.formulary.getParenteralia par

--- a/src/Informedica.GenPRES.Shared/Api.fs
+++ b/src/Informedica.GenPRES.Shared/Api.fs
@@ -10,8 +10,6 @@ module Api =
     type Command =
         | OrderContextCmd of OrderContextCommand * OrderContext
         | OrderPlanCmd of OrderPlanCommand
-        | FormularyCmd of Formulary
-        | ParenteraliaCmd of Parenteralia
         | NutritionPlanCmd of NutritionPlanCommand
         | InteractionCmd of InteractionCommand
 
@@ -64,8 +62,6 @@ module Api =
     type Response =
         | OrderContextResp of OrderContextResponse
         | OrderPlanResp of OrderPlanResponse
-        | FormularyResp of Formulary
-        | ParenteraliaResp of Parenteralia
         | NutritionPlanResp of NutritionPlanResponse
         | InteractionResp of InteractionResponse
 
@@ -150,8 +146,6 @@ module Api =
 
             | OrderPlanCmd(UpdateOrderPlan _) -> "UpdatedOrderPlan"
             | OrderPlanCmd(FilterOrderPlan _) -> "FilterOrderPlan"
-            | FormularyCmd _ -> "FormularyCmd"
-            | ParenteraliaCmd _ -> "ParenteraliaCmd"
             | NutritionPlanCmd(InitNutritionPlan _) -> "InitNutritionPlan"
             | NutritionPlanCmd(UpdateNutritionOrderContext _) -> "UpdateNutritionOrderContext"
             | NutritionPlanCmd(SelectNutritionOrderScenario _) -> "SelectNutritionOrderScenario"
@@ -289,6 +283,10 @@ module Api =
     type IServerApi =
         {
             processCommand: Request -> Async<Result<Reply, string[]>>
+            // one member per use case, each on the same envelope: the formulary and the
+            // parenteralia views ask their own
+            processFormulary: Request<Formulary> -> Async<Result<Reply<Formulary>, string[]>>
+            processParenteralia: Request<Parenteralia> -> Async<Result<Reply<Parenteralia>, string[]>>
             processLaunch: LaunchCommand -> Async<LaunchOutcome>
             processSession: SessionCommand -> Async<SessionResponse>
             processSigning: SigningCommand -> Async<SigningResponse>

--- a/tests/Informedica.GenPRES.Server.Tests/HttpTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/HttpTests.fs
@@ -15,7 +15,7 @@ let cacheControlCases =
         200, "/", "no-cache"
         200, "/index.html", "no-cache"
         200, "/genpres.png", "no-cache"
-        200, "/api/IServerApi/processCommand", "no-cache"
+        200, "/api/IServerApi/processFormulary", "no-cache"
         200, "/assets/index-abc123.js", immutable
         200, "/assets/index-abc123.css", immutable
         200, "/ASSETS/x.js", immutable

--- a/tests/Informedica.GenPRES.Server.Tests/ResourceErrorTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/ResourceErrorTests.fs
@@ -265,11 +265,9 @@ let processCmdGuardTests =
         "Compute.bound IsLoaded guard"
         [
 
-            test "FormularyCmd returns Error when provider IsLoaded = false" {
+            test "processFormulary returns Error when provider IsLoaded = false" {
                 let provider =
                     CachedResourceProvider((fun () -> Error [ errMsg "resources unavailable" ]), None)
-
-                let cmd = Shared.Api.FormularyCmd Formulary.empty
 
                 let env = ServerApi.Adapters.makeAppEnv provider
 
@@ -277,25 +275,23 @@ let processCmdGuardTests =
                     ServerApi.Compute.bound
                         env
                         noCookie
-                        Shared.Api.Command.toString
-                        ServerApi.Command.gate
-                        (ServerApi.Command.processCmd env)
+                        ServerApi.FormularyCommand.toString
+                        (fun _ -> ServerApi.Gate.RequiresLoaded)
+                        (ServerApi.FormularyCommand.processCmd env)
                         {
                             Opened = None
-                            Command = cmd
+                            Command = Formulary.empty
                         }
                     |> Async.RunSynchronously
 
                 result
                 |> Result.isError
-                |> Expect.isTrue "should return Error for FormularyCmd when not loaded"
+                |> Expect.isTrue "should return Error for processFormulary when not loaded"
             }
 
-            test "ParenteraliaCmd returns Error when provider IsLoaded = false" {
+            test "processParenteralia returns Error when provider IsLoaded = false" {
                 let provider =
                     CachedResourceProvider((fun () -> Error [ errMsg "resources unavailable" ]), None)
-
-                let cmd = Shared.Api.ParenteraliaCmd Parenteralia.empty
 
                 let env = ServerApi.Adapters.makeAppEnv provider
 
@@ -303,18 +299,18 @@ let processCmdGuardTests =
                     ServerApi.Compute.bound
                         env
                         noCookie
-                        Shared.Api.Command.toString
-                        ServerApi.Command.gate
-                        (ServerApi.Command.processCmd env)
+                        ServerApi.ParenteraliaCommand.toString
+                        (fun _ -> ServerApi.Gate.RequiresLoaded)
+                        (ServerApi.ParenteraliaCommand.processCmd env)
                         {
                             Opened = None
-                            Command = cmd
+                            Command = Parenteralia.empty
                         }
                     |> Async.RunSynchronously
 
                 result
                 |> Result.isError
-                |> Expect.isTrue "should return Error for ParenteraliaCmd when not loaded"
+                |> Expect.isTrue "should return Error for processParenteralia when not loaded"
             }
         ]
 

--- a/tests/Informedica.GenPRES.Server.Tests/Scripts/load.fsx
+++ b/tests/Informedica.GenPRES.Server.Tests/Scripts/load.fsx
@@ -21,6 +21,7 @@
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.StubAdapters.fs"
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.Adapters.fs"
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.Compute.fs"
+#load "../../../src/Informedica.GenPRES.Server/ServerApi.FormularyCommand.fs"
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.AdminCommand.fs"
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.Command.fs"
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.LaunchCommand.fs"

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -162,7 +162,7 @@ let commandRoutingTests =
         "Stub adapter command routing"
         [
 
-            testAsync "FormularyCmd dispatches to formulary.getFormulary" {
+            testAsync "processFormulary dispatches to formulary.getFormulary, typed" {
                 let returnForm = { Formulary.empty with Markdown = "stubbed" }
 
                 let env =
@@ -172,14 +172,14 @@ let commandRoutingTests =
                         (orderPlanAlwaysOk emptyPlan)
                         (nutritionPlanAlwaysOk emptyNutritionPlan)
 
-                let! result = Command.processCmd env (Api.FormularyCmd Formulary.empty)
+                let! result = FormularyCommand.processCmd env Formulary.empty
 
                 match result with
-                | Ok(Api.FormularyResp f) -> f.Markdown |> Expect.equal "should return stubbed formulary" "stubbed"
-                | other -> failtest $"expected Ok FormularyResp, got {other}"
+                | Ok f -> f.Markdown |> Expect.equal "should return stubbed formulary" "stubbed"
+                | Error errs -> failtest $"expected Ok, got {errs}"
             }
 
-            testAsync "ParenteraliaCmd dispatches to formulary.getParenteralia" {
+            testAsync "processParenteralia dispatches to formulary.getParenteralia, typed" {
                 let env =
                     makeEnv
                         (formularyAlwaysOk Formulary.empty)
@@ -187,11 +187,11 @@ let commandRoutingTests =
                         (orderPlanAlwaysOk emptyPlan)
                         (nutritionPlanAlwaysOk emptyNutritionPlan)
 
-                let! result = Command.processCmd env (Api.ParenteraliaCmd Parenteralia.empty)
+                let! result = ParenteraliaCommand.processCmd env Parenteralia.empty
 
                 match result with
-                | Ok(Api.ParenteraliaResp _) -> ()
-                | other -> failtest $"expected Ok ParenteraliaResp, got {other}"
+                | Ok _ -> ()
+                | Error errs -> failtest $"expected Ok, got {errs}"
             }
 
             testAsync "OrderContextCmd dispatches to orderContext.evaluate" {
@@ -246,7 +246,7 @@ let errorPropagationTests =
         "Stub adapter error propagation"
         [
 
-            testAsync "FormularyCmd propagates port error" {
+            testAsync "processFormulary propagates port error" {
                 let env =
                     makeEnv
                         (formularyAlwaysFails [| "test error" |])
@@ -254,7 +254,7 @@ let errorPropagationTests =
                         (orderPlanAlwaysOk emptyPlan)
                         (nutritionPlanAlwaysOk emptyNutritionPlan)
 
-                let! result = Command.processCmd env (Api.FormularyCmd Formulary.empty)
+                let! result = FormularyCommand.processCmd env Formulary.empty
 
                 match result with
                 | Error msgs -> msgs |> Expect.equal "should propagate error messages" [| "test error" |]
@@ -307,7 +307,7 @@ let requireLoadedTests =
             testAsync "requireLoaded returns Error when not loaded" {
                 let env = makeEnvNotLoaded [| "not ready" |]
 
-                let! result = bound env (Api.FormularyCmd Formulary.empty)
+                let! result = bound env (Api.OrderContextCmd(Api.UpdateOrderContext, emptyCtx))
 
                 match result with
                 | Error msgs -> msgs |> Expect.equal "should return requireLoaded error" [| "not ready" |]
@@ -322,7 +322,7 @@ let requireLoadedTests =
                         (orderPlanAlwaysOk emptyPlan)
                         (nutritionPlanAlwaysOk emptyNutritionPlan)
 
-                let! result = bound env (Api.FormularyCmd Formulary.empty)
+                let! result = bound env (Api.OrderContextCmd(Api.UpdateOrderContext, emptyCtx))
 
                 match result with
                 | Ok _ -> ()
@@ -4539,10 +4539,10 @@ module SessionStubTests =
                 IsDemo = true
             }
 
-        let request opened : Request =
+        let request opened : Request<Formulary> =
             {
                 Opened = opened
-                Command = Api.FormularyCmd Formulary.empty
+                Command = Formulary.empty
             }
 
         let sessionOf env cookie =
@@ -4553,7 +4553,7 @@ module SessionStubTests =
             }
 
         testList
-            "processCommand in a Session"
+            "a computing member in a Session"
             [
                 testAsync "without a cookie: computed as before, nothing told (UC-7)" {
                     let _, env = envWithStub ()
@@ -4561,13 +4561,11 @@ module SessionStubTests =
                     let stateCookie, _ = memoryStateCookie None
                     let api = CompositionRoot.compose settings env cookie stateCookie (noEnrolment ())
 
-                    match! api.processCommand (request None) with
+                    match! api.processFormulary (request None) with
                     | Ok reply ->
                         reply.Notice |> Expect.isNone "nothing told"
 
-                        match reply.Response with
-                        | Api.FormularyResp _ -> ()
-                        | other -> failtest $"expected FormularyResp, got {other}"
+                        reply.Response |> Expect.equal "computed" Formulary.empty
                     | Error errs -> failtest $"expected Ok, got {errs}"
                 }
 
@@ -4590,7 +4588,7 @@ module SessionStubTests =
                     let! opened = sessionOf env cookie
                     let api = CompositionRoot.compose settings env cookie stateCookie (noEnrolment ())
 
-                    match! api.processCommand (request opened.OpenedToken) with
+                    match! api.processFormulary (request opened.OpenedToken) with
                     | Ok reply -> reply.Notice |> Expect.isNone "nothing told"
                     | Error errs -> failtest $"expected Ok, got {errs}"
                 }
@@ -4627,14 +4625,12 @@ module SessionStubTests =
 
                     let api = CompositionRoot.compose settings env cookieA stateCookie (noEnrolment ())
 
-                    match! api.processCommand (request openedA.OpenedToken) with
+                    match! api.processFormulary (request openedA.OpenedToken) with
                     | Ok reply ->
                         reply.Notice
                         |> Expect.equal "ended" (Some(RecordNotice.Ended SessionEnding.SupersededByLaunch))
 
-                        match reply.Response with
-                        | Api.FormularyResp _ -> ()
-                        | other -> failtest $"still computed, got {other}"
+                        reply.Response |> Expect.equal "still computed" Formulary.empty
                     | Error errs -> failtest $"expected Ok, got {errs}"
                 }
 
@@ -4947,7 +4943,7 @@ module BoundTests =
             }
         |> Async.RunSynchronously
 
-    let formulary = Api.FormularyCmd Formulary.empty
+    let formulary = Api.OrderContextCmd(Api.UpdateOrderContext, emptyCtx)
 
     let converters = [| FableJsonConverter() :> JsonConverter |]
 
@@ -4969,8 +4965,8 @@ module BoundTests =
                         reply.Notice |> Expect.isNone "nothing told without a cookie"
 
                         match reply.Response with
-                        | Api.FormularyResp f -> f.Markdown |> Expect.equal "computed" "stubbed"
-                        | other -> failtest $"expected FormularyResp, got {other}"
+                        | Api.OrderContextResp _ -> ()
+                        | other -> failtest $"expected OrderContextResp, got {other}"
                     | Error errs -> failtest $"expected Ok, got {errs}"
                 }
 
@@ -4983,8 +4979,8 @@ module BoundTests =
                         |> Expect.equal "the ending" (Some(RecordNotice.Ended SessionEnding.SupersededByLaunch))
 
                         match reply.Response with
-                        | Api.FormularyResp f -> f.Markdown |> Expect.equal "still computed" "stubbed"
-                        | other -> failtest $"expected FormularyResp, got {other}"
+                        | Api.OrderContextResp _ -> ()
+                        | other -> failtest $"expected OrderContextResp, got {other}"
                     | Error errs -> failtest $"expected Ok, got {errs}"
                 }
 


### PR DESCRIPTION
Step 6 of [plan 654](https://github.com/informedica/GenPRES/blob/master/docs/implementation-plans/654-api-per-use-case.md): the first two families leave `processCommand`. The smallest ones first, so the generic envelope is seen on the browser's wire before the big ones move.

**In this PR (script, per the script-only policy)**

- `Server/Scripts/Compute.fsx` (rewritten): `FormularyCommand` and `ParenteraliaCommand` (`toString`, `processCmd`), the two `compose` lines and the two `IServerApi` members as comments. 5 tests through `Compute.bound`: the typed answers, the Session's notice riding along, both refused while the formulary is not loaded, the log naming the family and never the record.

**Migration (for the maintainer, `.claude/docs/654-pr5-migration.patch`, 10 files, +112/−94)**

`Shared/Api.fs`: `processFormulary: Request<Formulary> -> Async<Result<Reply<Formulary>, string[]>>` and `processParenteralia` on `IServerApi`; `FormularyCmd`, `ParenteraliaCmd`, `FormularyResp`, `ParenteraliaResp` and their `toString` arms gone. New `ServerApi.FormularyCommand.fs` (fsproj, both loaders); the two arms gone from `Command.fs`; `compose` builds both through `Compute.bound` with `Gate.RequiresLoaded`. Client: `createApiMsg` takes the member as its first argument, `Answer<'r>` and `ApiResponse<'r>` typed by what the member answers, `processApiMsg` takes an `apply` per family (`applyFormulary`, `applyParenteralia`; the other families keep `processResponse`), `LoadFormulary` and `LoadParenteralia` on the new members; the `loadFormuarly` typo goes. Tests: routing and error propagation through `FormularyCommand.processCmd`, the guard suites through `bound` with the new members, the composition suite (a Session's notice on a computing member) on `processFormulary`, the `bound` suite's sample command now the order context; `HttpTests` names `/api/IServerApi/processFormulary` as its no-cache sample. Verified in a worktree: build, 284 server tests, Fantomas, Fable, `CheckDependencyRule.fsx`.

After the migration the formulary and parenteralia pages are the browser check for the generic envelope: their requests go to `/api/IServerApi/processFormulary` and `processParenteralia` with `{ Opened; Command }` and answer `{ Response; Notice }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q228qLAaCzuK9Bhq2pEBGc