### PR TITLE
refactor(api): the interaction family as its own member (#654 PR 6)

### DIFF
--- a/src/Informedica.GenPRES.Client/App.fs
+++ b/src/Informedica.GenPRES.Client/App.fs
@@ -110,8 +110,8 @@ module private Elmish =
         | LoadParenteralia of ApiResponse<Parenteralia>
 
         | CheckInteractions of string list
-        | LoadInteractionsResult of ApiResponse<Api.Response>
-        | LoadInteractionDrugNames of ApiResponse<Api.Response>
+        | LoadInteractionsResult of ApiResponse<Api.InteractionResponse>
+        | LoadInteractionDrugNames of ApiResponse<Api.InteractionResponse>
 
         | UpdateLanguage of Localization.Locales
         | LoadLocalization of AsyncOperationStatus<Result<string[][], string>>
@@ -243,23 +243,6 @@ module private Elmish =
             { state with OrderPlan = Resolved tp }, cmd
         | Api.NutritionPlanResp(Api.NutritionPlanInitialised plan)
         | Api.NutritionPlanResp(Api.NutritionPlanUpdated plan) -> { state with NutritionPlan = Resolved plan }, Cmd.none
-        | Api.InteractionResp(Api.InteractionsChecked interactions) ->
-            let newState =
-                if interactions.Length > 0 then
-                    { state with
-                        SnackbarMsg = $"Er zijn %i{interactions.Length} interactie(s) gevonden"
-                        SnackbarOpen = true
-                        SnackbarSeverity = "warning"
-                    }
-                else
-                    { state with
-                        SnackbarMsg = ""
-                        SnackbarOpen = false
-                    }
-
-            { newState with Interactions = Resolved interactions }, Cmd.none
-        | Api.InteractionResp(Api.DrugNamesLoaded names) ->
-            { state with InteractionDrugNames = Resolved names }, Cmd.none
 
 
     /// A reload settles when the refresh it started has answered: the order context over a
@@ -337,6 +320,27 @@ module private Elmish =
 
     let applyParenteralia (state: State) (par: Parenteralia) =
         { state with Parenteralia = Resolved par }, Cmd.none
+
+
+    let applyInteraction (state: State) (response: Api.InteractionResponse) =
+        match response with
+        | Api.InteractionResponse.InteractionsChecked interactions ->
+            let newState =
+                if interactions.Length > 0 then
+                    { state with
+                        SnackbarMsg = $"Er zijn %i{interactions.Length} interactie(s) gevonden"
+                        SnackbarOpen = true
+                        SnackbarSeverity = "warning"
+                    }
+                else
+                    { state with
+                        SnackbarMsg = ""
+                        SnackbarOpen = false
+                    }
+
+            { newState with Interactions = Resolved interactions }, Cmd.none
+        | Api.InteractionResponse.DrugNamesLoaded names ->
+            { state with InteractionDrugNames = Resolved names }, Cmd.none
 
 
     let loadOrderContext opened resp =
@@ -1669,10 +1673,10 @@ module private Elmish =
                 Cmd.none
             else
                 { state with Interactions = InProgress },
-                Api.InteractionCmd(Api.CheckInteractions drugs)
-                |> createApiMsg serverApi.processCommand (tokenOf state.Session) LoadInteractionsResult
+                Api.InteractionCommand.CheckInteractions drugs
+                |> createApiMsg serverApi.processInteraction (tokenOf state.Session) LoadInteractionsResult
 
-        | LoadInteractionsResult(Finished(Ok msg)) -> msg |> processOk
+        | LoadInteractionsResult(Finished(Ok msg)) -> processApiMsg state msg applyInteraction
         | LoadInteractionsResult(Finished(Error err)) ->
             ({ state with Interactions = HasNotStartedYet }, Cmd.none) |> processError err
         | LoadInteractionsResult _ -> state, Cmd.none
@@ -1682,11 +1686,11 @@ module private Elmish =
             | InProgress -> state, Cmd.none
             | _ ->
                 { state with InteractionDrugNames = InProgress },
-                Api.InteractionCmd Api.GetDrugNames
-                |> createApiMsg serverApi.processCommand (tokenOf state.Session) LoadInteractionDrugNames
+                Api.InteractionCommand.GetDrugNames
+                |> createApiMsg serverApi.processInteraction (tokenOf state.Session) LoadInteractionDrugNames
 
         | LoadInteractionDrugNames(Finished(Ok msg)) ->
-            let state, cmd = msg |> processOk
+            let state, cmd = processApiMsg state msg applyInteraction
             { state with DrugNameRetries = 0 }, cmd
         | LoadInteractionDrugNames(Finished(Error _)) ->
             let retries = state.DrugNameRetries + 1

--- a/src/Informedica.GenPRES.Server/Informedica.GenPRES.Server.fsproj
+++ b/src/Informedica.GenPRES.Server/Informedica.GenPRES.Server.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="ServerApi.Adapters.fs" />
     <Compile Include="ServerApi.Compute.fs" />
     <Compile Include="ServerApi.FormularyCommand.fs" />
+    <Compile Include="ServerApi.InteractionCommand.fs" />
     <Compile Include="ServerApi.AdminCommand.fs" />
     <Compile Include="ServerApi.Command.fs" />
     <Compile Include="ServerApi.LaunchCommand.fs" />

--- a/src/Informedica.GenPRES.Server/Scripts/Compute.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/Compute.fsx
@@ -1,20 +1,19 @@
-// The first two members peeled off processCommand (plan 654, step 6): `processFormulary` and
-// `processParenteralia`, each a `Request<_>` of its own command answered with a `Reply<_>` of
-// its own answer, built through `Compute.bound` like every computing member. The smallest
-// families first, so the generic envelope is seen on the browser's wire before the big ones
-// move. `FormularyCmd`, `ParenteraliaCmd`, `FormularyResp` and `ParenteraliaResp` leave
-// `Command` and `Response` with the migration.
+// The interaction member (plan 654, step 7): `processInteraction`, a `Request<InteractionCommand>`
+// answered with a `Reply<InteractionResponse>` through `Compute.bound`. This family carries the
+// one gate that differs per command: the drug names come from the interaction source and are
+// served while the formulary is not loaded, a check over a plan's drugs needs it. With this
+// family gone from `Command`, every command left there needs the formulary, and `Command.gate`
+// says so without a match.
 //
 // Script-first draft (script-only policy) of:
-//   - `FormularyCommand` and `ParenteraliaCommand` (`toString`, `processCmd`) → new
-//     `ServerApi.FormularyCommand.fs`, compiled after `Compute.fs` (fsproj, both loaders);
-//   - `processFormulary` and `processParenteralia` on `IServerApi` → `Shared/Api.fs`, the four
-//     cases and their `toString` arms deleted there and the two arms in `Command.fs`;
-//   - the two members in `compose` → `CompositionRoot.fs`;
-//   - the client: `createApiMsg` over the member, `Answer<'r>`/`ApiResponse<'r>`,
-//     `processApiMsg` with an `apply` per family, `LoadFormulary`/`LoadParenteralia` on the new
-//     members (in the migration patch, since the client cannot compile against members that do
-//     not exist yet).
+//   - `InteractionCommand` and `InteractionResponse` as qualified-access types with
+//     `InteractionCommand.toString`, and `processInteraction` on `IServerApi` → `Shared/Api.fs`
+//     (restated here under `Api654`: a script cannot add or qualify cases of `Shared.Api`);
+//   - `InteractionCommand.gate` and `processCmd` → new `ServerApi.InteractionCommand.fs`,
+//     compiled after `FormularyCommand.fs` (fsproj, both loaders);
+//   - `Command.gate` constant, the two arms gone → `ServerApi.Command.fs`;
+//   - the member in `compose` → `CompositionRoot.fs`;
+//   - the client's `applyInteraction` and the two loads on the member (in the patch).
 //
 // Run: `dotnet fsi Compute.fsx` from this directory (build first).
 
@@ -29,36 +28,79 @@ open ServerApi
 
 
 // ---------------------------------------------------------------------------------------------
-// The members (→ ServerApi.FormularyCommand.fs)
+// The wire (→ Shared/Api.fs)
 // ---------------------------------------------------------------------------------------------
 
-module FormularyCommand =
+module Api654 =
 
-    /// For the log: the record is long and says nothing a log needs.
-    let toString (_: Formulary) = "Formulary"
-
-    let processCmd (env: AppEnv) (form: Formulary) = env.formulary.getFormulary form
-
-
-module ParenteraliaCommand =
-
-    let toString (_: Parenteralia) = "Parenteralia"
-
-    let processCmd (env: AppEnv) (par: Parenteralia) = env.formulary.getParenteralia par
+    /// The interaction family: the drug names of the interaction source, and a check over the
+    /// drugs of a plan.
+    [<RequireQualifiedAccess>]
+    type InteractionCommand =
+        | CheckInteractions of string list
+        // from the interaction source, not the formulary: served while the formulary is not loaded
+        | GetDrugNames
 
 
-// and in `compose` (→ CompositionRoot.fs), next to processCommand:
+    [<RequireQualifiedAccess>]
+    type InteractionResponse =
+        | InteractionsChecked of DrugInteraction[]
+        | DrugNamesLoaded of string[]
+
+
+    module InteractionCommand =
+
+        /// For the log: never the drug list.
+        let toString cmd =
+            match cmd with
+            | InteractionCommand.CheckInteractions _ -> "CheckInteractions"
+            | InteractionCommand.GetDrugNames -> "GetDrugNames"
+
+
+    // on `IServerApi`:
+    //
+    //     processInteraction: Request<InteractionCommand> -> Async<Result<Reply<InteractionResponse>, string[]>>
+
+
+// ---------------------------------------------------------------------------------------------
+// The member (→ ServerApi.InteractionCommand.fs)
+// ---------------------------------------------------------------------------------------------
+
+module InteractionCommand =
+
+    open Api654
+
+    /// The drug names come from the interaction source, not the formulary; a check over a
+    /// plan's drugs needs the formulary loaded.
+    let gate =
+        function
+        | InteractionCommand.GetDrugNames -> Gate.Open
+        | InteractionCommand.CheckInteractions _ -> Gate.RequiresLoaded
+
+
+    let processCmd (env: AppEnv) (cmd: InteractionCommand) =
+        match cmd with
+        | InteractionCommand.GetDrugNames ->
+            async {
+                let! result = env.interaction.getDrugNames ()
+                return result |> Result.map (List.toArray >> InteractionResponse.DrugNamesLoaded)
+            }
+        | InteractionCommand.CheckInteractions drugs ->
+            async {
+                let! result = env.interaction.checkInteractions drugs
+                return result |> Result.map (List.toArray >> InteractionResponse.InteractionsChecked)
+            }
+
+
+// and (→ ServerApi.Command.fs), once no open command is left in Command:
 //
-//     processFormulary =
-//         Compute.bound env cookie FormularyCommand.toString (fun _ -> Gate.RequiresLoaded) (FormularyCommand.processCmd env)
+//     /// Every command left here needs the formulary loaded. Applied by Compute.bound.
+//     let gate (_: Command) = Gate.RequiresLoaded
 //
-//     processParenteralia =
-//         Compute.bound env cookie ParenteraliaCommand.toString (fun _ -> Gate.RequiresLoaded) (ParenteraliaCommand.processCmd env)
+// and in `compose` (→ CompositionRoot.fs):
 //
-// on `IServerApi` (→ Shared/Api.fs):
-//
-//     processFormulary: Request<Formulary> -> Async<Result<Reply<Formulary>, string[]>>
-//     processParenteralia: Request<Parenteralia> -> Async<Result<Reply<Parenteralia>, string[]>>
+//     processInteraction =
+//         Compute.bound env cookie InteractionCommand.toString InteractionCommand.gate (InteractionCommand.processCmd env)
 
 
 // ---------------------------------------------------------------------------------------------
@@ -68,6 +110,7 @@ module ParenteraliaCommand =
 open Expecto
 open Expecto.Flip
 open Informedica.GenForm.Lib
+open Api654
 
 
 let cookieOf (id: string option) : SessionCookie =
@@ -78,8 +121,10 @@ let cookieOf (id: string option) : SessionCookie =
     }
 
 
