### PR TITLE
feat(server): the one plan, nutrition included (#654 PR 7a)

### DIFF
--- a/src/Informedica.GenPRES.Server/Informedica.GenPRES.Server.fsproj
+++ b/src/Informedica.GenPRES.Server/Informedica.GenPRES.Server.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="ServerApi.Compute.fs" />
     <Compile Include="ServerApi.FormularyCommand.fs" />
     <Compile Include="ServerApi.InteractionCommand.fs" />
+    <Compile Include="ServerApi.PlanCommand.fs" />
     <Compile Include="ServerApi.AdminCommand.fs" />
     <Compile Include="ServerApi.Command.fs" />
     <Compile Include="ServerApi.LaunchCommand.fs" />

--- a/src/Informedica.GenPRES.Server/Scripts/Compute.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/Compute.fsx
@@ -1,28 +1,33 @@
-// The interaction member (plan 654, step 7): `processInteraction`, a `Request<InteractionCommand>`
-// answered with a `Reply<InteractionResponse>` through `Compute.bound`. This family carries the
-// one gate that differs per command: the drug names come from the interaction source and are
-// served while the formulary is not loaded, a check over a plan's drugs needs it. With this
-// family gone from `Command`, every command left there needs the formulary, and `Command.gate`
-// says so without a match.
+// The one plan (plan 654, step 8a): the nutrition plan is a subset of the order plan, and only
+// the order plan is signed, nutrition included. `OrderPlan` gains `NutritionContexts`, the
+// workbenches that produce orders by category, and one rule makes one signature cover them:
+// a context narrowed to exactly one scenario has that scenario in `plan.Scenarios`, upserted by
+// order id; a context with several candidates contributes nothing yet; a removed context takes
+// its order with it. Totals are computed once, over `Scenarios`. One command family,
+// `PlanCommand`, served by one member, `processOrderPlan`.
 //
 // Script-first draft (script-only policy) of:
-//   - `InteractionCommand` and `InteractionResponse` as qualified-access types with
-//     `InteractionCommand.toString`, and `processInteraction` on `IServerApi` → `Shared/Api.fs`
-//     (restated here under `Api654`: a script cannot add or qualify cases of `Shared.Api`);
-//   - `InteractionCommand.gate` and `processCmd` → new `ServerApi.InteractionCommand.fs`,
-//     compiled after `FormularyCommand.fs` (fsproj, both loaders);
-//   - `Command.gate` constant, the two arms gone → `ServerApi.Command.fs`;
-//   - the member in `compose` → `CompositionRoot.fs`;
-//   - the client's `applyInteraction` and the two loads on the member (in the patch).
+//   - `OrderPlan.NutritionContexts` (with `NutritionCategory` and `NutritionContext` declared
+//     before it) → `Shared/Types.fs`; `OrderPlan.create` → `Shared/Models.fs`;
+//   - `PlanCommand` and `PlanCommand.toString`, `processOrderPlan` → `Shared/Api.fs`;
+//   - `PlanPort` and `AppEnv.plan` → `Ports.fs`; `PlanService` → `Services.fs`; `makePlanPort`
+//     → `Adapters.fs`; `PlanCommand.processCmd` → new `ServerApi.PlanCommand.fs`; the member in
+//     `compose` → `CompositionRoot.fs`.
 //
-// Run: `dotnet fsi Compute.fsx` from this directory (build first).
+// The shared `OrderPlan` has no `NutritionContexts` while this script runs, so the rules are
+// drafted over the pieces they read (the contexts, the orders) and the service over a local
+// record of the target shape. The old plan families stay served until the client moves (8b)
+// and are deleted after (8c). Run: `dotnet fsi Compute.fsx` from this directory (build first).
 
 #I __SOURCE_DIRECTORY__
 #r "nuget: Expecto, 10.2.3"
 
 #load "load.fsx"
 
+open System
+open Shared
 open Shared.Types
+open Shared.Models
 open Shared.Api
 open ServerApi
 
@@ -33,74 +38,131 @@ open ServerApi
 
 module Api654 =
 
-    /// The interaction family: the drug names of the interaction source, and a check over the
-    /// drugs of a plan.
+    /// The plan command family: the order plan, nutrition included.
     [<RequireQualifiedAccess>]
-    type InteractionCommand =
-        | CheckInteractions of string list
-        // from the interaction source, not the formulary: served while the formulary is not loaded
-        | GetDrugNames
+    type PlanCommand =
+        // the plan as it is, totals recomputed over its orders
+        | Recalculate of OrderPlan
+        // an order-context command evaluated and folded into the plan: into the nutrition context
+        // named, or into the selected scenario when None
+        | Navigate of OrderPlan * contextId: string option * OrderContextCommand * OrderContext
+        // a nutrition context for the category, its filter discovered
+        | AddContext of OrderPlan * NutritionCategory
+        // the nutrition context removed with its order; a feeding takes its supplements with it
+        | RemoveContext of OrderPlan * contextId: string
 
 
-    [<RequireQualifiedAccess>]
-    type InteractionResponse =
-        | InteractionsChecked of DrugInteraction[]
-        | DrugNamesLoaded of string[]
+    module PlanCommand =
 
-
-    module InteractionCommand =
-
-        /// For the log: never the drug list.
+        /// For the log: never the plan.
         let toString cmd =
             match cmd with
-            | InteractionCommand.CheckInteractions _ -> "CheckInteractions"
-            | InteractionCommand.GetDrugNames -> "GetDrugNames"
+            | PlanCommand.Recalculate _ -> "Recalculate"
+            | PlanCommand.Navigate(_, None, ctxCmd, _) -> $"Navigate {ctxCmd}"
+            | PlanCommand.Navigate(_, Some _, ctxCmd, _) -> $"Navigate context {ctxCmd}"
+            | PlanCommand.AddContext(_, category) -> $"AddContext {category}"
+            | PlanCommand.RemoveContext _ -> "RemoveContext"
 
 
     // on `IServerApi`:
     //
-    //     processInteraction: Request<InteractionCommand> -> Async<Result<Reply<InteractionResponse>, string[]>>
+    //     processOrderPlan: Request<PlanCommand> -> Async<Result<Reply<OrderPlan>, string[]>>
 
 
 // ---------------------------------------------------------------------------------------------
-// The member (→ ServerApi.InteractionCommand.fs)
+// The rules (→ Services.fs, module PlanService)
 // ---------------------------------------------------------------------------------------------
 
-module InteractionCommand =
+/// The target shape of `OrderPlan` (→ Types.fs: `NutritionContexts: NutritionContext[]`).
+type Plan654 =
+    {
+        Patient: Patient
+        Selected: OrderScenario option
+        Filtered: OrderScenario[]
+        Scenarios: OrderScenario[]
+        NutritionContexts: NutritionContext[]
+        Totals: Totals
+    }
 
-    open Api654
 
-    /// The drug names come from the interaction source, not the formulary; a check over a
-    /// plan's drugs needs the formulary loaded.
-    let gate =
-        function
-        | InteractionCommand.GetDrugNames -> Gate.Open
-        | InteractionCommand.CheckInteractions _ -> Gate.RequiresLoaded
+module PlanService =
+
+    /// The order a nutrition context contributes to the plan: its scenario, once the context
+    /// is narrowed to exactly one; nothing while it holds several candidates or none.
+    let contribution (nc: NutritionContext) = nc.OrderContext.Scenarios |> Array.tryExactlyOne
 
 
-    let processCmd (env: AppEnv) (cmd: InteractionCommand) =
-        match cmd with
-        | InteractionCommand.GetDrugNames ->
-            async {
-                let! result = env.interaction.getDrugNames ()
-                return result |> Result.map (List.toArray >> InteractionResponse.DrugNamesLoaded)
+    /// The plan's orders with one context's contribution replaced: the one it contributed
+    /// before goes out by order id, the one it contributes now comes in; the same order in
+    /// place, a different one at the end.
+    let withContribution (before: OrderScenario option) (after: OrderScenario option) (scenarios: OrderScenario[]) =
+        match before, after with
+        | Some old, Some sc when old.Order.Id = sc.Order.Id ->
+            scenarios |> Array.map (fun s -> if s.Order.Id = sc.Order.Id then sc else s)
+        | _ ->
+            let without =
+                match before with
+                | None -> scenarios
+                | Some old -> scenarios |> Array.filter (fun s -> s.Order.Id <> old.Order.Id)
+
+            match after with
+            | None -> without
+            | Some sc -> Array.append without [| sc |]
+
+
+    /// The resolved order context into the context named, filtered to the category's dose rule
+    /// set as before, and its contribution into the plan's orders.
+    let updateContext id (resolved: OrderContext) (plan: Plan654) =
+        match plan.NutritionContexts |> Array.tryFind (fun nc -> nc.Id = id) with
+        | None -> Error [| $"The plan holds no nutrition context %s{id}" |]
+        | Some nc ->
+            let drs = NutritionPlanService.getDoseRuleSet nc.Category
+            let updated = { nc with OrderContext = resolved |> NutritionPlanService.filterByDoseRuleSet drs }
+
+            { plan with
+                NutritionContexts = plan.NutritionContexts |> Array.map (fun c -> if c.Id = id then updated else c)
+                Scenarios = plan.Scenarios |> withContribution (contribution nc) (contribution updated)
             }
-        | InteractionCommand.CheckInteractions drugs ->
-            async {
-                let! result = env.interaction.checkInteractions drugs
-                return result |> Result.map (List.toArray >> InteractionResponse.InteractionsChecked)
-            }
+            |> Ok
 
 
-// and (→ ServerApi.Command.fs), once no open command is left in Command:
+    /// The context removed, and every supplement with a feeding; each takes its order with it.
+    let removeContext id (plan: Plan654) =
+        let removed = plan.NutritionContexts |> Array.tryFind (fun nc -> nc.Id = id)
+
+        let cascade =
+            removed
+            |> Option.map (fun nc -> nc.Category = NutritionCategory.EnteralFeeding)
+            |> Option.defaultValue false
+
+        let goes (nc: NutritionContext) =
+            nc.Id = id || (cascade && nc.Category = NutritionCategory.EnteralSupplement)
+
+        let gone, kept = plan.NutritionContexts |> Array.partition goes
+
+        { plan with
+            NutritionContexts = kept
+            Scenarios = gone |> Array.fold (fun scs nc -> scs |> withContribution (contribution nc) None) plan.Scenarios
+        }
+
+
+// and the totals (→ Services.fs): `OrderPlanService.calculateTotals totals plan`, once, over
+// `Scenarios` respecting `Filtered`; `calculateNutritionTotals` goes with the old family (8c).
 //
-//     /// Every command left here needs the formulary loaded. Applied by Compute.bound.
-//     let gate (_: Command) = Gate.RequiresLoaded
+// the port (→ Ports.fs):
 //
-// and in `compose` (→ CompositionRoot.fs):
+//     type PlanPort =
+//         {
+//             recalculate: OrderPlan -> Async<Result<OrderPlan, string[]>>
+//             navigate: OrderPlan -> string option -> OrderContextCommand -> OrderContext -> Async<Result<OrderPlan, string[]>>
+//             addContext: OrderPlan -> NutritionCategory -> Async<Result<OrderPlan, string[]>>
+//             removeContext: OrderPlan -> string -> Async<Result<OrderPlan, string[]>>
+//         }
 //
-//     processInteraction =
-//         Compute.bound env cookie InteractionCommand.toString InteractionCommand.gate (InteractionCommand.processCmd env)
+// `navigate plan None cmd ctx` is today's `OrderPlanService.updateOrderPlan plan (Some(cmd, ctx))`;
+// `navigate plan (Some id) cmd ctx` evaluates the context through the order-context port and
+// applies `updateContext`; `addContext` is today's `addNutritionContext` over the plan (the
+// discovered context appended, its contribution in); every answer ends in the totals.
 
 
 // ---------------------------------------------------------------------------------------------
@@ -109,90 +171,121 @@ module InteractionCommand =
 
 open Expecto
 open Expecto.Flip
-open Informedica.GenForm.Lib
-open Api654
 
 
-let cookieOf (id: string option) : SessionCookie =
+/// An OrderScenario with only its order id set, every other field a default, by reflection:
+/// the order graph is too deep to write by hand (as the server tests build theirs).
+let scenarioWithOrder (id: string) : OrderScenario =
+    let rec defaultOf (t: Type) : obj =
+        if t = typeof<string> then box ""
+        elif t = typeof<bool> then box false
+        elif t = typeof<int> then box 0
+        elif t = typeof<decimal> then box 0m
+        elif t = typeof<float> then box 0.0
+        elif t = typeof<DateTime> then box DateTime.MinValue
+        elif t.IsArray then box (Array.CreateInstance(t.GetElementType(), 0))
+        elif t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<option<_>> then null
+        elif t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<list<_>> then
+            t.GetProperty("Empty").GetValue null
+        elif Reflection.FSharpType.IsRecord t then
+            Reflection.FSharpType.GetRecordFields t
+            |> Array.map (fun f -> defaultOf f.PropertyType)
+            |> fun vs -> Reflection.FSharpValue.MakeRecord(t, vs)
+        elif Reflection.FSharpType.IsUnion t then
+            let case = Reflection.FSharpType.GetUnionCases t |> Array.head
+            Reflection.FSharpValue.MakeUnion(case, case.GetFields() |> Array.map (fun f -> defaultOf f.PropertyType))
+        else Activator.CreateInstance t
+
+    let sc = defaultOf typeof<OrderScenario> :?> OrderScenario
+    { sc with Order = { sc.Order with Id = id } }
+
+
+let context id category (scenarios: OrderScenario[]) =
+    NutritionContext.create id (string category) category true { OrderContext.empty with Scenarios = scenarios }
+
+
+let plan contexts scenarios : Plan654 =
     {
-        read = fun () -> id
-        write = ignore
-        delete = ignore
+        Patient = Patient.empty
+        Selected = None
+        Filtered = [||]
+        Scenarios = scenarios
+        NutritionContexts = contexts
+        Totals = Totals.empty
     }
 
 
-/// An env over a provider whose load failed, the interaction port stubbed and counted.
-let envWith (loaded: bool) =
-    let asked = ref 0
-
-    let env =
-        Adapters.makeAppEnv (
-            Resources.CachedResourceProvider(
-                (fun () -> Error [ Informedica.GenForm.Lib.Types.ErrorMsg("load failed", None) ]),
-                None
-            )
-        )
-
-    asked,
-    { env with
-        requireLoaded =
-            fun () ->
-                asked.Value <- asked.Value + 1
-                if loaded then None else env.requireLoaded ()
-        interaction =
-            {
-                checkInteractions = fun drugs -> async { return Ok [] }
-                getDrugNames = fun () -> async { return Ok [ "paracetamol"; "ibuprofen" ] }
-            }
-    }
-
-
-let processInteraction env cookie (request: Request<InteractionCommand>) =
-    Compute.bound env cookie InteractionCommand.toString InteractionCommand.gate (InteractionCommand.processCmd env) request
-    |> Async.RunSynchronously
+let ids (p: Plan654) = p.Scenarios |> Array.map _.Order.Id
 
 
 let tests =
     testList
-        "processInteraction"
+        "the one plan"
         [
-            test "the drug names are served while the formulary is not loaded, and the provider is not asked" {
-                let asked, env = envWith false
+            test "a context narrowed to one scenario has it in the plan's orders, once" {
+                let tpn = context "c-1" NutritionCategory.TPN [||]
+                let resolved = { OrderContext.empty with Scenarios = [| scenarioWithOrder "o-tpn" |] }
 
-                match processInteraction env (cookieOf None) { Opened = None; Command = InteractionCommand.GetDrugNames } with
-                | Ok reply ->
-                    reply.Response
-                    |> Expect.equal "the names" (InteractionResponse.DrugNamesLoaded [| "paracetamol"; "ibuprofen" |])
-                | Error errs -> failtest $"expected Ok, got {errs}"
+                match plan [| tpn |] [| scenarioWithOrder "o-drug" |] |> PlanService.updateContext "c-1" resolved with
+                | Ok p ->
+                    ids p |> Expect.equal "the drug and the tpn" [| "o-drug"; "o-tpn" |]
 
-                asked.Value |> Expect.equal "never asked: asking may load" 0
+                    // narrowed again to the same order: in place, not twice
+                    match p |> PlanService.updateContext "c-1" resolved with
+                    | Ok p -> ids p |> Expect.equal "once" [| "o-drug"; "o-tpn" |]
+                    | Error errs -> failtest $"{errs}"
+                | Error errs -> failtest $"{errs}"
             }
 
-            test "a check needs the formulary: refused while not loaded, computed when loaded" {
-                let asked, env = envWith false
+            test "a context re-narrowed to another order replaces its contribution" {
+                let tpn = context "c-1" NutritionCategory.TPN [| scenarioWithOrder "o-tpn" |]
+                let p = plan [| tpn |] [| scenarioWithOrder "o-drug"; scenarioWithOrder "o-tpn" |]
+                let other = { OrderContext.empty with Scenarios = [| scenarioWithOrder "o-tpn-2" |] }
 
-                processInteraction env (cookieOf None) { Opened = None; Command = InteractionCommand.CheckInteractions [ "a"; "b" ] }
-                |> Result.isError
-                |> Expect.isTrue "refused"
-
-                asked.Value |> Expect.equal "asked once" 1
-
-                let _, env = envWith true
-
-                match processInteraction env (cookieOf None) { Opened = None; Command = InteractionCommand.CheckInteractions [ "a"; "b" ] } with
-                | Ok reply -> reply.Response |> Expect.equal "checked" (InteractionResponse.InteractionsChecked [||])
-                | Error errs -> failtest $"expected Ok, got {errs}"
+                match p |> PlanService.updateContext "c-1" other with
+                | Ok p -> ids p |> Expect.equal "the other in place of the old" [| "o-drug"; "o-tpn-2" |]
+                | Error errs -> failtest $"{errs}"
             }
 
-            test "the gate per command" {
-                InteractionCommand.gate InteractionCommand.GetDrugNames |> Expect.equal "open" Gate.Open
-                InteractionCommand.gate (InteractionCommand.CheckInteractions []) |> Expect.equal "gated" Gate.RequiresLoaded
+            test "several candidates contribute nothing; widening again takes the order out" {
+                let tpn = context "c-1" NutritionCategory.TPN [| scenarioWithOrder "o-tpn" |]
+                let p = plan [| tpn |] [| scenarioWithOrder "o-drug"; scenarioWithOrder "o-tpn" |]
+                let widened = { OrderContext.empty with Scenarios = [| scenarioWithOrder "o-a"; scenarioWithOrder "o-b" |] }
+
+                match p |> PlanService.updateContext "c-1" widened with
+                | Ok p -> ids p |> Expect.equal "the drug only" [| "o-drug" |]
+                | Error errs -> failtest $"{errs}"
+
+                plan [||] [||] |> PlanService.updateContext "c-9" widened |> Result.isError |> Expect.isTrue "no such context"
             }
 
-            test "the log names the command, never the drugs" {
-                let line = InteractionCommand.toString (InteractionCommand.CheckInteractions [ "secret-drug" ])
-                line |> Expect.equal "name" "CheckInteractions"
-                InteractionCommand.toString InteractionCommand.GetDrugNames |> Expect.equal "name" "GetDrugNames"
+            test "a removed context takes its order; a feeding takes its supplements and theirs" {
+                let feeding = context "c-f" NutritionCategory.EnteralFeeding [| scenarioWithOrder "o-f" |]
+                let supplement = context "c-s" NutritionCategory.EnteralSupplement [| scenarioWithOrder "o-s" |]
+                let tpn = context "c-t" NutritionCategory.TPN [| scenarioWithOrder "o-t" |]
+
+                let p =
+                    plan
+                        [| feeding; supplement; tpn |]
+                        [| scenarioWithOrder "o-drug"; scenarioWithOrder "o-f"; scenarioWithOrder "o-s"; scenarioWithOrder "o-t" |]
+
+                let p = p |> PlanService.removeContext "c-f"
+                p.NutritionContexts |> Array.map _.Id |> Expect.equal "the tpn stays" [| "c-t" |]
+                ids p |> Expect.equal "the drug and the tpn order" [| "o-drug"; "o-t" |]
+
+                let p = p |> PlanService.removeContext "c-t"
+                p.NutritionContexts |> Expect.isEmpty "none left"
+                ids p |> Expect.equal "the drug only" [| "o-drug" |]
+            }
+
+            test "the log names the command, never the plan" {
+                let p = OrderPlan.create Patient.empty [||]
+
+                Api654.PlanCommand.toString (Api654.PlanCommand.Navigate(p, Some "c-1", UpdateOrderContext, OrderContext.empty))
+                |> Expect.equal "context" "Navigate context UpdateOrderContext"
+
+                Api654.PlanCommand.toString (Api654.PlanCommand.AddContext(p, NutritionCategory.TPN))
+                |> Expect.equal "category" "AddContext TPN"
             }
         ]
 

--- a/src/Informedica.GenPRES.Server/Scripts/Compute.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/Compute.fsx
@@ -110,6 +110,28 @@ module PlanService =
             | Some sc -> Array.append without [| sc |]
 
 
+    /// A derived view (the filter, the selection) follows a replaced order only where it held
+    /// the old one: replaced in place, or gone with it; never gains an order on its own.
+    let private follow (before: OrderScenario option) (after: OrderScenario option) (view: OrderScenario[]) =
+        match before with
+        | Some old when view |> Array.exists (fun s -> s.Order.Id = old.Order.Id) -> view |> withContribution before after
+        | _ -> view
+
+
+    /// The plan's orders with one contribution replaced, and the filter and the selection
+    /// following it, so that a replaced order keeps counting in the totals (which count by
+    /// order id) and a removed one is nowhere.
+    let withOrders (before: OrderScenario option) (after: OrderScenario option) (plan: Plan654) =
+        { plan with
+            Scenarios = plan.Scenarios |> withContribution before after
+            Filtered = plan.Filtered |> follow before after
+            Selected =
+                match plan.Selected, before with
+                | Some sel, Some old when sel.Order.Id = old.Order.Id -> after
+                | sel, _ -> sel
+        }
+
+
     /// The resolved order context into the context named, filtered to the category's dose rule
     /// set as before, and its contribution into the plan's orders.
     let updateContext id (resolved: OrderContext) (plan: Plan654) =
@@ -121,8 +143,8 @@ module PlanService =
 
             { plan with
                 NutritionContexts = plan.NutritionContexts |> Array.map (fun c -> if c.Id = id then updated else c)
-                Scenarios = plan.Scenarios |> withContribution (contribution nc) (contribution updated)
             }
+            |> withOrders (contribution nc) (contribution updated)
             |> Ok
 
 
@@ -140,10 +162,8 @@ module PlanService =
 
         let gone, kept = plan.NutritionContexts |> Array.partition goes
 
-        { plan with
-            NutritionContexts = kept
-            Scenarios = gone |> Array.fold (fun scs nc -> scs |> withContribution (contribution nc) None) plan.Scenarios
-        }
+        gone
+        |> Array.fold (fun p nc -> p |> withOrders (contribution nc) None) { plan with NutritionContexts = kept }
 
 
 // and the totals (→ Services.fs): `OrderPlanService.calculateTotals totals plan`, once, over
@@ -159,7 +179,8 @@ module PlanService =
 //             removeContext: OrderPlan -> string -> Async<Result<OrderPlan, string[]>>
 //         }
 //
-// `navigate plan None cmd ctx` is today's `OrderPlanService.updateOrderPlan plan (Some(cmd, ctx))`;
+// `navigate plan None cmd ctx` evaluates the context and folds the selected scenario in by
+// order id (an evaluation that fails is the answer, not the plan as it was);
 // `navigate plan (Some id) cmd ctx` evaluates the context through the order-context port and
 // applies `updateContext`; `addContext` is today's `addNutritionContext` over the plan (the
 // discovered context appended, its contribution in); every answer ends in the totals.

--- a/src/Informedica.GenPRES.Server/Scripts/load.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/load.fsx
@@ -26,6 +26,7 @@
 #load "../ServerApi.Compute.fs"
 #load "../ServerApi.FormularyCommand.fs"
 #load "../ServerApi.InteractionCommand.fs"
+#load "../ServerApi.PlanCommand.fs"
 #load "../ServerApi.AdminCommand.fs"
 #load "../ServerApi.Command.fs"
 #load "../ServerApi.LaunchCommand.fs"

--- a/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
@@ -138,6 +138,36 @@ module Adapters =
         }
 
 
+    let private makePlanPort agent (provider: Resources.IResourceProvider) (orderCtxPort: OrderContextPort) : PlanPort =
+        {
+            recalculate =
+                fun plan ->
+                    async {
+                        do! setComponentName "OrderPlan" agent
+                        return plan |> PlanService.recalculate (provider.GetTotals()) |> Ok
+                    }
+            navigate =
+                fun plan contextId ctxCmd ctx ->
+                    async {
+                        do! setComponentName "OrderPlan" agent
+                        let recalc = PlanService.recalculate (provider.GetTotals())
+                        return! PlanService.navigate recalc orderCtxPort plan contextId ctxCmd ctx
+                    }
+            addContext =
+                fun plan category ->
+                    PlanService.addContext (PlanService.recalculate (provider.GetTotals())) orderCtxPort plan category
+            removeContext =
+                fun plan id ->
+                    async {
+                        return
+                            plan
+                            |> PlanService.removeContext id
+                            |> PlanService.recalculate (provider.GetTotals())
+                            |> Ok
+                    }
+        }
+
+
     /// The session port of a server that does not launch: every Launch is refused as
     /// invalid and no session is ever found. Used in production until the scope switch (#580)
     /// decides what a production server exposes.
@@ -190,6 +220,7 @@ module Adapters =
             orderContext = orderCtxPort
             orderPlan = makeOrderPlanPort agent provider orderCtxPort
             nutritionPlan = makeNutritionPlanPort orderCtxPort logger provider
+            plan = makePlanPort agent provider orderCtxPort
             interaction =
                 {
                     checkInteractions =

--- a/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.CompositionRoot.fs
@@ -38,6 +38,15 @@ module CompositionRoot =
                     (fun _ -> Gate.RequiresLoaded)
                     (ParenteraliaCommand.processCmd env)
 
+            // the one plan, nutrition included
+            processOrderPlan =
+                Compute.bound
+                    env
+                    cookie
+                    PlanCommand.toString
+                    (fun _ -> Gate.RequiresLoaded)
+                    (PlanCommand.processCmd env)
+
             // the one member whose gate differs per command: the drug names run open
             processInteraction =
                 Compute.bound

--- a/src/Informedica.GenPRES.Server/ServerApi.PlanCommand.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.PlanCommand.fs
@@ -1,0 +1,15 @@
+namespace ServerApi
+
+
+/// The plan member: the one plan, nutrition included, over the plan port.
+module PlanCommand =
+
+    open Shared.Api
+
+
+    let processCmd (env: AppEnv) (cmd: PlanCommand) =
+        match cmd with
+        | PlanCommand.Recalculate plan -> env.plan.recalculate plan
+        | PlanCommand.Navigate(plan, contextId, ctxCmd, ctx) -> env.plan.navigate plan contextId ctxCmd ctx
+        | PlanCommand.AddContext(plan, category) -> env.plan.addContext plan category
+        | PlanCommand.RemoveContext(plan, id) -> env.plan.removeContext plan id

--- a/src/Informedica.GenPRES.Server/ServerApi.Ports.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Ports.fs
@@ -33,6 +33,18 @@ type NutritionPlanPort =
     }
 
 
+/// The one plan: every member answers the plan with its totals recomputed over its orders.
+type PlanPort =
+    {
+        recalculate: OrderPlan -> Async<Result<OrderPlan, string[]>>
+        // the command into the nutrition context named, or into the selected scenario when None
+        navigate:
+            OrderPlan -> string option -> OrderContextCommand -> OrderContext -> Async<Result<OrderPlan, string[]>>
+        addContext: OrderPlan -> NutritionCategory -> Async<Result<OrderPlan, string[]>>
+        removeContext: OrderPlan -> string -> Async<Result<OrderPlan, string[]>>
+    }
+
+
 type InteractionPort =
     {
         checkInteractions: string list -> Async<Result<DrugInteraction list, string[]>>
@@ -226,6 +238,7 @@ type AppEnv =
         orderContext: OrderContextPort
         orderPlan: OrderPlanPort
         nutritionPlan: NutritionPlanPort
+        plan: PlanPort
         interaction: InteractionPort
         admin: AdminPort
         requireLoaded: unit -> string[] option

--- a/src/Informedica.GenPRES.Server/ServerApi.Services.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Services.fs
@@ -489,11 +489,13 @@ module OrderPlanService =
                 let w = tp.Patient |> Models.Patient.getWeight |> Option.map int
                 let a = tp.Patient |> Models.Patient.getAgeInDays |> Option.map int
 
+                // by order id: a scenario replaced in Scenarios still counts under its filter
                 let scs =
                     if tp.Filtered |> Array.isEmpty then
                         tp.Scenarios
                     else
-                        tp.Scenarios |> Array.filter (fun sc -> tp.Filtered |> Array.exists ((=) sc))
+                        tp.Scenarios
+                        |> Array.filter (fun sc -> tp.Filtered |> Array.exists (fun f -> f.Order.Id = sc.Order.Id))
 
                 scs |> Array.map _.Order |> OrderService.getTotals totals a w
         }
@@ -874,6 +876,29 @@ module PlanService =
             | Some sc -> Array.append without [| sc |]
 
 
+    /// A derived view (the filter, the selection) follows a replaced order only where it held
+    /// the old one: replaced in place, or gone with it; never gains an order on its own.
+    let private follow (before: OrderScenario option) (after: OrderScenario option) (view: OrderScenario[]) =
+        match before with
+        | Some old when view |> Array.exists (fun s -> s.Order.Id = old.Order.Id) ->
+            view |> withContribution before after
+        | _ -> view
+
+
+    /// The plan's orders with one contribution replaced, and the filter and the selection
+    /// following it, so that a replaced order keeps counting in the totals and a removed one
+    /// is nowhere.
+    let withOrders (before: OrderScenario option) (after: OrderScenario option) (plan: OrderPlan) =
+        { plan with
+            Scenarios = plan.Scenarios |> withContribution before after
+            Filtered = plan.Filtered |> follow before after
+            Selected =
+                match plan.Selected, before with
+                | Some sel, Some old when sel.Order.Id = old.Order.Id -> after
+                | sel, _ -> sel
+        }
+
+
     /// The resolved order context into the context named, filtered to the category's dose rule
     /// set, and its contribution into the plan's orders.
     let updateContext id (resolved: OrderContext) (plan: OrderPlan) =
@@ -887,8 +912,8 @@ module PlanService =
 
             { plan with
                 NutritionContexts = plan.NutritionContexts |> Array.map (fun c -> if c.Id = id then updated else c)
-                Scenarios = plan.Scenarios |> withContribution (contribution nc) (contribution updated)
             }
+            |> withOrders (contribution nc) (contribution updated)
             |> Ok
 
 
@@ -906,12 +931,8 @@ module PlanService =
 
         let gone, kept = plan.NutritionContexts |> Array.partition goes
 
-        { plan with
-            NutritionContexts = kept
-            Scenarios =
-                gone
-                |> Array.fold (fun scs nc -> scs |> withContribution (contribution nc) None) plan.Scenarios
-        }
+        gone
+        |> Array.fold (fun p nc -> p |> withOrders (contribution nc) None) { plan with NutritionContexts = kept }
 
 
     let recalculate totals (plan: OrderPlan) =
@@ -931,9 +952,26 @@ module PlanService =
         =
         async {
             match contextId with
+            // the selected scenario re-evaluated: the plan's copy replaced by order id, the
+            // selection on the result; an evaluation that fails is the answer, not the plan as it was
             | None ->
-                let! updated = OrderPlanService.updateOrderPlan orderCtxPort plan (Some(ctxCmd, ctx))
-                return updated |> recalc |> Ok
+                let! result = orderCtxPort.evaluate ctxCmd ctx
+
+                return
+                    result
+                    |> Result.map (fun evaluated ->
+                        match evaluated.Scenarios |> Array.tryExactlyOne with
+                        | None -> { plan with Selected = None }
+                        | Some sc ->
+                            let before = plan.Scenarios |> Array.tryFind (fun s -> s.Order.Id = sc.Order.Id)
+
+                            { (match before with
+                               | Some _ -> plan |> withOrders before (Some sc)
+                               | None -> plan) with
+                                Selected = Some sc
+                            }
+                    )
+                    |> Result.map recalc
             | Some id ->
                 let! result = orderCtxPort.evaluate ctxCmd ctx
 
@@ -975,10 +1013,8 @@ module PlanService =
                     let id = System.Guid.NewGuid().ToString()
                     let nc = Models.NutritionContext.create id drs.Label category true resolved
 
-                    { plan with
-                        NutritionContexts = Array.append plan.NutritionContexts [| nc |]
-                        Scenarios = plan.Scenarios |> withContribution None (contribution nc)
-                    }
+                    { plan with NutritionContexts = Array.append plan.NutritionContexts [| nc |] }
+                    |> withOrders None (contribution nc)
                     |> recalc
                     |> Ok
                 | None ->

--- a/src/Informedica.GenPRES.Server/ServerApi.Services.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Services.fs
@@ -839,3 +839,151 @@ module NutritionPlanService =
         }
         |> calculateNutritionTotals totals
         |> Ok
+
+
+/// The one plan, nutrition included: the nutrition workbenches produce orders by category, and
+/// a context narrowed to exactly one scenario has that scenario among the plan's orders, so one
+/// signature covers it. Totals are computed once, over the orders.
+module PlanService =
+
+    open Shared
+    open Shared.Types
+
+
+    /// The order a nutrition context contributes to the plan: its scenario, once the context
+    /// is narrowed to exactly one; nothing while it holds several candidates or none.
+    let contribution (nc: NutritionContext) =
+        nc.OrderContext.Scenarios |> Array.tryExactlyOne
+
+
+    /// The plan's orders with one context's contribution replaced: the one it contributed
+    /// before goes out by order id, the one it contributes now comes in; the same order in
+    /// place, a different one at the end.
+    let withContribution (before: OrderScenario option) (after: OrderScenario option) (scenarios: OrderScenario[]) =
+        match before, after with
+        | Some old, Some sc when old.Order.Id = sc.Order.Id ->
+            scenarios |> Array.map (fun s -> if s.Order.Id = sc.Order.Id then sc else s)
+        | _ ->
+            let without =
+                match before with
+                | None -> scenarios
+                | Some old -> scenarios |> Array.filter (fun s -> s.Order.Id <> old.Order.Id)
+
+            match after with
+            | None -> without
+            | Some sc -> Array.append without [| sc |]
+
+
+    /// The resolved order context into the context named, filtered to the category's dose rule
+    /// set, and its contribution into the plan's orders.
+    let updateContext id (resolved: OrderContext) (plan: OrderPlan) =
+        match plan.NutritionContexts |> Array.tryFind (fun nc -> nc.Id = id) with
+        | None -> Error [| $"The plan holds no nutrition context %s{id}" |]
+        | Some nc ->
+            let drs = NutritionPlanService.getDoseRuleSet nc.Category
+
+            let updated =
+                { nc with OrderContext = resolved |> NutritionPlanService.filterByDoseRuleSet drs }
+
+            { plan with
+                NutritionContexts = plan.NutritionContexts |> Array.map (fun c -> if c.Id = id then updated else c)
+                Scenarios = plan.Scenarios |> withContribution (contribution nc) (contribution updated)
+            }
+            |> Ok
+
+
+    /// The context removed, and every supplement with a feeding; each takes its order with it.
+    let removeContext id (plan: OrderPlan) =
+        let removed = plan.NutritionContexts |> Array.tryFind (fun nc -> nc.Id = id)
+
+        let cascade =
+            removed
+            |> Option.map (fun nc -> nc.Category = NutritionCategory.EnteralFeeding)
+            |> Option.defaultValue false
+
+        let goes (nc: NutritionContext) =
+            nc.Id = id || (cascade && nc.Category = NutritionCategory.EnteralSupplement)
+
+        let gone, kept = plan.NutritionContexts |> Array.partition goes
+
+        { plan with
+            NutritionContexts = kept
+            Scenarios =
+                gone
+                |> Array.fold (fun scs nc -> scs |> withContribution (contribution nc) None) plan.Scenarios
+        }
+
+
+    let recalculate totals (plan: OrderPlan) =
+        plan |> OrderPlanService.calculateTotals totals
+
+
+    /// A command into the nutrition context named, or into the selected scenario when none is;
+    /// `recalc` ends the answer in its totals (the adapter's `recalculate` over the provider's
+    /// totals data).
+    let navigate
+        (recalc: OrderPlan -> OrderPlan)
+        (orderCtxPort: OrderContextPort)
+        (plan: OrderPlan)
+        (contextId: string option)
+        (ctxCmd: Api.OrderContextCommand)
+        (ctx: OrderContext)
+        =
+        async {
+            match contextId with
+            | None ->
+                let! updated = OrderPlanService.updateOrderPlan orderCtxPort plan (Some(ctxCmd, ctx))
+                return updated |> recalc |> Ok
+            | Some id ->
+                let! result = orderCtxPort.evaluate ctxCmd ctx
+
+                return
+                    result
+                    |> Result.bind (fun resolved -> plan |> updateContext id resolved)
+                    |> Result.map recalc
+        }
+
+
+    /// A nutrition context for the category, its filter discovered, appended to the plan with
+    /// whatever it contributes.
+    let addContext
+        (recalc: OrderPlan -> OrderPlan)
+        (orderCtxPort: OrderContextPort)
+        (plan: OrderPlan)
+        (category: NutritionCategory)
+        =
+        async {
+            let drs = NutritionPlanService.getDoseRuleSet category
+
+            let ctx =
+                Models.OrderContext.empty
+                |> Models.OrderContext.setPatient plan.Patient
+                |> fun c ->
+                    { c with
+                        Filter =
+                            { c.Filter with
+                                Indications = drs.Indications
+                                Generics = drs.Generics
+                            }
+                    }
+
+            let! discovered = NutritionPlanService.discoverFilterOptions orderCtxPort ctx
+
+            return
+                match discovered with
+                | Some resolved ->
+                    let id = System.Guid.NewGuid().ToString()
+                    let nc = Models.NutritionContext.create id drs.Label category true resolved
+
+                    { plan with
+                        NutritionContexts = Array.append plan.NutritionContexts [| nc |]
+                        Scenarios = plan.Scenarios |> withContribution None (contribution nc)
+                    }
+                    |> recalc
+                    |> Ok
+                | None ->
+                    Error
+                        [|
+                            "Could not discover filter options for nutrition context"
+                        |]
+        }

--- a/src/Informedica.GenPRES.Shared/Api.fs
+++ b/src/Informedica.GenPRES.Shared/Api.fs
@@ -276,6 +276,32 @@ module Api =
             | InteractionCommand.GetDrugNames -> "GetDrugNames"
 
 
+    /// The plan command family: the order plan, nutrition included.
+    [<RequireQualifiedAccess>]
+    type PlanCommand =
+        // the plan as it is, totals recomputed over its orders
+        | Recalculate of OrderPlan
+        // an order-context command evaluated and folded into the plan: into the nutrition
+        // context named, or into the selected scenario when None
+        | Navigate of OrderPlan * contextId: string option * OrderContextCommand * OrderContext
+        // a nutrition context for the category, its filter discovered
+        | AddContext of OrderPlan * NutritionCategory
+        // the nutrition context removed with its order; a feeding takes its supplements with it
+        | RemoveContext of OrderPlan * contextId: string
+
+
+    module PlanCommand =
+
+        /// For the log: never the plan.
+        let toString cmd =
+            match cmd with
+            | PlanCommand.Recalculate _ -> "Recalculate"
+            | PlanCommand.Navigate(_, None, ctxCmd, _) -> $"Navigate {ctxCmd}"
+            | PlanCommand.Navigate(_, Some _, ctxCmd, _) -> $"Navigate context {ctxCmd}"
+            | PlanCommand.AddContext(_, category) -> $"AddContext {category}"
+            | PlanCommand.RemoveContext _ -> "RemoveContext"
+
+
     /// Defines how routes are generated on server and mapped from the client
     let routerPaths typeName method = $"/api/%s{typeName}/%s{method}"
 
@@ -300,6 +326,8 @@ module Api =
             processFormulary: Request<Formulary> -> Async<Result<Reply<Formulary>, string[]>>
             processParenteralia: Request<Parenteralia> -> Async<Result<Reply<Parenteralia>, string[]>>
             processInteraction: Request<InteractionCommand> -> Async<Result<Reply<InteractionResponse>, string[]>>
+            // the one plan, nutrition included; the old plan families stay until the client moved
+            processOrderPlan: Request<PlanCommand> -> Async<Result<Reply<OrderPlan>, string[]>>
             processLaunch: LaunchCommand -> Async<LaunchOutcome>
             processSession: SessionCommand -> Async<SessionResponse>
             processSigning: SigningCommand -> Async<SigningResponse>

--- a/src/Informedica.GenPRES.Shared/Models.fs
+++ b/src/Informedica.GenPRES.Shared/Models.fs
@@ -2337,14 +2337,18 @@ module Models =
 
     module OrderPlan =
 
-        let create pat srs =
+        let create pat srs : OrderPlan =
             {
                 Patient = pat
                 Selected = None
                 Filtered = [||]
                 Scenarios = srs
+                NutritionContexts = [||]
                 Totals = Totals.empty
             }
+
+
+        let empty = create Patient.empty [||]
 
 
     module NutritionContext =

--- a/src/Informedica.GenPRES.Shared/Types.fs
+++ b/src/Informedica.GenPRES.Shared/Types.fs
@@ -494,18 +494,6 @@ module Types =
         }
 
 
-    type OrderPlan =
-        {
-            Patient: Patient
-            Selected: OrderScenario option
-            Filtered: OrderScenario[]
-            // NOTE: maybe use ordercontext to preserve full info
-            // so, OrderContexts: OrderContext []
-            Scenarios: OrderScenario[]
-            Totals: Totals
-        }
-
-
     [<RequireQualifiedAccess>]
     type NutritionCategory =
         | EnteralFeeding
@@ -515,6 +503,9 @@ module Types =
         | ElectrolyteGlucose
 
 
+    /// A nutrition workbench of the plan: one per category added, an order context narrowed
+    /// down to the product and dose; once it holds exactly one scenario, that scenario is an
+    /// order of the plan.
     type NutritionContext =
         {
             Id: string
@@ -522,6 +513,20 @@ module Types =
             Category: NutritionCategory
             Removable: bool
             OrderContext: OrderContext
+        }
+
+
+    /// The one plan: every order for the patient, nutrition included, which is what is signed.
+    type OrderPlan =
+        {
+            Patient: Patient
+            Selected: OrderScenario option
+            Filtered: OrderScenario[]
+            // every order in the plan, the nutrition orders included
+            Scenarios: OrderScenario[]
+            // the nutrition workbenches; a context narrowed to one scenario has it in Scenarios
+            NutritionContexts: NutritionContext[]
+            Totals: Totals
         }
 
 

--- a/tests/Informedica.GenPRES.Server.Tests/Scripts/load.fsx
+++ b/tests/Informedica.GenPRES.Server.Tests/Scripts/load.fsx
@@ -23,6 +23,7 @@
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.Compute.fs"
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.FormularyCommand.fs"
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.InteractionCommand.fs"
+#load "../../../src/Informedica.GenPRES.Server/ServerApi.PlanCommand.fs"
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.AdminCommand.fs"
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.Command.fs"
 #load "../../../src/Informedica.GenPRES.Server/ServerApi.LaunchCommand.fs"

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -5232,6 +5232,84 @@ module PlanTests =
                     ids p |> Expect.equal "the drug only" [| "o-drug" |]
                 }
 
+                test "a replaced contribution follows into the filter and the selection; a removed one leaves them" {
+                    let tpn = context "c-1" NutritionCategory.TPN [| scenarioWithOrder "o-tpn" |]
+
+                    let p =
+                        { plan [| tpn |] [| scenarioWithOrder "o-drug"; scenarioWithOrder "o-tpn" |] with
+                            Filtered = [| scenarioWithOrder "o-tpn" |]
+                            Selected = Some(scenarioWithOrder "o-tpn")
+                        }
+
+                    let other =
+                        { OrderContext.empty with Scenarios = [| scenarioWithOrder "o-tpn-2" |] }
+
+                    match p |> PlanService.updateContext "c-1" other with
+                    | Ok p ->
+                        p.Filtered
+                        |> Array.map _.Order.Id
+                        |> Expect.equal "the filter follows" [| "o-tpn-2" |]
+
+                        p.Selected
+                        |> Option.map _.Order.Id
+                        |> Expect.equal "the selection follows" (Some "o-tpn-2")
+
+                        let p = p |> PlanService.removeContext "c-1"
+                        p.Filtered |> Expect.isEmpty "gone from the filter"
+                        p.Selected |> Expect.isNone "gone from the selection"
+                    | Error errs -> failtest $"{errs}"
+
+                    // a view that did not hold the old order gains nothing
+                    let unfiltered =
+                        plan [| tpn |] [| scenarioWithOrder "o-drug"; scenarioWithOrder "o-tpn" |]
+
+                    match unfiltered |> PlanService.updateContext "c-1" other with
+                    | Ok p -> p.Filtered |> Expect.isEmpty "still unfiltered"
+                    | Error errs -> failtest $"{errs}"
+                }
+
+                testAsync "navigate without a context folds the selected scenario in, and keeps an evaluation's error" {
+                    let p =
+                        { plan
+                              [||]
+                              [|
+                                  scenarioWithOrder "o-drug"
+                                  scenarioWithOrder "o-other"
+                              |] with
+                            Filtered = [| scenarioWithOrder "o-drug" |]
+                        }
+
+                    let evaluated =
+                        { OrderContext.empty with
+                            Scenarios =
+                                [|
+                                    { scenarioWithOrder "o-drug" with Name = "re-evaluated" }
+                                |]
+                        }
+
+                    let port: OrderContextPort = { evaluate = fun _ _ -> async { return Ok evaluated } }
+
+                    match! PlanService.navigate id port p None Api.UpdateOrderContext OrderContext.empty with
+                    | Ok p ->
+                        p.Selected |> Option.map _.Name |> Expect.equal "selected" (Some "re-evaluated")
+
+                        p.Scenarios
+                        |> Array.map _.Name
+                        |> Expect.equal "replaced in place" [| "re-evaluated"; "" |]
+
+                        p.Filtered
+                        |> Array.map _.Name
+                        |> Expect.equal "the filter follows" [| "re-evaluated" |]
+                    | Error errs -> failtest $"{errs}"
+
+                    let failing: OrderContextPort =
+                        { evaluate = fun _ _ -> async { return Error [| "no dose rules" |] } }
+
+                    match! PlanService.navigate id failing p None Api.UpdateOrderContext OrderContext.empty with
+                    | Error errs -> errs |> Expect.equal "the error, not the plan as it was" [| "no dose rules" |]
+                    | Ok _ -> failtest "expected Error"
+                }
+
                 testAsync "navigate into a context evaluates it and folds the order in" {
                     let evaluated =
                         { OrderContext.empty with Scenarios = [| scenarioWithOrder "o-tpn" |] }

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -46,6 +46,15 @@ module StubAdapters =
         }
 
 
+    let planAlwaysOk (returnPlan: OrderPlan) : PlanPort =
+        {
+            recalculate = fun _ -> async { return Ok returnPlan }
+            navigate = fun _ _ _ _ -> async { return Ok returnPlan }
+            addContext = fun _ _ -> async { return Ok returnPlan }
+            removeContext = fun _ _ -> async { return Ok returnPlan }
+        }
+
+
     let nutritionPlanAlwaysOk (returnPlan: NutritionPlan) : NutritionPlanPort =
         {
             initNutritionPlan = fun _ -> async { return Ok returnPlan }
@@ -99,6 +108,7 @@ module StubAdapters =
             orderContext = orderContext
             orderPlan = orderPlan
             nutritionPlan = nutritionPlan
+            plan = planAlwaysOk (OrderPlan.create Models.Patient.empty [||])
             interaction =
                 {
                     checkInteractions = fun _ -> async { return Ok [] }
@@ -128,6 +138,13 @@ module StubAdapters =
                     selectNutritionOrderScenario = fun _ -> async { return Error [| "not loaded" |] }
                     navigateNutritionOrderContext = fun _ -> async { return Error [| "not loaded" |] }
                 }
+            plan =
+                {
+                    recalculate = fun _ -> async { return Error [| "not loaded" |] }
+                    navigate = fun _ _ _ _ -> async { return Error [| "not loaded" |] }
+                    addContext = fun _ _ -> async { return Error [| "not loaded" |] }
+                    removeContext = fun _ _ -> async { return Error [| "not loaded" |] }
+                }
             interaction =
                 {
                     checkInteractions = fun _ -> async { return Error [| "not loaded" |] }
@@ -143,16 +160,7 @@ open StubAdapters
 
 let emptyCtx = Models.OrderContext.empty
 
-// Copied to TotalsTests. One more copy/paste, and by the rule of three we should consider deduplication.
-// An OrderPlan.empty value seems reasonable.
-let emptyPlan: OrderPlan =
-    {
-        Patient = Models.Patient.empty
-        Scenarios = [||]
-        Selected = None
-        Filtered = [||]
-        Totals = Models.Totals.empty
-    }
+let emptyPlan = OrderPlan.empty
 
 let emptyNutritionPlan = Models.NutritionPlan.create Models.Patient.empty [||]
 
@@ -2751,6 +2759,31 @@ module SessionStubTests =
                         |> Expect.equal "issued" (SigningResponse.ChallengeIssued "n-1")
                     }
 
+                    test "a plan holding a nutrition context's order is challenged with that order" {
+                        let tpn =
+                            NutritionContext.create "c-1" "TPN" NutritionCategory.TPN true OrderContext.empty
+
+                        let resolved =
+                            { OrderContext.empty with Scenarios = [| scenarioWithOrder "o-tpn" |] }
+
+                        let plan =
+                            { OrderPlan.create stubPatient [| scenarioWithOrder "o-drug" |] with
+                                NutritionContexts = [| tpn |]
+                            }
+                            |> PlanService.updateContext "c-1" resolved
+                            |> Result.defaultWith (fun errs -> failtest $"{errs}")
+
+                        let state, answer =
+                            stateOf [ opened ] [] |> ask t0 (counter "n") <| "s-1" <| (plan, token "s-1")
+
+                        answer |> Expect.equal "issued" (SigningResponse.ChallengeIssued "n-1")
+
+                        state.Challenges
+                        |> Map.toList
+                        |> List.map (snd >> _.Scenarios >> Array.map _.Order.Id)
+                        |> Expect.equal "the drug and the tpn order under the challenge" [ [| "o-drug"; "o-tpn" |] ]
+                    }
+
                     test "refuses when the record moved on (Rule 20): whose version, and when" {
                         let byOther = signedBy other 1 (t0 - minutes 5.0)
 
@@ -5099,6 +5132,179 @@ module BoundTests =
             ]
 
 
+/// The one plan: the rules that put a nutrition context's order among the plan's orders, and
+/// the member over the port.
+module PlanTests =
+
+    open Shared.Api
+
+    let scenarioWithOrder = SessionStubTests.scenarioWithOrder
+
+    let context id category (scenarios: OrderScenario[]) =
+        NutritionContext.create id (string category) category true { OrderContext.empty with Scenarios = scenarios }
+
+    let plan contexts scenarios =
+        { OrderPlan.create Models.Patient.empty scenarios with NutritionContexts = contexts }
+
+    let ids (p: OrderPlan) = p.Scenarios |> Array.map _.Order.Id
+
+    let tests =
+        testList
+            "the one plan"
+            [
+                test "a context narrowed to one scenario has it in the plan's orders, once" {
+                    let tpn = context "c-1" NutritionCategory.TPN [||]
+
+                    let resolved =
+                        { OrderContext.empty with Scenarios = [| scenarioWithOrder "o-tpn" |] }
+
+                    match
+                        plan [| tpn |] [| scenarioWithOrder "o-drug" |]
+                        |> PlanService.updateContext "c-1" resolved
+                    with
+                    | Ok p ->
+                        ids p |> Expect.equal "the drug and the tpn" [| "o-drug"; "o-tpn" |]
+
+                        match p |> PlanService.updateContext "c-1" resolved with
+                        | Ok p -> ids p |> Expect.equal "once" [| "o-drug"; "o-tpn" |]
+                        | Error errs -> failtest $"{errs}"
+                    | Error errs -> failtest $"{errs}"
+                }
+
+                test "a context re-narrowed to another order replaces its contribution" {
+                    let tpn = context "c-1" NutritionCategory.TPN [| scenarioWithOrder "o-tpn" |]
+                    let p = plan [| tpn |] [| scenarioWithOrder "o-drug"; scenarioWithOrder "o-tpn" |]
+
+                    let other =
+                        { OrderContext.empty with Scenarios = [| scenarioWithOrder "o-tpn-2" |] }
+
+                    match p |> PlanService.updateContext "c-1" other with
+                    | Ok p -> ids p |> Expect.equal "the other in place of the old" [| "o-drug"; "o-tpn-2" |]
+                    | Error errs -> failtest $"{errs}"
+                }
+
+                test "several candidates contribute nothing; widening again takes the order out" {
+                    let tpn = context "c-1" NutritionCategory.TPN [| scenarioWithOrder "o-tpn" |]
+                    let p = plan [| tpn |] [| scenarioWithOrder "o-drug"; scenarioWithOrder "o-tpn" |]
+
+                    let widened =
+                        { OrderContext.empty with Scenarios = [| scenarioWithOrder "o-a"; scenarioWithOrder "o-b" |] }
+
+                    match p |> PlanService.updateContext "c-1" widened with
+                    | Ok p -> ids p |> Expect.equal "the drug only" [| "o-drug" |]
+                    | Error errs -> failtest $"{errs}"
+
+                    plan [||] [||]
+                    |> PlanService.updateContext "c-9" widened
+                    |> Result.isError
+                    |> Expect.isTrue "no such context"
+                }
+
+                test "a removed context takes its order; a feeding takes its supplements and theirs" {
+                    let feeding =
+                        context "c-f" NutritionCategory.EnteralFeeding [| scenarioWithOrder "o-f" |]
+
+                    let supplement =
+                        context "c-s" NutritionCategory.EnteralSupplement [| scenarioWithOrder "o-s" |]
+
+                    let tpn = context "c-t" NutritionCategory.TPN [| scenarioWithOrder "o-t" |]
+
+                    let p =
+                        plan
+                            [| feeding; supplement; tpn |]
+                            [|
+                                scenarioWithOrder "o-drug"
+                                scenarioWithOrder "o-f"
+                                scenarioWithOrder "o-s"
+                                scenarioWithOrder "o-t"
+                            |]
+
+                    let p = p |> PlanService.removeContext "c-f"
+
+                    p.NutritionContexts
+                    |> Array.map _.Id
+                    |> Expect.equal "the tpn stays" [| "c-t" |]
+
+                    ids p |> Expect.equal "the drug and the tpn order" [| "o-drug"; "o-t" |]
+
+                    let p = p |> PlanService.removeContext "c-t"
+                    p.NutritionContexts |> Expect.isEmpty "none left"
+                    ids p |> Expect.equal "the drug only" [| "o-drug" |]
+                }
+
+                testAsync "navigate into a context evaluates it and folds the order in" {
+                    let evaluated =
+                        { OrderContext.empty with Scenarios = [| scenarioWithOrder "o-tpn" |] }
+
+                    let port: OrderContextPort = { evaluate = fun _ _ -> async { return Ok evaluated } }
+
+                    let p =
+                        plan [| context "c-1" NutritionCategory.TPN [||] |] [| scenarioWithOrder "o-drug" |]
+
+                    // the totals are the adapter's; here the answer is left as folded
+                    match! PlanService.navigate id port p (Some "c-1") Api.UpdateOrderContext OrderContext.empty with
+                    | Ok p -> ids p |> Expect.equal "folded in" [| "o-drug"; "o-tpn" |]
+                    | Error errs -> failtest $"{errs}"
+
+                    match! PlanService.navigate id port p (Some "c-9") Api.UpdateOrderContext OrderContext.empty with
+                    | Error _ -> ()
+                    | Ok _ -> failtest "no such context"
+                }
+
+                testAsync "processOrderPlan dispatches each case to the plan port" {
+                    let answered = ref []
+
+                    let answering name p =
+                        async {
+                            answered.Value <- name :: answered.Value
+                            return Ok p
+                        }
+
+                    let port: PlanPort =
+                        {
+                            recalculate = answering "recalculate"
+                            navigate = fun p _ _ _ -> answering "navigate" p
+                            addContext = fun p _ -> answering "addContext" p
+                            removeContext = fun p _ -> answering "removeContext" p
+                        }
+
+                    let env =
+                        { makeEnv
+                              (formularyAlwaysOk Formulary.empty)
+                              (orderContextAlwaysOk emptyCtx)
+                              (orderPlanAlwaysOk emptyPlan)
+                              (nutritionPlanAlwaysOk emptyNutritionPlan) with
+                            plan = port
+                        }
+
+                    let p = OrderPlan.empty
+                    let! _ = PlanCommand.processCmd env (PlanCommand.Recalculate p)
+
+                    let! _ =
+                        PlanCommand.processCmd env (PlanCommand.Navigate(p, None, Api.UpdateOrderContext, emptyCtx))
+
+                    let! _ = PlanCommand.processCmd env (PlanCommand.AddContext(p, NutritionCategory.TPN))
+                    let! _ = PlanCommand.processCmd env (PlanCommand.RemoveContext(p, "c-1"))
+
+                    answered.Value
+                    |> List.rev
+                    |> Expect.equal "each to its port" [ "recalculate"; "navigate"; "addContext"; "removeContext" ]
+                }
+
+                test "the log names the command, never the plan" {
+                    let p = OrderPlan.empty
+
+                    PlanCommand.toString (
+                        PlanCommand.Navigate(p, Some "c-1", Api.UpdateOrderContext, OrderContext.empty)
+                    )
+                    |> Expect.equal "context" "Navigate context UpdateOrderContext"
+
+                    PlanCommand.toString (PlanCommand.AddContext(p, NutritionCategory.TPN))
+                    |> Expect.equal "category" "AddContext TPN"
+                }
+            ]
+
+
 [<Tests>]
 let tests =
     testList
@@ -5110,4 +5316,5 @@ let tests =
             SessionStubTests.tests
             AdminTests.tests
             BoundTests.tests
+            PlanTests.tests
         ]

--- a/tests/Informedica.GenPRES.Server.Tests/TotalsTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/TotalsTests.fs
@@ -34,16 +34,7 @@ type TotalsSpy() =
         member _.GetUnitMappings() = raise (NotImplementedException())
         member _.GetValidForms() = raise (NotImplementedException())
 
-// Copied from StubAdapterTests. One more copy/paste, and by the rule of three we should consider deduplication.
-// An OrderPlan.empty value seems reasonable.
-let emptyPlan: OrderPlan =
-    {
-        Patient = Models.Patient.empty
-        Scenarios = [||]
-        Selected = None
-        Filtered = [||]
-        Totals = Models.Totals.empty
-    }
+let emptyPlan = Models.OrderPlan.empty
 
 [<Tests>]
 let tests =


### PR DESCRIPTION
Step 8a of [plan 654](https://github.com/informedica/GenPRES/blob/master/docs/implementation-plans/654-api-per-use-case.md): the domain change. The nutrition plan is a subset of the order plan and only the order plan is signed, nutrition included. Additive: the old plan families stay served until the client moves (8b) and are deleted after (8c).

**The rule that makes one signature cover nutrition.** `OrderPlan` gains `NutritionContexts`, the workbenches that produce orders by category. A context narrowed to exactly one scenario has that scenario among the plan's orders, upserted by order id: the same order in place, a different one replacing the old, several candidates contributing nothing, a removed context taking its order with it and a feeding its supplements too. Totals are computed once, over the orders. Signing is untouched in shape: a challenge over such a plan carries the nutrition order.

**In this PR (script, per the script-only policy)**

- `Server/Scripts/Compute.fsx` (rewritten): `PlanCommand` with `toString`, the rules `contribution`, `withContribution`, `updateContext`, `removeContext` over the target shape, the port and adapter as comments. 5 tests: in once, replaced when re-narrowed, out when widened, the cascade, the log never naming the plan.

**Migration (for the maintainer, `.claude/docs/654-pr7a-migration.patch`, 12 files, +472/−33)**

`Shared/Types.fs`: `NutritionCategory` and `NutritionContext` declared before `OrderPlan`, which gains `NutritionContexts`; `Models.fs`: `OrderPlan.create` sets it empty, `OrderPlan.empty` added (the tests' two copies of `emptyPlan` go). `Shared/Api.fs`: `[<RequireQualifiedAccess>] PlanCommand` (`Recalculate | Navigate of plan * contextId option * OrderContextCommand * OrderContext | AddContext | RemoveContext`) with `toString`, `processOrderPlan: Request<PlanCommand> -> Async<Result<Reply<OrderPlan>, string[]>>`. `Ports.fs`: `PlanPort`, `AppEnv.plan`. `Services.fs`: `PlanService` (the rules; `navigate`, `addContext` over the order-context port with the recalculation as a seam; `recalculate` over `OrderPlanService.calculateTotals`). `Adapters.fs`: `makePlanPort`. New `ServerApi.PlanCommand.fs` (fsproj, both loaders); `compose` builds `processOrderPlan` through `bound`. Tests: 7 `PlanTests` (the rules, `navigate` folding an evaluated context in, the dispatch to the port, the log) and one challenge test proving a plan holding a nutrition context's order is challenged with that order. Verified in a worktree: build (client unchanged, compiles against the new field), 292 server tests (284 before), Fantomas, Fable, `CheckDependencyRule.fsx`.

Consequences, as the plan states them: nutrition totals will stop counting unnarrowed candidates once the client moves (8b); after a reopen the signed nutrition orders are in the plan and its totals but the workbenches are empty (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q228qLAaCzuK9Bhq2pEBGc