### PR TITLE
feat(client): the nutrition page on the one plan (#654 PR 7b)

### DIFF
--- a/src/Informedica.GenPRES.Client/App.fs
+++ b/src/Informedica.GenPRES.Client/App.fs
@@ -32,7 +32,6 @@ module private Elmish =
             Interactions: Deferred<DrugInteraction[]>
             InteractionDrugNames: Deferred<string[]>
             DrugNameRetries: int
-            NutritionPlan: Deferred<NutritionPlan>
             Formulary: Deferred<Formulary>
             Parenteralia: Deferred<Parenteralia>
             Localization: Deferred<string[][]>
@@ -97,11 +96,11 @@ module private Elmish =
         | OrderContextMsg of Api.OrderContextCommand * OrderContext
         | LoadOrderContextResult of Api.OrderContextCommand * ApiResponse<Api.Response>
 
-        | OrderPlanMsg of Api.OrderPlanCommand
-        | LoadOrderPlanResult of Api.OrderPlanCommand * ApiResponse<Api.Response>
-
-        | NutritionPlanMsg of Api.NutritionPlanCommand
-        | LoadNutritionPlanResult of Api.NutritionPlanCommand * ApiResponse<Api.Response>
+        // the one plan, nutrition included
+        | OrderPlanMsg of Api.PlanCommand
+        | LoadOrderPlanResult of Api.PlanCommand * ApiResponse<OrderPlan>
+        // the plan as shown: the order-plan page opens on it and its totals are recomputed
+        | ShowOrderPlan of OrderPlan
 
         | UpdateFormulary of Formulary
         | LoadFormulary of ApiResponse<Formulary>
@@ -230,19 +229,9 @@ module private Elmish =
     let processResponse (state: State) (response: Api.Response) =
         match response with
         | Api.OrderContextResp(Api.OrderContextResult ctx) -> { state with OrderContext = Resolved ctx }, Cmd.none
-        | Api.OrderPlanResp(Api.OrderPlanFiltered tp)
-        | Api.OrderPlanResp(Api.OrderPlanUpdated tp) ->
-            let drugs = tp.Scenarios |> Array.map _.Name |> Array.distinct |> Array.toList
-
-            let cmd =
-                if drugs.Length >= 2 then
-                    Cmd.ofMsg (CheckInteractions drugs)
-                else
-                    Cmd.none
-
-            { state with OrderPlan = Resolved tp }, cmd
-        | Api.NutritionPlanResp(Api.NutritionPlanInitialised plan)
-        | Api.NutritionPlanResp(Api.NutritionPlanUpdated plan) -> { state with NutritionPlan = Resolved plan }, Cmd.none
+        // the plan families answer processOrderPlan now; these cases go with them
+        | Api.OrderPlanResp _
+        | Api.NutritionPlanResp _ -> state, Cmd.none
 
 
     /// A reload settles when the refresh it started has answered: the order context over a
@@ -322,6 +311,19 @@ module private Elmish =
         { state with Parenteralia = Resolved par }, Cmd.none
 
 
+    /// The plan answered: shown, and its drugs checked for interactions when there are two.
+    let applyPlan (state: State) (tp: OrderPlan) =
+        let drugs = tp.Scenarios |> Array.map _.Name |> Array.distinct |> Array.toList
+
+        let cmd =
+            if drugs.Length >= 2 then
+                Cmd.ofMsg (CheckInteractions drugs)
+            else
+                Cmd.none
+
+        { state with OrderPlan = Resolved tp }, cmd
+
+
     let applyInteraction (state: State) (response: Api.InteractionResponse) =
         match response with
         | Api.InteractionResponse.InteractionsChecked interactions ->
@@ -348,7 +350,16 @@ module private Elmish =
 
 
     let loadOrderPlan opened resp =
-        Api.OrderPlanCmd >> createApiMsg serverApi.processCommand opened resp
+        createApiMsg serverApi.processOrderPlan opened resp
+
+
+    /// The command over the plan the state holds instead of the one it was made with.
+    let withPlan plan (cmd: Api.PlanCommand) =
+        match cmd with
+        | Api.PlanCommand.Recalculate _ -> Api.PlanCommand.Recalculate plan
+        | Api.PlanCommand.Navigate(_, contextId, ctxCmd, ctx) -> Api.PlanCommand.Navigate(plan, contextId, ctxCmd, ctx)
+        | Api.PlanCommand.AddContext(_, category) -> Api.PlanCommand.AddContext(plan, category)
+        | Api.PlanCommand.RemoveContext(_, id) -> Api.PlanCommand.RemoveContext(plan, id)
 
 
     let loadFormulary opened =
@@ -588,7 +599,6 @@ module private Elmish =
                 match pat with
                 | None -> HasNotStartedYet
                 | Some p -> OrderPlan.create p [||] |> Resolved
-            NutritionPlan = HasNotStartedYet
             Formulary = HasNotStartedYet
             Parenteralia = HasNotStartedYet
             Interactions = HasNotStartedYet
@@ -1141,7 +1151,8 @@ module private Elmish =
 
         | LoadCart head ->
             match state.Patient with
-            | Some pat -> state, Cmd.ofMsg (OrderPlanMsg(Api.FilterOrderPlan(OrderPlan.create pat head.Scenarios)))
+            | Some pat ->
+                state, Cmd.ofMsg (OrderPlanMsg(Api.PlanCommand.Recalculate(OrderPlan.create pat head.Scenarios)))
             | None -> state, Cmd.none
 
         | UpdatePatient pat ->
@@ -1168,7 +1179,6 @@ module private Elmish =
                         |> Deferred.map (fun tp -> { tp with Patient = p })
                         |> Deferred.defaultValue tp
                         |> Resolved
-                NutritionPlan = HasNotStartedYet
                 Formulary = { Formulary.empty with Patient = pat } |> Resolved
                 Parenteralia = Parenteralia.empty |> Resolved
                 EmergencyListFilter = [||]
@@ -1178,7 +1188,7 @@ module private Elmish =
                 [
                     Cmd.ofMsg (LoadOrderContextResult(Api.UpdateOrderContext, Started))
                     Cmd.ofMsg (
-                        LoadOrderPlanResult(Api.UpdateOrderPlan(OrderPlan.create Patient.empty [||], None), Started)
+                        LoadOrderPlanResult(Api.PlanCommand.Recalculate(OrderPlan.create Patient.empty [||]), Started)
                     )
                     Cmd.ofMsg (LoadFormulary Started)
                     Cmd.ofMsg (LoadParenteralia Started)
@@ -1477,55 +1487,56 @@ module private Elmish =
                 Cmd.none
 
 
-        | OrderPlanMsg tpCmd ->
-            match tpCmd with
-            | Api.UpdateOrderPlan(tp, Some(ctxCmd, ctx)) ->
+        // the plan as shown: the page opens on it; its totals are recomputed unless the only
+        // change is a scenario selected for the dialog
+        | ShowOrderPlan tp ->
+            let onlySetOrderContext =
+                state.OrderPlan
+                |> Deferred.map (fun st -> st.Selected.IsNone && tp.Selected.IsSome)
+                |> Deferred.defaultValue false
+
+            let tpState =
+                match state.OrderPlan with
+                | Recalculating _ -> Recalculating tp
+                | _ -> Resolved tp
+
+            let recalculate =
+                Cmd.ofMsg (LoadOrderPlanResult(Api.PlanCommand.Recalculate tp, Started))
+
+            // CheckInteractions is dispatched when the plan answers, so not here
+            let cmd =
+                if state.Page = OrderPlan then
+                    match state.OrderPlan with
+                    | Recalculating _ -> Cmd.none
+                    | _ -> if onlySetOrderContext then Cmd.none else recalculate
+                else
+                    Cmd.batch
+                        [
+                            Cmd.ofMsg (OrderContextMsg(Api.UpdateOrderContext, OrderContext.empty))
+                            recalculate
+                        ]
+
+            { state with
+                Page = OrderPlan
+                OrderPlan = tpState
+            },
+            cmd
+
+        | OrderPlanMsg cmd ->
+            match cmd with
+            | Api.PlanCommand.Recalculate tp ->
+                { state with OrderPlan = Resolved tp }, Cmd.ofMsg (LoadOrderPlanResult(cmd, Started))
+            // a change to the plan: one at a time, over the plan as it is
+            | Api.PlanCommand.Navigate(tp, _, _, _)
+            | Api.PlanCommand.AddContext(tp, _)
+            | Api.PlanCommand.RemoveContext(tp, _) ->
                 match state.OrderPlan with
                 | InProgress
                 | Recalculating _ -> state, Cmd.none
                 | _ ->
                     { state with OrderPlan = Recalculating tp },
-                    Api.OrderPlanCmd(Api.UpdateOrderPlan(tp, Some(ctxCmd, ctx)))
-                    |> createApiMsg
-                        serverApi.processCommand
-                        (tokenOf state.Session)
-                        (fun resp -> LoadOrderPlanResult(tpCmd, resp))
-            | Api.UpdateOrderPlan(tp, None) ->
-                let onlySetOrderContext =
-                    state.OrderPlan
-                    |> Deferred.map (fun st -> st.Selected.IsNone && tp.Selected.IsSome)
-                    |> Deferred.defaultValue false
-
-                let tpState =
-                    match state.OrderPlan with
-                    | Recalculating _ -> Recalculating tp
-                    | _ -> Resolved tp
-
-                // CheckInteractions is dispatched by processApiMsg when the API response
-                // arrives, so we don't duplicate it here.
-                let cmd =
-                    if state.Page = OrderPlan then
-                        match state.OrderPlan with
-                        | Recalculating _ -> Cmd.none
-                        | _ ->
-                            if onlySetOrderContext then
-                                Cmd.none
-                            else
-                                Cmd.ofMsg (LoadOrderPlanResult(tpCmd, Started))
-                    else
-                        Cmd.batch
-                            [
-                                Cmd.ofMsg (OrderContextMsg(Api.UpdateOrderContext, OrderContext.empty))
-                                Cmd.ofMsg (LoadOrderPlanResult(tpCmd, Started))
-                            ]
-
-                { state with
-                    Page = OrderPlan
-                    OrderPlan = tpState
-                },
-                cmd
-            | Api.FilterOrderPlan tp ->
-                { state with OrderPlan = Resolved tp }, Cmd.ofMsg (LoadOrderPlanResult(tpCmd, Started))
+                    cmd
+                    |> loadOrderPlan (tokenOf state.Session) (fun resp -> LoadOrderPlanResult(cmd, resp))
 
         | LoadOrderPlanResult(cmd, Started) ->
             match state.Patient with
@@ -1535,45 +1546,19 @@ module private Elmish =
                 | InProgress
                 | Recalculating _ -> state, Cmd.none
                 | HasNotStartedYet ->
-                    let apiCmd =
-                        match cmd with
-                        | Api.FilterOrderPlan _ -> Api.FilterOrderPlan(OrderPlan.create pat [||])
-                        | Api.UpdateOrderPlan(_, ctxOpt) -> Api.UpdateOrderPlan(OrderPlan.create pat [||], ctxOpt)
-
                     { state with OrderPlan = InProgress },
-                    apiCmd
+                    cmd
+                    |> withPlan (OrderPlan.create pat [||])
                     |> loadOrderPlan (tokenOf state.Session) (fun resp -> LoadOrderPlanResult(cmd, resp))
                 | Resolved tp ->
-                    let apiCmd =
-                        match cmd with
-                        | Api.FilterOrderPlan _ -> Api.FilterOrderPlan tp
-                        | Api.UpdateOrderPlan(_, ctxOpt) -> Api.UpdateOrderPlan(tp, ctxOpt)
-
                     { state with OrderPlan = InProgress },
-                    apiCmd
+                    cmd
+                    |> withPlan tp
                     |> loadOrderPlan (tokenOf state.Session) (fun resp -> LoadOrderPlanResult(cmd, resp))
 
-        | LoadOrderPlanResult(_, Finished(Ok msg)) -> msg |> processOk
+        | LoadOrderPlanResult(_, Finished(Ok msg)) -> processApiMsg state msg applyPlan
         | LoadOrderPlanResult(_, Finished(Error err)) ->
             ({ state with OrderPlan = HasNotStartedYet }, Cmd.none) |> processError err
-
-        | NutritionPlanMsg npCmd ->
-            let planState =
-                match state.NutritionPlan with
-                | Resolved plan -> Recalculating plan
-                | _ -> InProgress
-
-            { state with NutritionPlan = planState },
-            Api.NutritionPlanCmd npCmd
-            |> createApiMsg
-                serverApi.processCommand
-                (tokenOf state.Session)
-                (fun resp -> LoadNutritionPlanResult(npCmd, resp))
-
-        | LoadNutritionPlanResult(_, Started) -> state, Cmd.none
-        | LoadNutritionPlanResult(_, Finished(Ok msg)) -> msg |> processOk
-        | LoadNutritionPlanResult(_, Finished(Error err)) ->
-            ({ state with NutritionPlan = HasNotStartedYet }, Cmd.none) |> processError err
 
         | LoadFormulary Started ->
             match state.Formulary with
@@ -1743,11 +1728,8 @@ type private ConcreteAppEnv
 
     interface AppEnv.IOrderPlan with
         member _.OrderPlan = state.OrderPlan
-        member _.OrderPlanCommand cmd = OrderPlanMsg cmd |> dispatch
-
-    interface AppEnv.INutritionPlan with
-        member _.NutritionPlan = state.NutritionPlan
-        member _.NutritionPlanMsg cmd = NutritionPlanMsg cmd |> dispatch
+        member _.PlanCommand cmd = OrderPlanMsg cmd |> dispatch
+        member _.ShowOrderPlan tp = ShowOrderPlan tp |> dispatch
 
     interface AppEnv.IPatient with
         member _.Patient = state.Patient

--- a/src/Informedica.GenPRES.Client/App.fs
+++ b/src/Informedica.GenPRES.Client/App.fs
@@ -1554,15 +1554,19 @@ module private Elmish =
                 match state.OrderPlan with
                 | InProgress
                 | Recalculating _ -> state, Cmd.none
+                // the answer carries the command as sent, over the plan the state held, so
+                // that a refusal restores that plan and not the one the command was made with
                 | HasNotStartedYet ->
+                    let cmd = cmd |> withPlan (OrderPlan.create pat [||])
+
                     { state with OrderPlan = InProgress },
                     cmd
-                    |> withPlan (OrderPlan.create pat [||])
                     |> loadOrderPlan (tokenOf state.Session) (fun resp -> LoadOrderPlanResult(cmd, resp))
                 | Resolved tp ->
+                    let cmd = cmd |> withPlan tp
+
                     { state with OrderPlan = InProgress },
                     cmd
-                    |> withPlan tp
                     |> loadOrderPlan (tokenOf state.Session) (fun resp -> LoadOrderPlanResult(cmd, resp))
 
         | LoadOrderPlanResult(_, Finished(Ok msg)) -> processApiMsg state msg applyPlan

--- a/src/Informedica.GenPRES.Client/App.fs
+++ b/src/Informedica.GenPRES.Client/App.fs
@@ -353,6 +353,15 @@ module private Elmish =
         createApiMsg serverApi.processOrderPlan opened resp
 
 
+    /// The plan a command was made with.
+    let planOf (cmd: Api.PlanCommand) =
+        match cmd with
+        | Api.PlanCommand.Recalculate plan
+        | Api.PlanCommand.Navigate(plan, _, _, _)
+        | Api.PlanCommand.AddContext(plan, _)
+        | Api.PlanCommand.RemoveContext(plan, _) -> plan
+
+
     /// The command over the plan the state holds instead of the one it was made with.
     let withPlan plan (cmd: Api.PlanCommand) =
         match cmd with
@@ -1557,8 +1566,15 @@ module private Elmish =
                     |> loadOrderPlan (tokenOf state.Session) (fun resp -> LoadOrderPlanResult(cmd, resp))
 
         | LoadOrderPlanResult(_, Finished(Ok msg)) -> processApiMsg state msg applyPlan
-        | LoadOrderPlanResult(_, Finished(Error err)) ->
-            ({ state with OrderPlan = HasNotStartedYet }, Cmd.none) |> processError err
+        // a refused change leaves the plan as the request found it, so the pages keep their
+        // controls and the next action is the retry; without a patient there is no plan
+        | LoadOrderPlanResult(cmd, Finished(Error err)) ->
+            let plan =
+                match state.Patient with
+                | None -> HasNotStartedYet
+                | Some _ -> Resolved(planOf cmd)
+
+            ({ state with OrderPlan = plan }, Cmd.none) |> processError err
 
         | LoadFormulary Started ->
             match state.Formulary with

--- a/src/Informedica.GenPRES.Client/AppEnv.fs
+++ b/src/Informedica.GenPRES.Client/AppEnv.fs
@@ -21,18 +21,13 @@ type IOrderContext =
     abstract OrderContextMsg: Api.OrderContextCommand * OrderContext -> unit
 
 
-/// Order plan data and commands
+/// The one plan, nutrition included, and the commands on it
 [<Interface>]
 type IOrderPlan =
     abstract OrderPlan: Deferred<OrderPlan>
-    abstract OrderPlanCommand: Api.OrderPlanCommand -> unit
-
-
-/// Nutrition plan data and commands
-[<Interface>]
-type INutritionPlan =
-    abstract NutritionPlan: Deferred<NutritionPlan>
-    abstract NutritionPlanMsg: Api.NutritionPlanCommand -> unit
+    abstract PlanCommand: Api.PlanCommand -> unit
+    // the plan as shown: opens the order-plan page on it and recomputes its totals
+    abstract ShowOrderPlan: OrderPlan -> unit
 
 
 /// Patient data and updates

--- a/src/Informedica.GenPRES.Client/Pages/GenPres.fs
+++ b/src/Informedica.GenPRES.Client/Pages/GenPres.fs
@@ -129,7 +129,6 @@ module GenPres =
 
         let orderContext = (AppEnv.asEnv<AppEnv.IOrderContext> props.appEnv).OrderContext
         let orderPlan = (AppEnv.asEnv<AppEnv.IOrderPlan> props.appEnv).OrderPlan
-        let nutritionPlan = (AppEnv.asEnv<AppEnv.INutritionPlan> props.appEnv).NutritionPlan
         let auth = AppEnv.asEnv<AppEnv.IAuthentication> props.appEnv
 
         let updatePageRef = React.useRef props.updatePage
@@ -309,11 +308,8 @@ module GenPres =
                 | Resolved pr
                 | Recalculating pr -> Views.Totals.View {| intake = pr.Intake |} |> Some
                 | _ -> None
-            | Global.Pages.Nutrition ->
-                match nutritionPlan with
-                | Resolved np
-                | Recalculating np -> Views.Totals.View {| intake = np.Totals |} |> Some
-                | _ -> None
+            // the one plan: the nutrition page shows the plan's totals, nutrition included
+            | Global.Pages.Nutrition
             | Global.Pages.OrderPlan ->
                 match orderPlan with
                 | Resolved tp

--- a/src/Informedica.GenPRES.Client/Views/Nutrition.fs
+++ b/src/Informedica.GenPRES.Client/Views/Nutrition.fs
@@ -360,7 +360,7 @@ module Nutrition =
     let private ParenteralPrintView
         (props:
             {|
-                plan: NutritionPlan
+                plan: OrderPlan
                 onClose: unit -> unit
             |})
         =
@@ -607,8 +607,8 @@ module Nutrition =
         (props:
             {|
                 nutritionContext: NutritionContext
-                plan: NutritionPlan
-                nutritionPlanMsg: Api.NutritionPlanCommand -> unit
+                plan: OrderPlan
+                planCommand: Api.PlanCommand -> unit
                 localizationTerms: Deferred<string[][]>
                 onRemove: (unit -> unit) option
                 wrapInAccordion: bool
@@ -666,22 +666,22 @@ module Nutrition =
                 // In Nutrition, Generic is upstream of Indication.
                 // Clear Indication selection (but NOT the Indications list — server repopulates it).
                 { updCtx with OrderContext.Filter.Indication = None }
-            |> fun updCtx -> Api.NavigateNutritionOrderContext(planRef.current, ncId, Api.UpdateOrderContext, updCtx)
-            |> props.nutritionPlanMsg
+            |> fun updCtx -> Api.PlanCommand.Navigate(planRef.current, Some ncId, Api.UpdateOrderContext, updCtx)
+            |> props.planCommand
 
         let indicationChange s =
             ctx
             |> OrderContext.indicationChange s
-            |> fun updCtx -> Api.NavigateNutritionOrderContext(planRef.current, ncId, Api.UpdateOrderContext, updCtx)
-            |> props.nutritionPlanMsg
+            |> fun updCtx -> Api.PlanCommand.Navigate(planRef.current, Some ncId, Api.UpdateOrderContext, updCtx)
+            |> props.planCommand
 
         let doseTypeChange s =
             let dt = s |> Option.map DoseType.doseTypeFromString
 
             ctx
             |> OrderContext.doseTypeChange dt
-            |> fun updCtx -> Api.NavigateNutritionOrderContext(planRef.current, ncId, Api.UpdateOrderContext, updCtx)
-            |> props.nutritionPlanMsg
+            |> fun updCtx -> Api.PlanCommand.Navigate(planRef.current, Some ncId, Api.UpdateOrderContext, updCtx)
+            |> props.planCommand
 
         let updateOrderScenario (ol: OrderLoader) =
             { ctx with
@@ -699,12 +699,12 @@ module Nutrition =
                     )
             }
             |> fun updCtx ->
-                Api.NavigateNutritionOrderContext(planRef.current, ncId, Api.UpdateOrderScenario, updCtx)
-                |> props.nutritionPlanMsg
+                Api.PlanCommand.Navigate(planRef.current, Some ncId, Api.UpdateOrderScenario, updCtx)
+                |> props.planCommand
 
         let resetOrderScenario (_ol: OrderLoader) =
-            Api.NavigateNutritionOrderContext(planRef.current, ncId, Api.ResetOrderScenario, ctx)
-            |> props.nutritionPlanMsg
+            Api.PlanCommand.Navigate(planRef.current, Some ncId, Api.ResetOrderScenario, ctx)
+            |> props.planCommand
 
         let stepper =
             let create nav =
@@ -795,23 +795,23 @@ module Nutrition =
 
             let navRate cmd =
                 fun updCtx ->
-                    Api.NavigateNutritionOrderContext(planRef.current, ncId, cmd, updCtx)
-                    |> props.nutritionPlanMsg
+                    Api.PlanCommand.Navigate(planRef.current, Some ncId, cmd, updCtx)
+                    |> props.planCommand
 
             let navRateN cmd =
                 fun (updCtx, n, uc) ->
-                    Api.NavigateNutritionOrderContext(planRef.current, ncId, cmd (n, uc), updCtx)
-                    |> props.nutritionPlanMsg
+                    Api.PlanCommand.Navigate(planRef.current, Some ncId, cmd (n, uc), updCtx)
+                    |> props.planCommand
 
             let navCmpQty cmd =
                 fun (updCtx, cmp) ->
-                    Api.NavigateNutritionOrderContext(planRef.current, ncId, cmd cmp, updCtx)
-                    |> props.nutritionPlanMsg
+                    Api.PlanCommand.Navigate(planRef.current, Some ncId, cmd cmp, updCtx)
+                    |> props.planCommand
 
             let navCmpQtyN cmd =
                 fun (updCtx, cmp, n, uc) ->
-                    Api.NavigateNutritionOrderContext(planRef.current, ncId, cmd (cmp, n, uc), updCtx)
-                    |> props.nutritionPlanMsg
+                    Api.PlanCommand.Navigate(planRef.current, Some ncId, cmd (cmp, n, uc), updCtx)
+                    |> props.planCommand
 
             {|
                 // Dose Rate
@@ -1350,9 +1350,11 @@ module Nutrition =
     [<JSX.Component>]
     let View (props: {| appEnv: obj |}) =
         let patient = (AppEnv.asEnv<AppEnv.IPatient> props.appEnv).Patient
-        let envNutritionPlan = AppEnv.asEnv<AppEnv.INutritionPlan> props.appEnv
-        let nutritionPlan = envNutritionPlan.NutritionPlan
-        let nutritionPlanMsg = envNutritionPlan.NutritionPlanMsg
+        // the one plan: the nutrition workbenches live in the order plan, which is there
+        // with the patient
+        let envOrderPlan = AppEnv.asEnv<AppEnv.IOrderPlan> props.appEnv
+        let orderPlan = envOrderPlan.OrderPlan
+        let planCommand = envOrderPlan.PlanCommand
 
         let localizationTerms =
             (AppEnv.asEnv<AppEnv.ILocalization> props.appEnv).LocalizationTerms
@@ -1363,26 +1365,17 @@ module Nutrition =
 
         let isMobile = Mui.Hooks.useMediaQuery "(max-width:1200px)"
 
-        React.useEffect (
-            (fun () ->
-                match patient, nutritionPlan with
-                | Some pat, HasNotStartedYet -> nutritionPlanMsg (Api.InitNutritionPlan pat)
-                | _ -> ()
-            ),
-            [| box patient; box nutritionPlan |]
-        )
-
         let progress =
-            match nutritionPlan with
+            match orderPlan with
             | HasNotStartedYet when patient.IsNone ->
                 let msg =
                     Terms.``Patient enter patient data`` |> getTerm "Voer patient gegevens in ..."
 
                 JSX.jsx $"<>{msg}</>"
-            | _ -> ViewHelpers.progressOrEmpty nutritionPlan
+            | _ -> ViewHelpers.progressOrEmpty orderPlan
 
         let isRecalculating =
-            match nutritionPlan with
+            match orderPlan with
             | Recalculating _ -> true
             | _ -> false
 
@@ -1390,7 +1383,7 @@ module Nutrition =
         let enteralExpanded, setEnteralExpanded = React.useState true
         let printOpen, setPrintOpen = React.useState false
 
-        let makeSlot wrapInAccordion plan nc =
+        let makeSlot wrapInAccordion (plan: OrderPlan) nc =
             let onRemove =
                 if nc.Removable then
                     let hasSupplements =
@@ -1402,7 +1395,7 @@ module Nutrition =
                         if hasSupplements then
                             setConfirmDeleteTarget (Some nc.Id)
                         else
-                            Api.RemoveNutritionContext(plan, nc.Id) |> nutritionPlanMsg
+                            Api.PlanCommand.RemoveContext(plan, nc.Id) |> planCommand
                     )
                 else
                     None
@@ -1411,21 +1404,21 @@ module Nutrition =
                 {|
                     nutritionContext = nc
                     plan = plan
-                    nutritionPlanMsg = nutritionPlanMsg
+                    planCommand = planCommand
                     localizationTerms = localizationTerms
                     onRemove = onRemove
                     wrapInAccordion = wrapInAccordion
                     isRecalculating = isRecalculating
                 |}
 
-        let addContext plan category =
-            Api.AddNutritionContext(plan, category) |> nutritionPlanMsg
+        let addContext (plan: OrderPlan) category =
+            Api.PlanCommand.AddContext(plan, category) |> planCommand
 
-        let hasCategory plan cat =
+        let hasCategory (plan: OrderPlan) cat =
             plan.NutritionContexts |> Array.exists (fun nc -> nc.Category = cat)
 
         let content =
-            match nutritionPlan with
+            match orderPlan with
             | Resolved plan
             | Recalculating plan ->
                 let enteralContexts =
@@ -1571,9 +1564,9 @@ module Nutrition =
 
             let handleConfirm =
                 fun _ ->
-                    match confirmDeleteTarget, nutritionPlan with
+                    match confirmDeleteTarget, orderPlan with
                     | Some ncId, (Resolved plan | Recalculating plan) ->
-                        Api.RemoveNutritionContext(plan, ncId) |> nutritionPlanMsg
+                        Api.PlanCommand.RemoveContext(plan, ncId) |> planCommand
                     | _ -> ()
 
                     setConfirmDeleteTarget None
@@ -1605,7 +1598,7 @@ module Nutrition =
             """
 
         let printDialog =
-            match printOpen, nutritionPlan with
+            match printOpen, orderPlan with
             | true, (Resolved plan | Recalculating plan) ->
                 ParenteralPrintView
                     {|

--- a/src/Informedica.GenPRES.Client/Views/OrderPlan.fs
+++ b/src/Informedica.GenPRES.Client/Views/OrderPlan.fs
@@ -15,20 +15,20 @@ module OrderPlan =
     let View (props: {| appEnv: obj |}) =
         let envOrderPlan = AppEnv.asEnv<AppEnv.IOrderPlan> props.appEnv
         let orderPlan = envOrderPlan.OrderPlan
-        let orderPlanCommand = envOrderPlan.OrderPlanCommand
+        let planCommand = envOrderPlan.PlanCommand
         let session = AppEnv.asEnv<AppEnv.ISession> props.appEnv
         let signing = AppEnv.asEnv<AppEnv.ISigning> props.appEnv
 
-        let updateOrderPlan tp =
-            orderPlanCommand (Api.UpdateOrderPlan(tp, None))
+        let updateOrderPlan tp = envOrderPlan.ShowOrderPlan tp
 
         let filterOrderPlan tp =
-            orderPlanCommand (Api.FilterOrderPlan tp)
+            planCommand (Api.PlanCommand.Recalculate tp)
 
+        // an order-context command over the selected scenario
         let orderContextMsg (cmd, ctx) =
             match orderPlan with
             | Resolved tp
-            | Recalculating tp -> orderPlanCommand (Api.UpdateOrderPlan(tp, Some(cmd, ctx)))
+            | Recalculating tp -> planCommand (Api.PlanCommand.Navigate(tp, None, cmd, ctx))
             | _ -> ()
 
         let localizationTerms =

--- a/src/Informedica.GenPRES.Client/Views/Prescribe.fs
+++ b/src/Informedica.GenPRES.Client/Views/Prescribe.fs
@@ -27,10 +27,8 @@ module Prescribe =
         let orderContextMsg = envOrderContext.OrderContextMsg
         let envOrderPlan = AppEnv.asEnv<AppEnv.IOrderPlan> props.appEnv
         let orderPlan = envOrderPlan.OrderPlan
-        let orderPlanCommand = envOrderPlan.OrderPlanCommand
 
-        let updateOrderPlan tp =
-            orderPlanCommand (Api.UpdateOrderPlan(tp, None))
+        let updateOrderPlan tp = envOrderPlan.ShowOrderPlan tp
 
         let localizationTerms =
             (AppEnv.asEnv<AppEnv.ILocalization> props.appEnv).LocalizationTerms


### PR DESCRIPTION
Step 8b of [plan 654](https://github.com/informedica/GenPRES/blob/master/docs/implementation-plans/654-api-per-use-case.md). Client only, direct edits; no migration patch.

- `AppEnv.IOrderPlan` is the one plan: `PlanCommand` and `ShowOrderPlan`; `INutritionPlan` is gone.
- `App.fs`: `State.NutritionPlan` and its messages gone; `OrderPlanMsg of PlanCommand`, `LoadOrderPlanResult of PlanCommand * ApiResponse<OrderPlan>` on `processOrderPlan`; `ShowOrderPlan` is the client-side page navigation the old `UpdateOrderPlan(_, None)` carried on the wire; `applyPlan` keeps the interactions check; `withPlan` retargets a command onto the plan the state holds. The old plan responses are a no-op arm until 7c deletes them.
- `Views/OrderPlan.fs` and `Views/Prescribe.fs`: show the plan, recalculate, or navigate the selected scenario. `Views/Nutrition.fs`: reads the order plan, sends `Navigate(plan, Some contextId, …)`, `AddContext`, `RemoveContext`; the init effect is gone. `Pages/GenPres.fs`: the nutrition page shows the plan's totals.

Verified: Fable compile clean (no warnings), generated JSX inspected, Fantomas. Not clicked through in a browser: the nutrition page (add TPN and a feeding, narrow a context, see its order on the order-plan page and in the totals, remove the feeding) is the manual pass worth doing before merging.

Consequences the plan states: nutrition totals now count only narrowed contexts; after a reopen the signed nutrition orders are in the plan but the workbenches are empty (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q228qLAaCzuK9Bhq2pEBGc