-/// An env over a provider whose load failed, the formulary port stubbed, the Session's answer given.
-let envWith (loaded: bool) (told: RecordNotice option) =
+/// An env over a provider whose load failed, the interaction port stubbed and counted.
+let envWith (loaded: bool) =
+    let asked = ref 0
+
     let env =
         Adapters.makeAppEnv (
             Resources.CachedResourceProvider(
@@ -88,78 +133,66 @@ let envWith (loaded: bool) (told: RecordNotice option) =
             )
         )
 
+    asked,
     { env with
-        requireLoaded = if loaded then (fun () -> None) else env.requireLoaded
-        formulary =
+        requireLoaded =
+            fun () ->
+                asked.Value <- asked.Value + 1
+                if loaded then None else env.requireLoaded ()
+        interaction =
             {
-                getFormulary = fun f -> async { return Ok { f with Markdown = "stubbed" } }
-                getParenteralia = fun p -> async { return Ok { p with Generic = Some "stubbed" } }
-            }
-        session =
-            { env.session with
-                seen = fun _ _ -> async { return told }
+                checkInteractions = fun drugs -> async { return Ok [] }
+                getDrugNames = fun () -> async { return Ok [ "paracetamol"; "ibuprofen" ] }
             }
     }
 
 
-let processFormulary env cookie (request: Request<Formulary>) =
-    Compute.bound env cookie FormularyCommand.toString (fun _ -> Gate.RequiresLoaded) (FormularyCommand.processCmd env) request
-    |> Async.RunSynchronously
-
-
-let processParenteralia env cookie (request: Request<Parenteralia>) =
-    Compute.bound env cookie ParenteraliaCommand.toString (fun _ -> Gate.RequiresLoaded) (ParenteraliaCommand.processCmd env) request
+let processInteraction env cookie (request: Request<InteractionCommand>) =
+    Compute.bound env cookie InteractionCommand.toString InteractionCommand.gate (InteractionCommand.processCmd env) request
     |> Async.RunSynchronously
 
 
 let tests =
     testList
-        "processFormulary and processParenteralia"
+        "processInteraction"
         [
-            test "the formulary answers its own envelope, typed" {
-                let env = envWith true None
+            test "the drug names are served while the formulary is not loaded, and the provider is not asked" {
+                let asked, env = envWith false
 
-                match processFormulary env (cookieOf None) { Opened = None; Command = Shared.Models.Formulary.empty } with
+                match processInteraction env (cookieOf None) { Opened = None; Command = InteractionCommand.GetDrugNames } with
                 | Ok reply ->
-                    // no family to match on: the answer is a Formulary
-                    reply.Response.Markdown |> Expect.equal "computed" "stubbed"
-                    reply.Notice |> Expect.isNone "nothing told"
+                    reply.Response
+                    |> Expect.equal "the names" (InteractionResponse.DrugNamesLoaded [| "paracetamol"; "ibuprofen" |])
                 | Error errs -> failtest $"expected Ok, got {errs}"
+
+                asked.Value |> Expect.equal "never asked: asking may load" 0
             }
 
-            test "the parenteralia answers its own envelope, typed" {
-                let env = envWith true None
+            test "a check needs the formulary: refused while not loaded, computed when loaded" {
+                let asked, env = envWith false
 
-                match processParenteralia env (cookieOf None) { Opened = None; Command = Shared.Models.Parenteralia.empty } with
-                | Ok reply -> reply.Response.Generic |> Expect.equal "computed" (Some "stubbed")
-                | Error errs -> failtest $"expected Ok, got {errs}"
-            }
-
-            test "with a cookie: what the Session is told rides on the reply" {
-                let env = envWith true (Some(RecordNotice.Ended SessionEnding.SupersededByLaunch))
-
-                match processFormulary env (cookieOf (Some "s-1")) { Opened = None; Command = Shared.Models.Formulary.empty } with
-                | Ok reply ->
-                    reply.Notice |> Expect.equal "the ending" (Some(RecordNotice.Ended SessionEnding.SupersededByLaunch))
-                    reply.Response.Markdown |> Expect.equal "still computed" "stubbed"
-                | Error errs -> failtest $"expected Ok, got {errs}"
-            }
-
-            test "both are behind the formulary being loaded" {
-                let env = envWith false None
-
-                processFormulary env (cookieOf None) { Opened = None; Command = Shared.Models.Formulary.empty }
+                processInteraction env (cookieOf None) { Opened = None; Command = InteractionCommand.CheckInteractions [ "a"; "b" ] }
                 |> Result.isError
-                |> Expect.isTrue "formulary refused"
+                |> Expect.isTrue "refused"
 
-                processParenteralia env (cookieOf None) { Opened = None; Command = Shared.Models.Parenteralia.empty }
-                |> Result.isError
-                |> Expect.isTrue "parenteralia refused"
+                asked.Value |> Expect.equal "asked once" 1
+
+                let _, env = envWith true
+
+                match processInteraction env (cookieOf None) { Opened = None; Command = InteractionCommand.CheckInteractions [ "a"; "b" ] } with
+                | Ok reply -> reply.Response |> Expect.equal "checked" (InteractionResponse.InteractionsChecked [||])
+                | Error errs -> failtest $"expected Ok, got {errs}"
             }
 
-            test "the log names the family, never the record" {
-                FormularyCommand.toString Shared.Models.Formulary.empty |> Expect.equal "name" "Formulary"
-                ParenteraliaCommand.toString Shared.Models.Parenteralia.empty |> Expect.equal "name" "Parenteralia"
+            test "the gate per command" {
+                InteractionCommand.gate InteractionCommand.GetDrugNames |> Expect.equal "open" Gate.Open
+                InteractionCommand.gate (InteractionCommand.CheckInteractions []) |> Expect.equal "gated" Gate.RequiresLoaded
+            }
+
+            test "the log names the command, never the drugs" {
+                let line = InteractionCommand.toString (InteractionCommand.CheckInteractions [ "secret-drug" ])
+                line |> Expect.equal "name" "CheckInteractions"
+                InteractionCommand.toString InteractionCommand.GetDrugNames |> Expect.equal "name" "GetDrugNames"
             }
         ]
 

--- a/src/Informedica.GenPRES.Server/Scripts/load.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/load.fsx
@@ -25,6 +25,7 @@
 #load "../ServerApi.Adapters.fs"
 #load "../ServerApi.Compute.fs"
 #load "../ServerApi.FormularyCommand.fs"
+#load "../ServerApi.InteractionCommand.fs"
 #load "../ServerApi.AdminCommand.fs"
 #load "../ServerApi.Command.fs"
 #load "../ServerApi.LaunchCommand.fs"

--- a/src/Informedica.GenPRES.Server/ServerApi.Command.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Command.fs
@@ -6,28 +6,14 @@ module Command =
     open Shared.Api
 
 
-    /// The drug names come from the interaction source, not the formulary; everything else
-    /// needs the formulary loaded. Applied by Compute.bound, not here.
-    let gate =
-        function
-        | InteractionCmd GetDrugNames -> Gate.Open
-        | _ -> Gate.RequiresLoaded
+    /// Every command left here needs the formulary loaded. Applied by Compute.bound, not here.
+    let gate (_: Command) = Gate.RequiresLoaded
 
 
     /// The dispatcher: each command to its port. Gating, logging and the Session notice are
     /// Compute.bound's.
     let processCmd (env: AppEnv) cmd =
         match cmd with
-        | InteractionCmd GetDrugNames ->
-            async {
-                let! result = env.interaction.getDrugNames ()
-                return result |> Result.map (List.toArray >> DrugNamesLoaded >> InteractionResp)
-            }
-        | InteractionCmd(CheckInteractions drugs) ->
-            async {
-                let! result = env.interaction.checkInteractions drugs
-                return result |> Result.map (List.toArray >> InteractionsChecked >> InteractionResp)
-            }
         | OrderContextCmd(ctxCmd, ctx) ->
             async {
                 let! result = env.orderContext.evaluate ctxCmd ctx

--- a/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
@@ -38,6 +38,15 @@ module CompositionRoot =
                     (fun _ -> Gate.RequiresLoaded)
                     (ParenteraliaCommand.processCmd env)
 
+            // the one member whose gate differs per command: the drug names run open
+            processInteraction =
+                Compute.bound
+                    env
+                    cookie
+                    InteractionCommand.toString
+                    InteractionCommand.gate
+                    (InteractionCommand.processCmd env)
+
             processLaunch =
                 Compute.logged "launch" LaunchCommand.toString (LaunchCommand.processCmd env cookie stateCookie)
 

--- a/src/Informedica.GenPRES.Server/ServerApi.InteractionCommand.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.InteractionCommand.fs
@@ -1,0 +1,29 @@
+namespace ServerApi
+
+
+/// The interaction member: the drug names and the check, over the interaction port.
+module InteractionCommand =
+
+    open Shared.Api
+
+
+    /// The drug names come from the interaction source, not the formulary; a check over a
+    /// plan's drugs needs the formulary loaded.
+    let gate =
+        function
+        | InteractionCommand.GetDrugNames -> Gate.Open
+        | InteractionCommand.CheckInteractions _ -> Gate.RequiresLoaded
+
+
+    let processCmd (env: AppEnv) (cmd: InteractionCommand) =
+        match cmd with
+        | InteractionCommand.GetDrugNames ->
+            async {
+                let! result = env.interaction.getDrugNames ()
+                return result |> Result.map (List.toArray >> InteractionResponse.DrugNamesLoaded)
+            }
+        | InteractionCommand.CheckInteractions drugs ->
+            async {
+                let! result = env.interaction.checkInteractions drugs
+                return result |> Result.map (List.toArray >> InteractionResponse.InteractionsChecked)
+            }

--- a/src/Informedica.GenPRES.Shared/Api.fs
+++ b/src/Informedica.GenPRES.Shared/Api.fs
@@ -11,7 +11,6 @@ module Api =
         | OrderContextCmd of OrderContextCommand * OrderContext
         | OrderPlanCmd of OrderPlanCommand
         | NutritionPlanCmd of NutritionPlanCommand
-        | InteractionCmd of InteractionCommand
 
     and OrderContextCommand =
         | UpdateOrderContext
@@ -55,15 +54,10 @@ module Api =
         | AddNutritionContext of NutritionPlan * NutritionCategory
         | RemoveNutritionContext of NutritionPlan * string
 
-    and InteractionCommand =
-        | CheckInteractions of string list
-        | GetDrugNames
-
     type Response =
         | OrderContextResp of OrderContextResponse
         | OrderPlanResp of OrderPlanResponse
         | NutritionPlanResp of NutritionPlanResponse
-        | InteractionResp of InteractionResponse
 
     and OrderContextResponse = OrderContextResult of OrderContext
 
@@ -74,10 +68,6 @@ module Api =
     and NutritionPlanResponse =
         | NutritionPlanInitialised of NutritionPlan
         | NutritionPlanUpdated of NutritionPlan
-
-    and InteractionResponse =
-        | InteractionsChecked of DrugInteraction[]
-        | DrugNamesLoaded of string[]
 
 
     /// Every computing request: the command and the OpenedToken the Session holds.
@@ -152,8 +142,6 @@ module Api =
             | NutritionPlanCmd(NavigateNutritionOrderContext _) -> "NavigateNutritionOrderContext"
             | NutritionPlanCmd(AddNutritionContext _) -> "AddNutritionContext"
             | NutritionPlanCmd(RemoveNutritionContext _) -> "RemoveNutritionContext"
-            | InteractionCmd(CheckInteractions _) -> "CheckInteractions"
-            | InteractionCmd GetDrugNames -> "GetDrugNames"
 
 
     /// The launch command family. Cut from the session family at the authentication boundary:
@@ -264,6 +252,30 @@ module Api =
             | AdminCommand.ReloadResources _ -> "ReloadResources"
 
 
+    /// The interaction family: the drug names of the interaction source, and a check over the
+    /// drugs of a plan.
+    [<RequireQualifiedAccess>]
+    type InteractionCommand =
+        | CheckInteractions of string list
+        // from the interaction source, not the formulary: served while the formulary is not loaded
+        | GetDrugNames
+
+
+    [<RequireQualifiedAccess>]
+    type InteractionResponse =
+        | InteractionsChecked of DrugInteraction[]
+        | DrugNamesLoaded of string[]
+
+
+    module InteractionCommand =
+
+        /// For the log: never the drug list.
+        let toString cmd =
+            match cmd with
+            | InteractionCommand.CheckInteractions _ -> "CheckInteractions"
+            | InteractionCommand.GetDrugNames -> "GetDrugNames"
+
+
     /// Defines how routes are generated on server and mapped from the client
     let routerPaths typeName method = $"/api/%s{typeName}/%s{method}"
 
@@ -287,6 +299,7 @@ module Api =
             // parenteralia views ask their own
             processFormulary: Request<Formulary> -> Async<Result<Reply<Formulary>, string[]>>
             processParenteralia: Request<Parenteralia> -> Async<Result<Reply<Parenteralia>, string[]>>
+            processInteraction: Request<InteractionCommand> -> Async<Result<Reply<InteractionResponse>, string[]>>
             processLaunch: LaunchCommand -> Async<LaunchOutcome>
             processSession: SessionCommand -> Async<SessionResponse>
             processSigning: SigningCommand -> Async<SigningResponse>

--- a/tests/Informedica.GenPRES.Server.Tests/Scripts/load.fsx
+++ b/tests/Informedica.GenPRES.Server.Tests/Scripts/load.fsx
@@ -22,6 +22,7 @@
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.Adapters.fs"
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.Compute.fs"
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.FormularyCommand.fs"
+#load "../../../src/Informedica.GenPRES.Server/ServerApi.InteractionCommand.fs"
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.AdminCommand.fs"
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.Command.fs"
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.LaunchCommand.fs"

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -4945,6 +4945,19 @@ module BoundTests =
 
     let formulary = Api.OrderContextCmd(Api.UpdateOrderContext, emptyCtx)
 
+    let runInteraction env cookie cmd =
+        Compute.bound
+            env
+            cookie
+            InteractionCommand.toString
+            InteractionCommand.gate
+            (InteractionCommand.processCmd env)
+            {
+                Opened = None
+                Command = cmd
+            }
+        |> Async.RunSynchronously
+
     let converters = [| FableJsonConverter() :> JsonConverter |]
 
     let toJson (v: 'a) =
@@ -4994,17 +5007,20 @@ module BoundTests =
                 test "an open command runs while the formulary is not loaded" {
                     let env = envWith false None
 
-                    match run env (cookieOf None) (Command.processCmd env) (Api.InteractionCmd Api.GetDrugNames) with
+                    match runInteraction env (cookieOf None) InteractionCommand.GetDrugNames with
                     | Ok reply ->
                         reply.Response
-                        |> Expect.equal "the names" (Api.InteractionResp(Api.DrugNamesLoaded [||]))
+                        |> Expect.equal "the names" (InteractionResponse.DrugNamesLoaded [||])
                     | Error errs -> failtest $"expected Ok, got {errs}"
 
-                    Command.gate (Api.InteractionCmd Api.GetDrugNames)
+                    InteractionCommand.gate InteractionCommand.GetDrugNames
                     |> Expect.equal "open" Gate.Open
 
-                    Command.gate (Api.InteractionCmd(Api.CheckInteractions []))
+                    InteractionCommand.gate (InteractionCommand.CheckInteractions [])
                     |> Expect.equal "gated" Gate.RequiresLoaded
+
+                    Command.gate formulary
+                    |> Expect.equal "every command left is gated" Gate.RequiresLoaded
                 }
 
                 test "an open command never asks the provider whether it is loaded" {
@@ -5018,7 +5034,7 @@ module BoundTests =
                                     None
                         }
 
-                    run env (cookieOf None) (Command.processCmd env) (Api.InteractionCmd Api.GetDrugNames)
+                    runInteraction env (cookieOf None) InteractionCommand.GetDrugNames
                     |> Result.isOk
                     |> Expect.isTrue "computed"
 


### PR DESCRIPTION
Step 7 of [plan 654](https://github.com/informedica/GenPRES/blob/master/docs/implementation-plans/654-api-per-use-case.md): the interaction family leaves `processCommand`. It is the one family whose gate differs per command, so it introduces the per-command gate: the drug names come from the interaction source and are served while the formulary is not loaded; a check over a plan's drugs needs it. With it gone, every command left in `Command` needs the formulary and `Command.gate` says so without a match.

**In this PR (script, per the script-only policy)**

- `Server/Scripts/Compute.fsx` (rewritten): `InteractionCommand`/`InteractionResponse` as qualified-access types with `toString`, `InteractionCommand.gate` and `processCmd`, the `compose` line and the `IServerApi` member as comments. 4 tests through `Compute.bound`: the names served and the provider never asked, the check refused then computed, the gate per command, the log never naming the drugs.

**Migration (for the maintainer, `.claude/docs/654-pr6-migration.patch`, 8 files, +89/−58)**

`Shared/Api.fs`: `[<RequireQualifiedAccess>] InteractionCommand` and `InteractionResponse` with `InteractionCommand.toString`, `processInteraction: Request<InteractionCommand> -> Async<Result<Reply<InteractionResponse>, string[]>>`; `InteractionCmd`/`InteractionResp` and their `toString` arms gone. New `ServerApi.InteractionCommand.fs` (fsproj, both loaders); `Command.gate` is a constant `RequiresLoaded` and the two arms are gone; `compose` builds the member through `bound` with `InteractionCommand.gate`. Client: `applyInteraction` (the snackbar and the two state slices), both loads on `processInteraction`, the answers typed `InteractionResponse`. Tests: the two open-command `bound` tests run through the interaction member, and one asserts `Command.gate` is now always gated. Verified in a worktree: build, 284 server tests, Fantomas, Fable, `CheckDependencyRule.fsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q228qLAaCzuK9Bhq2pEBGc