### PR TITLE
refactor(api): delete the old plan families (#654 PR 7c)

### DIFF
--- a/docs/domain/core-domain.md
+++ b/docs/domain/core-domain.md
@@ -117,11 +117,14 @@ Across the **client/server API boundary**, the system uses a concrete transport 
 
 **API request/response wrapper**
 
-Requests are `Shared.Api.Command` values and responses are `Shared.Api.Response` values, both
-defined in `src/Informedica.GenPRES.Shared/Api.fs`. Order-context traffic travels as
-`OrderContextCmd of OrderContextCommand * OrderContext` and comes back as
-`OrderContextResp`. Alongside it the same channel carries the order-plan, nutrition-plan,
-interaction and log-analyzer command families.
+Every computing member of `IServerApi` (`src/Informedica.GenPRES.Shared/Api.fs`) takes a
+`Request<'cmd>` (the command and the OpenedToken the Session holds) and answers a
+`Reply<'resp>` (the answer and what the Session is told). Order-context traffic still travels
+as `OrderContextCmd of OrderContextCommand * OrderContext` under `processCommand` and comes
+back as `OrderContextResp`. The other use cases have their own members: `processOrderPlan`
+over `PlanCommand` for the one plan, nutrition included; `processFormulary` and
+`processParenteralia`; `processInteraction`; and `processAdmin`, token-authenticated and
+without the envelope.
 
 The individual cases are not restated here: `OrderContextCommand` alone has around thirty of
 them (selection, reset, and the increase/decrease/min/max/median stepping commands for

--- a/src/Informedica.GenPRES.Client/App.fs
+++ b/src/Informedica.GenPRES.Client/App.fs
@@ -229,9 +229,6 @@ module private Elmish =
     let processResponse (state: State) (response: Api.Response) =
         match response with
         | Api.OrderContextResp(Api.OrderContextResult ctx) -> { state with OrderContext = Resolved ctx }, Cmd.none
-        // the plan families answer processOrderPlan now; these cases go with them
-        | Api.OrderPlanResp _
-        | Api.NutritionPlanResp _ -> state, Cmd.none
 
 
     /// A reload settles when the refresh it started has answered: the order context over a

--- a/src/Informedica.GenPRES.Server/Scripts/Compute.fsx
+++ b/src/Informedica.GenPRES.Server/Scripts/Compute.fsx
@@ -1,189 +1,57 @@
-// The one plan (plan 654, step 8a): the nutrition plan is a subset of the order plan, and only
-// the order plan is signed, nutrition included. `OrderPlan` gains `NutritionContexts`, the
-// workbenches that produce orders by category, and one rule makes one signature cover them:
-// a context narrowed to exactly one scenario has that scenario in `plan.Scenarios`, upserted by
-// order id; a context with several candidates contributes nothing yet; a removed context takes
-// its order with it. Totals are computed once, over `Scenarios`. One command family,
-// `PlanCommand`, served by one member, `processOrderPlan`.
+// Deleting the old plan families (plan 654, step 8c): with the client on the one plan, the
+// `OrderPlanCmd` and `NutritionPlanCmd` families, the `NutritionPlan` type and the two ports and
+// services that served them leave the contract and the server. What stays of them is what the
+// one plan reuses: the nutrition dose-rule sets, the filter by rule set, the filter discovery,
+// and the totals, which move from `OrderPlanService` into `PlanService`.
 //
 // Script-first draft (script-only policy) of:
-//   - `OrderPlan.NutritionContexts` (with `NutritionCategory` and `NutritionContext` declared
-//     before it) → `Shared/Types.fs`; `OrderPlan.create` → `Shared/Models.fs`;
-//   - `PlanCommand` and `PlanCommand.toString`, `processOrderPlan` → `Shared/Api.fs`;
-//   - `PlanPort` and `AppEnv.plan` → `Ports.fs`; `PlanService` → `Services.fs`; `makePlanPort`
-//     → `Adapters.fs`; `PlanCommand.processCmd` → new `ServerApi.PlanCommand.fs`; the member in
-//     `compose` → `CompositionRoot.fs`.
+//   - `PlanService.recalculate` computing the totals itself (was `OrderPlanService.calculateTotals`)
+//     → `Services.fs`; `OrderPlanService` and the nutrition-plan functions deleted there;
+//   - the deletions are stated, not drafted (a script cannot remove cases or types):
+//     `OrderPlanCmd`, `NutritionPlanCmd`, `OrderPlanCommand`, `NutritionPlanCommand`,
+//     `OrderPlanResp`, `NutritionPlanResp`, `OrderPlanResponse`, `NutritionPlanResponse` and
+//     their `toString` arms → `Shared/Api.fs`; `NutritionPlan` → `Shared/Types.fs`, its module
+//     → `Shared/Models.fs`; `OrderPlanPort`, `NutritionPlanPort`, `AppEnv.orderPlan`,
+//     `AppEnv.nutritionPlan` → `Ports.fs`; their adapters → `Adapters.fs`; their arms →
+//     `Command.fs`, which then dispatches the order context alone; the client's no-op arm →
+//     `App.fs`; the test stubs, the totals tests onto the plan port.
 //
-// The shared `OrderPlan` has no `NutritionContexts` while this script runs, so the rules are
-// drafted over the pieces they read (the contexts, the orders) and the service over a local
-// record of the target shape. The old plan families stay served until the client moves (8b)
-// and are deleted after (8c). Run: `dotnet fsi Compute.fsx` from this directory (build first).
+// Run: `dotnet fsi Compute.fsx` from this directory (build first).
 
 #I __SOURCE_DIRECTORY__
 #r "nuget: Expecto, 10.2.3"
 
 #load "load.fsx"
 
-open System
 open Shared
 open Shared.Types
 open Shared.Models
-open Shared.Api
 open ServerApi
 
 
 // ---------------------------------------------------------------------------------------------
-// The wire (→ Shared/Api.fs)
+// The totals, the plan's own (→ Services.fs, module PlanService)
 // ---------------------------------------------------------------------------------------------
-
-module Api654 =
-
-    /// The plan command family: the order plan, nutrition included.
-    [<RequireQualifiedAccess>]
-    type PlanCommand =
-        // the plan as it is, totals recomputed over its orders
-        | Recalculate of OrderPlan
-        // an order-context command evaluated and folded into the plan: into the nutrition context
-        // named, or into the selected scenario when None
-        | Navigate of OrderPlan * contextId: string option * OrderContextCommand * OrderContext
-        // a nutrition context for the category, its filter discovered
-        | AddContext of OrderPlan * NutritionCategory
-        // the nutrition context removed with its order; a feeding takes its supplements with it
-        | RemoveContext of OrderPlan * contextId: string
-
-
-    module PlanCommand =
-
-        /// For the log: never the plan.
-        let toString cmd =
-            match cmd with
-            | PlanCommand.Recalculate _ -> "Recalculate"
-            | PlanCommand.Navigate(_, None, ctxCmd, _) -> $"Navigate {ctxCmd}"
-            | PlanCommand.Navigate(_, Some _, ctxCmd, _) -> $"Navigate context {ctxCmd}"
-            | PlanCommand.AddContext(_, category) -> $"AddContext {category}"
-            | PlanCommand.RemoveContext _ -> "RemoveContext"
-
-
-    // on `IServerApi`:
-    //
-    //     processOrderPlan: Request<PlanCommand> -> Async<Result<Reply<OrderPlan>, string[]>>
-
-
-// ---------------------------------------------------------------------------------------------
-// The rules (→ Services.fs, module PlanService)
-// ---------------------------------------------------------------------------------------------
-
-/// The target shape of `OrderPlan` (→ Types.fs: `NutritionContexts: NutritionContext[]`).
-type Plan654 =
-    {
-        Patient: Patient
-        Selected: OrderScenario option
-        Filtered: OrderScenario[]
-        Scenarios: OrderScenario[]
-        NutritionContexts: NutritionContext[]
-        Totals: Totals
-    }
-
 
 module PlanService =
 
-    /// The order a nutrition context contributes to the plan: its scenario, once the context
-    /// is narrowed to exactly one; nothing while it holds several candidates or none.
-    let contribution (nc: NutritionContext) = nc.OrderContext.Scenarios |> Array.tryExactlyOne
-
-
-    /// The plan's orders with one context's contribution replaced: the one it contributed
-    /// before goes out by order id, the one it contributes now comes in; the same order in
-    /// place, a different one at the end.
-    let withContribution (before: OrderScenario option) (after: OrderScenario option) (scenarios: OrderScenario[]) =
-        match before, after with
-        | Some old, Some sc when old.Order.Id = sc.Order.Id ->
-            scenarios |> Array.map (fun s -> if s.Order.Id = sc.Order.Id then sc else s)
-        | _ ->
-            let without =
-                match before with
-                | None -> scenarios
-                | Some old -> scenarios |> Array.filter (fun s -> s.Order.Id <> old.Order.Id)
-
-            match after with
-            | None -> without
-            | Some sc -> Array.append without [| sc |]
-
-
-    /// A derived view (the filter, the selection) follows a replaced order only where it held
-    /// the old one: replaced in place, or gone with it; never gains an order on its own.
-    let private follow (before: OrderScenario option) (after: OrderScenario option) (view: OrderScenario[]) =
-        match before with
-        | Some old when view |> Array.exists (fun s -> s.Order.Id = old.Order.Id) -> view |> withContribution before after
-        | _ -> view
-
-
-    /// The plan's orders with one contribution replaced, and the filter and the selection
-    /// following it, so that a replaced order keeps counting in the totals (which count by
-    /// order id) and a removed one is nowhere.
-    let withOrders (before: OrderScenario option) (after: OrderScenario option) (plan: Plan654) =
+    /// The plan with its totals recomputed over its orders: the filtered ones, by order id, when
+    /// a filter is set, else all of them.
+    let recalculate (totals: Informedica.GenForm.Lib.Types.Data.TotalsData[]) (plan: OrderPlan) =
         { plan with
-            Scenarios = plan.Scenarios |> withContribution before after
-            Filtered = plan.Filtered |> follow before after
-            Selected =
-                match plan.Selected, before with
-                | Some sel, Some old when sel.Order.Id = old.Order.Id -> after
-                | sel, _ -> sel
+            Totals =
+                let w = plan.Patient |> Patient.getWeight |> Option.map int
+                let a = plan.Patient |> Patient.getAgeInDays |> Option.map int
+
+                let scs =
+                    if plan.Filtered |> Array.isEmpty then
+                        plan.Scenarios
+                    else
+                        plan.Scenarios
+                        |> Array.filter (fun sc -> plan.Filtered |> Array.exists (fun f -> f.Order.Id = sc.Order.Id))
+
+                scs |> Array.map _.Order |> OrderService.getTotals totals a w
         }
-
-
-    /// The resolved order context into the context named, filtered to the category's dose rule
-    /// set as before, and its contribution into the plan's orders.
-    let updateContext id (resolved: OrderContext) (plan: Plan654) =
-        match plan.NutritionContexts |> Array.tryFind (fun nc -> nc.Id = id) with
-        | None -> Error [| $"The plan holds no nutrition context %s{id}" |]
-        | Some nc ->
-            let drs = NutritionPlanService.getDoseRuleSet nc.Category
-            let updated = { nc with OrderContext = resolved |> NutritionPlanService.filterByDoseRuleSet drs }
-
-            { plan with
-                NutritionContexts = plan.NutritionContexts |> Array.map (fun c -> if c.Id = id then updated else c)
-            }
-            |> withOrders (contribution nc) (contribution updated)
-            |> Ok
-
-
-    /// The context removed, and every supplement with a feeding; each takes its order with it.
-    let removeContext id (plan: Plan654) =
-        let removed = plan.NutritionContexts |> Array.tryFind (fun nc -> nc.Id = id)
-
-        let cascade =
-            removed
-            |> Option.map (fun nc -> nc.Category = NutritionCategory.EnteralFeeding)
-            |> Option.defaultValue false
-
-        let goes (nc: NutritionContext) =
-            nc.Id = id || (cascade && nc.Category = NutritionCategory.EnteralSupplement)
-
-        let gone, kept = plan.NutritionContexts |> Array.partition goes
-
-        gone
-        |> Array.fold (fun p nc -> p |> withOrders (contribution nc) None) { plan with NutritionContexts = kept }
-
-
-// and the totals (→ Services.fs): `OrderPlanService.calculateTotals totals plan`, once, over
-// `Scenarios` respecting `Filtered`; `calculateNutritionTotals` goes with the old family (8c).
-//
-// the port (→ Ports.fs):
-//
-//     type PlanPort =
-//         {
-//             recalculate: OrderPlan -> Async<Result<OrderPlan, string[]>>
-//             navigate: OrderPlan -> string option -> OrderContextCommand -> OrderContext -> Async<Result<OrderPlan, string[]>>
-//             addContext: OrderPlan -> NutritionCategory -> Async<Result<OrderPlan, string[]>>
-//             removeContext: OrderPlan -> string -> Async<Result<OrderPlan, string[]>>
-//         }
-//
-// `navigate plan None cmd ctx` evaluates the context and folds the selected scenario in by
-// order id (an evaluation that fails is the answer, not the plan as it was);
-// `navigate plan (Some id) cmd ctx` evaluates the context through the order-context port and
-// applies `updateContext`; `addContext` is today's `addNutritionContext` over the plan (the
-// discovered context appended, its contribution in); every answer ends in the totals.
 
 
 // ---------------------------------------------------------------------------------------------
@@ -194,119 +62,22 @@ open Expecto
 open Expecto.Flip
 
 
-/// An OrderScenario with only its order id set, every other field a default, by reflection:
-/// the order graph is too deep to write by hand (as the server tests build theirs).
-let scenarioWithOrder (id: string) : OrderScenario =
-    let rec defaultOf (t: Type) : obj =
-        if t = typeof<string> then box ""
-        elif t = typeof<bool> then box false
-        elif t = typeof<int> then box 0
-        elif t = typeof<decimal> then box 0m
-        elif t = typeof<float> then box 0.0
-        elif t = typeof<DateTime> then box DateTime.MinValue
-        elif t.IsArray then box (Array.CreateInstance(t.GetElementType(), 0))
-        elif t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<option<_>> then null
-        elif t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<list<_>> then
-            t.GetProperty("Empty").GetValue null
-        elif Reflection.FSharpType.IsRecord t then
-            Reflection.FSharpType.GetRecordFields t
-            |> Array.map (fun f -> defaultOf f.PropertyType)
-            |> fun vs -> Reflection.FSharpValue.MakeRecord(t, vs)
-        elif Reflection.FSharpType.IsUnion t then
-            let case = Reflection.FSharpType.GetUnionCases t |> Array.head
-            Reflection.FSharpValue.MakeUnion(case, case.GetFields() |> Array.map (fun f -> defaultOf f.PropertyType))
-        else Activator.CreateInstance t
-
-    let sc = defaultOf typeof<OrderScenario> :?> OrderScenario
-    { sc with Order = { sc.Order with Id = id } }
-
-
-let context id category (scenarios: OrderScenario[]) =
-    NutritionContext.create id (string category) category true { OrderContext.empty with Scenarios = scenarios }
-
-
-let plan contexts scenarios : Plan654 =
-    {
-        Patient = Patient.empty
-        Selected = None
-        Filtered = [||]
-        Scenarios = scenarios
-        NutritionContexts = contexts
-        Totals = Totals.empty
-    }
-
-
-let ids (p: Plan654) = p.Scenarios |> Array.map _.Order.Id
-
-
 let tests =
     testList
-        "the one plan"
+        "the totals, the plan's own"
         [
-            test "a context narrowed to one scenario has it in the plan's orders, once" {
-                let tpn = context "c-1" NutritionCategory.TPN [||]
-                let resolved = { OrderContext.empty with Scenarios = [| scenarioWithOrder "o-tpn" |] }
-
-                match plan [| tpn |] [| scenarioWithOrder "o-drug" |] |> PlanService.updateContext "c-1" resolved with
-                | Ok p ->
-                    ids p |> Expect.equal "the drug and the tpn" [| "o-drug"; "o-tpn" |]
-
-                    // narrowed again to the same order: in place, not twice
-                    match p |> PlanService.updateContext "c-1" resolved with
-                    | Ok p -> ids p |> Expect.equal "once" [| "o-drug"; "o-tpn" |]
-                    | Error errs -> failtest $"{errs}"
-                | Error errs -> failtest $"{errs}"
+            test "an empty plan's totals are the empty totals" {
+                OrderPlan.empty
+                |> PlanService.recalculate [||]
+                |> _.Totals
+                |> Expect.equal "empty" Totals.empty
             }
 
-            test "a context re-narrowed to another order replaces its contribution" {
-                let tpn = context "c-1" NutritionCategory.TPN [| scenarioWithOrder "o-tpn" |]
-                let p = plan [| tpn |] [| scenarioWithOrder "o-drug"; scenarioWithOrder "o-tpn" |]
-                let other = { OrderContext.empty with Scenarios = [| scenarioWithOrder "o-tpn-2" |] }
+            test "the same answer as the service it replaces" {
+                let plan = OrderPlan.create Patient.empty [||]
 
-                match p |> PlanService.updateContext "c-1" other with
-                | Ok p -> ids p |> Expect.equal "the other in place of the old" [| "o-drug"; "o-tpn-2" |]
-                | Error errs -> failtest $"{errs}"
-            }
-
-            test "several candidates contribute nothing; widening again takes the order out" {
-                let tpn = context "c-1" NutritionCategory.TPN [| scenarioWithOrder "o-tpn" |]
-                let p = plan [| tpn |] [| scenarioWithOrder "o-drug"; scenarioWithOrder "o-tpn" |]
-                let widened = { OrderContext.empty with Scenarios = [| scenarioWithOrder "o-a"; scenarioWithOrder "o-b" |] }
-
-                match p |> PlanService.updateContext "c-1" widened with
-                | Ok p -> ids p |> Expect.equal "the drug only" [| "o-drug" |]
-                | Error errs -> failtest $"{errs}"
-
-                plan [||] [||] |> PlanService.updateContext "c-9" widened |> Result.isError |> Expect.isTrue "no such context"
-            }
-
-            test "a removed context takes its order; a feeding takes its supplements and theirs" {
-                let feeding = context "c-f" NutritionCategory.EnteralFeeding [| scenarioWithOrder "o-f" |]
-                let supplement = context "c-s" NutritionCategory.EnteralSupplement [| scenarioWithOrder "o-s" |]
-                let tpn = context "c-t" NutritionCategory.TPN [| scenarioWithOrder "o-t" |]
-
-                let p =
-                    plan
-                        [| feeding; supplement; tpn |]
-                        [| scenarioWithOrder "o-drug"; scenarioWithOrder "o-f"; scenarioWithOrder "o-s"; scenarioWithOrder "o-t" |]
-
-                let p = p |> PlanService.removeContext "c-f"
-                p.NutritionContexts |> Array.map _.Id |> Expect.equal "the tpn stays" [| "c-t" |]
-                ids p |> Expect.equal "the drug and the tpn order" [| "o-drug"; "o-t" |]
-
-                let p = p |> PlanService.removeContext "c-t"
-                p.NutritionContexts |> Expect.isEmpty "none left"
-                ids p |> Expect.equal "the drug only" [| "o-drug" |]
-            }
-
-            test "the log names the command, never the plan" {
-                let p = OrderPlan.create Patient.empty [||]
-
-                Api654.PlanCommand.toString (Api654.PlanCommand.Navigate(p, Some "c-1", UpdateOrderContext, OrderContext.empty))
-                |> Expect.equal "context" "Navigate context UpdateOrderContext"
-
-                Api654.PlanCommand.toString (Api654.PlanCommand.AddContext(p, NutritionCategory.TPN))
-                |> Expect.equal "category" "AddContext TPN"
+                PlanService.recalculate [||] plan
+                |> Expect.equal "the same" (OrderPlanService.calculateTotals [||] plan)
             }
         ]
 

--- a/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Adapters.fs
@@ -69,75 +69,6 @@ module Adapters =
         }
 
 
-    let private makeOrderPlanPort
-        agent
-        (provider: Resources.IResourceProvider)
-        (orderCtxPort: OrderContextPort)
-        : OrderPlanPort
-        =
-        {
-            updateOrderPlan =
-                fun tp cmdOpt ->
-                    async {
-                        do! setComponentName "OrderPlan" agent
-
-                        let! updated = OrderPlanService.updateOrderPlan orderCtxPort tp cmdOpt
-                        let totals = provider.GetTotals()
-                        return updated |> OrderPlanService.calculateTotals totals |> Ok
-                    }
-
-            filterOrderPlan =
-                fun tp ->
-                    async {
-                        let totals = provider.GetTotals()
-                        return tp |> OrderPlanService.calculateTotals totals |> Ok
-                    }
-        }
-
-
-    let private makeNutritionPlanPort
-        (orderCtxPort: OrderContextPort)
-        logger
-        (provider: Resources.IResourceProvider)
-        : NutritionPlanPort
-        =
-        {
-            initNutritionPlan =
-                fun patient ->
-                    async {
-                        let totals = provider.GetTotals()
-                        return NutritionPlanService.initNutritionPlan logger totals patient
-                    }
-
-            addNutritionContext =
-                fun (plan, category) ->
-                    let totals = provider.GetTotals()
-                    NutritionPlanService.addNutritionContext totals orderCtxPort (plan, category)
-
-            removeNutritionContext =
-                fun (plan, id) ->
-                    async {
-                        let totals = provider.GetTotals()
-                        return NutritionPlanService.removeNutritionContext totals (plan, id)
-                    }
-
-            updateNutritionOrderContext =
-                fun (plan, label, ctx) ->
-                    let totals = provider.GetTotals()
-                    NutritionPlanService.updateNutritionOrderContext totals orderCtxPort (plan, label, ctx)
-
-            selectNutritionOrderScenario =
-                fun (plan, label, ctx) ->
-                    let totals = provider.GetTotals()
-                    NutritionPlanService.selectNutritionOrderScenario totals orderCtxPort (plan, label, ctx)
-
-            navigateNutritionOrderContext =
-                fun (plan, label, ctxCmd, ctx) ->
-                    let totals = provider.GetTotals()
-                    NutritionPlanService.navigateNutritionOrderContext totals orderCtxPort (plan, label, ctxCmd, ctx)
-        }
-
-
     let private makePlanPort agent (provider: Resources.IResourceProvider) (orderCtxPort: OrderContextPort) : PlanPort =
         {
             recalculate =
@@ -218,8 +149,6 @@ module Adapters =
         {
             formulary = makeFormularyPort provider
             orderContext = orderCtxPort
-            orderPlan = makeOrderPlanPort agent provider orderCtxPort
-            nutritionPlan = makeNutritionPlanPort orderCtxPort logger provider
             plan = makePlanPort agent provider orderCtxPort
             interaction =
                 {

--- a/src/Informedica.GenPRES.Server/ServerApi.Command.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Command.fs
@@ -10,52 +10,12 @@ module Command =
     let gate (_: Command) = Gate.RequiresLoaded
 
 
-    /// The dispatcher: each command to its port. Gating, logging and the Session notice are
-    /// Compute.bound's.
+    /// The dispatcher: the order context to its port. Gating, logging and the Session notice
+    /// are Compute.bound's.
     let processCmd (env: AppEnv) cmd =
         match cmd with
         | OrderContextCmd(ctxCmd, ctx) ->
             async {
                 let! result = env.orderContext.evaluate ctxCmd ctx
                 return result |> Result.map (OrderContextResult >> OrderContextResp)
-            }
-        | OrderPlanCmd(UpdateOrderPlan(tp, cmdOpt)) ->
-            async {
-                let! result = env.orderPlan.updateOrderPlan tp cmdOpt
-                return result |> Result.map (OrderPlanUpdated >> OrderPlanResp)
-            }
-        | OrderPlanCmd(FilterOrderPlan tp) ->
-            async {
-                let! result = env.orderPlan.filterOrderPlan tp
-                return result |> Result.map (OrderPlanFiltered >> OrderPlanResp)
-            }
-        | NutritionPlanCmd(InitNutritionPlan patient) ->
-            async {
-                let! result = env.nutritionPlan.initNutritionPlan patient
-                return result |> Result.map (NutritionPlanInitialised >> NutritionPlanResp)
-            }
-        | NutritionPlanCmd(UpdateNutritionOrderContext(plan, label, ctx)) ->
-            async {
-                let! result = env.nutritionPlan.updateNutritionOrderContext (plan, label, ctx)
-                return result |> Result.map (NutritionPlanUpdated >> NutritionPlanResp)
-            }
-        | NutritionPlanCmd(SelectNutritionOrderScenario(plan, label, ctx)) ->
-            async {
-                let! result = env.nutritionPlan.selectNutritionOrderScenario (plan, label, ctx)
-                return result |> Result.map (NutritionPlanUpdated >> NutritionPlanResp)
-            }
-        | NutritionPlanCmd(NavigateNutritionOrderContext(plan, label, ctxCmd, ctx)) ->
-            async {
-                let! result = env.nutritionPlan.navigateNutritionOrderContext (plan, label, ctxCmd, ctx)
-                return result |> Result.map (NutritionPlanUpdated >> NutritionPlanResp)
-            }
-        | NutritionPlanCmd(AddNutritionContext(plan, category)) ->
-            async {
-                let! result = env.nutritionPlan.addNutritionContext (plan, category)
-                return result |> Result.map (NutritionPlanUpdated >> NutritionPlanResp)
-            }
-        | NutritionPlanCmd(RemoveNutritionContext(plan, id)) ->
-            async {
-                let! result = env.nutritionPlan.removeNutritionContext (plan, id)
-                return result |> Result.map (NutritionPlanUpdated >> NutritionPlanResp)
             }

--- a/src/Informedica.GenPRES.Server/ServerApi.Ports.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Ports.fs
@@ -14,25 +14,6 @@ type FormularyPort =
 type OrderContextPort = { evaluate: OrderContextCommand -> OrderContext -> Async<Result<OrderContext, string[]>> }
 
 
-type OrderPlanPort =
-    {
-        updateOrderPlan: OrderPlan -> (OrderContextCommand * OrderContext) option -> Async<Result<OrderPlan, string[]>>
-        filterOrderPlan: OrderPlan -> Async<Result<OrderPlan, string[]>>
-    }
-
-
-type NutritionPlanPort =
-    {
-        initNutritionPlan: Patient -> Async<Result<NutritionPlan, string[]>>
-        addNutritionContext: NutritionPlan * NutritionCategory -> Async<Result<NutritionPlan, string[]>>
-        removeNutritionContext: NutritionPlan * string -> Async<Result<NutritionPlan, string[]>>
-        updateNutritionOrderContext: NutritionPlan * string * OrderContext -> Async<Result<NutritionPlan, string[]>>
-        selectNutritionOrderScenario: NutritionPlan * string * OrderContext -> Async<Result<NutritionPlan, string[]>>
-        navigateNutritionOrderContext:
-            NutritionPlan * string * OrderContextCommand * OrderContext -> Async<Result<NutritionPlan, string[]>>
-    }
-
-
 /// The one plan: every member answers the plan with its totals recomputed over its orders.
 type PlanPort =
     {
@@ -236,8 +217,6 @@ type AppEnv =
     {
         formulary: FormularyPort
         orderContext: OrderContextPort
-        orderPlan: OrderPlanPort
-        nutritionPlan: NutritionPlanPort
         plan: PlanPort
         interaction: InteractionPort
         admin: AdminPort

--- a/src/Informedica.GenPRES.Server/ServerApi.Services.fs
+++ b/src/Informedica.GenPRES.Server/ServerApi.Services.fs
@@ -443,64 +443,6 @@ DoseType : {filter.DoseType
             Error [| e.Message |]
 
 
-module OrderPlanService =
-
-    open Shared
-    open Shared.Types
-
-    module OrderLogger = Informedica.GenOrder.Lib.OrderLogging
-
-
-    let updateOrderPlan
-        (orderCtxPort: OrderContextPort)
-        (tp: OrderPlan)
-        (cmdOpt: (Api.OrderContextCommand * OrderContext) option)
-        =
-        match cmdOpt with
-        | None -> async { return tp }
-        | Some(cmd, ctx) ->
-            async {
-                let! result = orderCtxPort.evaluate cmd ctx
-
-                return
-                    result
-                    |> Result.map (fun newCtx ->
-                        let newOsc = newCtx.Scenarios |> Array.tryExactlyOne
-
-                        { tp with
-                            Selected = newOsc
-                            Scenarios =
-                                match newOsc with
-                                | None -> tp.Scenarios
-                                | Some newOsc ->
-                                    tp.Scenarios
-                                    |> Array.map (fun sc ->
-                                        if sc |> Models.OrderScenario.eqs newOsc then newOsc else sc
-                                    )
-                        }
-                    )
-                    |> Result.defaultValue tp
-            }
-
-
-    let calculateTotals (totals: Informedica.GenForm.Lib.Types.Data.TotalsData[]) (tp: OrderPlan) =
-        { tp with
-            Totals =
-                let w = tp.Patient |> Models.Patient.getWeight |> Option.map int
-                let a = tp.Patient |> Models.Patient.getAgeInDays |> Option.map int
-
-                // by order id: a scenario replaced in Scenarios still counts under its filter
-                let scs =
-                    if tp.Filtered |> Array.isEmpty then
-                        tp.Scenarios
-                    else
-                        tp.Scenarios
-                        |> Array.filter (fun sc -> tp.Filtered |> Array.exists (fun f -> f.Order.Id = sc.Order.Id))
-
-                scs |> Array.map _.Order |> OrderService.getTotals totals a w
-        }
-
-
 module NutritionPlanService =
 
     open Shared
@@ -647,18 +589,6 @@ module NutritionPlanService =
         | NutritionCategory.ElectrolyteGlucose -> electrolyteGlucoseDoseRuleSet
 
 
-    let calculateNutritionTotals (totals: Informedica.GenForm.Lib.Types.Data.TotalsData[]) (plan: NutritionPlan) =
-        { plan with
-            Totals =
-                let w = plan.Patient |> Models.Patient.getWeight |> Option.map int
-                let a = plan.Patient |> Models.Patient.getAgeInDays |> Option.map int
-
-                plan.NutritionContexts
-                |> Array.collect (fun nc -> nc.OrderContext.Scenarios |> Array.map _.Order)
-                |> OrderService.getTotals totals a w
-        }
-
-
     /// Discovers available filter options for a given OrderContext.
     /// Evaluates the context via the OrderContext port and intersects
     /// the resolved options with the configured values.
@@ -688,13 +618,6 @@ module NutritionPlanService =
         }
 
 
-    let initNutritionPlan _logger totals (patient: Patient) : Result<NutritionPlan, string[]> =
-        [||]
-        |> Models.NutritionPlan.create patient
-        |> calculateNutritionTotals totals
-        |> Ok
-
-
     /// Filters a resolved OrderContext's filter arrays against the configured
     /// dose rule set. If a configured array is non-empty, only matching values
     /// are kept; if empty, no restriction is applied.
@@ -717,130 +640,6 @@ module NutritionPlanService =
                     DoseTypes = resolved.Filter.DoseTypes
                 }
         }
-
-
-    let updateContext totals id resolved (plan: NutritionPlan) =
-        let updatedContexts =
-            plan.NutritionContexts
-            |> Array.map (fun nc ->
-                if nc.Id = id then
-                    let drs = getDoseRuleSet nc.Category
-                    { nc with OrderContext = resolved |> filterByDoseRuleSet drs }
-                else
-                    nc
-            )
-
-        { plan with NutritionContexts = updatedContexts }
-        |> calculateNutritionTotals totals
-
-
-    let updateNutritionOrderContext
-        totals
-        (orderCtxPort: OrderContextPort)
-        (plan: NutritionPlan, id: string, ctx: OrderContext)
-        : Async<Result<NutritionPlan, string[]>>
-        =
-        async {
-            let! result = orderCtxPort.evaluate Api.UpdateOrderContext ctx
-
-            return
-                match result with
-                | Ok resolved -> plan |> updateContext totals id resolved |> Ok
-                | Error errs -> Error errs
-        }
-
-
-    let navigateNutritionOrderContext
-        totals
-        (orderCtxPort: OrderContextPort)
-        (plan: NutritionPlan, id: string, ctxCmd: Api.OrderContextCommand, ctx: OrderContext)
-        : Async<Result<NutritionPlan, string[]>>
-        =
-        async {
-            let! result = orderCtxPort.evaluate ctxCmd ctx
-
-            return
-                match result with
-                | Ok resolved -> plan |> updateContext totals id resolved |> Ok
-                | Error errs -> Error errs
-        }
-
-
-    let selectNutritionOrderScenario
-        totals
-        (orderCtxPort: OrderContextPort)
-        (plan: NutritionPlan, id: string, ctx: OrderContext)
-        : Async<Result<NutritionPlan, string[]>>
-        =
-        async {
-            let! result = orderCtxPort.evaluate Api.SelectOrderScenario ctx
-
-            return
-                match result with
-                | Ok resolved -> plan |> updateContext totals id resolved |> Ok
-                | Error errs -> Error errs
-        }
-
-
-    let addNutritionContext
-        totals
-        (orderCtxPort: OrderContextPort)
-        (plan: NutritionPlan, category: NutritionCategory)
-        : Async<Result<NutritionPlan, string[]>>
-        =
-        async {
-            let drs = getDoseRuleSet category
-
-            let ctx =
-                Models.OrderContext.empty
-                |> Models.OrderContext.setPatient plan.Patient
-                |> fun c ->
-                    { c with
-                        Filter =
-                            { c.Filter with
-                                Indications = drs.Indications
-                                Generics = drs.Generics
-                            }
-                    }
-
-            let! filterResult = discoverFilterOptions orderCtxPort ctx
-
-            return
-                match filterResult with
-                | Some resolved ->
-                    let id = System.Guid.NewGuid().ToString()
-                    let nc = Models.NutritionContext.create id drs.Label category true resolved
-
-                    { plan with NutritionContexts = Array.append plan.NutritionContexts [| nc |] }
-                    |> calculateNutritionTotals totals
-                    |> Ok
-                | None ->
-                    Error
-                        [|
-                            "Could not discover filter options for nutrition context"
-                        |]
-        }
-
-
-    let removeNutritionContext totals (plan: NutritionPlan, id: string) : Result<NutritionPlan, string[]> =
-        let removedCtx = plan.NutritionContexts |> Array.tryFind (fun nc -> nc.Id = id)
-
-        let cascadeRemoveSupplements =
-            removedCtx
-            |> Option.map (fun nc -> nc.Category = NutritionCategory.EnteralFeeding)
-            |> Option.defaultValue false
-
-        { plan with
-            NutritionContexts =
-                plan.NutritionContexts
-                |> Array.filter (fun nc ->
-                    nc.Id <> id
-                    && (not cascadeRemoveSupplements
-                        || nc.Category <> NutritionCategory.EnteralSupplement)
-                )
-        }
-        |> calculateNutritionTotals totals
-        |> Ok
 
 
 /// The one plan, nutrition included: the nutrition workbenches produce orders by category, and
@@ -935,8 +734,24 @@ module PlanService =
         |> Array.fold (fun p nc -> p |> withOrders (contribution nc) None) { plan with NutritionContexts = kept }
 
 
-    let recalculate totals (plan: OrderPlan) =
-        plan |> OrderPlanService.calculateTotals totals
+    /// The plan with its totals recomputed over its orders: the filtered ones, by order id, when
+    /// a filter is set, else all of them.
+    let recalculate (totals: Informedica.GenForm.Lib.Types.Data.TotalsData[]) (plan: OrderPlan) =
+        { plan with
+            Totals =
+                let w = plan.Patient |> Models.Patient.getWeight |> Option.map int
+                let a = plan.Patient |> Models.Patient.getAgeInDays |> Option.map int
+
+                // by order id: a scenario replaced in Scenarios still counts under its filter
+                let scs =
+                    if plan.Filtered |> Array.isEmpty then
+                        plan.Scenarios
+                    else
+                        plan.Scenarios
+                        |> Array.filter (fun sc -> plan.Filtered |> Array.exists (fun f -> f.Order.Id = sc.Order.Id))
+
+                scs |> Array.map _.Order |> OrderService.getTotals totals a w
+        }
 
 
     /// A command into the nutrition context named, or into the selected scenario when none is;

--- a/src/Informedica.GenPRES.Shared/Api.fs
+++ b/src/Informedica.GenPRES.Shared/Api.fs
@@ -7,10 +7,7 @@ module Api =
     open Types
 
 
-    type Command =
-        | OrderContextCmd of OrderContextCommand * OrderContext
-        | OrderPlanCmd of OrderPlanCommand
-        | NutritionPlanCmd of NutritionPlanCommand
+    type Command = OrderContextCmd of OrderContextCommand * OrderContext
 
     and OrderContextCommand =
         | UpdateOrderContext
@@ -42,33 +39,9 @@ module Api =
         | SetMaxComponentOrderableQuantityProperty of cmp: string
         | SetMedianComponentOrderableQuantityProperty of cmp: string
 
-    and OrderPlanCommand =
-        | UpdateOrderPlan of OrderPlan * (OrderContextCommand * OrderContext) option
-        | FilterOrderPlan of OrderPlan
-
-    and NutritionPlanCommand =
-        | InitNutritionPlan of Patient
-        | UpdateNutritionOrderContext of NutritionPlan * string * OrderContext
-        | SelectNutritionOrderScenario of NutritionPlan * string * OrderContext
-        | NavigateNutritionOrderContext of NutritionPlan * string * OrderContextCommand * OrderContext
-        | AddNutritionContext of NutritionPlan * NutritionCategory
-        | RemoveNutritionContext of NutritionPlan * string
-
-    type Response =
-        | OrderContextResp of OrderContextResponse
-        | OrderPlanResp of OrderPlanResponse
-        | NutritionPlanResp of NutritionPlanResponse
+    type Response = OrderContextResp of OrderContextResponse
 
     and OrderContextResponse = OrderContextResult of OrderContext
-
-    and OrderPlanResponse =
-        | OrderPlanFiltered of OrderPlan
-        | OrderPlanUpdated of OrderPlan
-
-    and NutritionPlanResponse =
-        | NutritionPlanInitialised of NutritionPlan
-        | NutritionPlanUpdated of NutritionPlan
-
 
     /// Every computing request: the command and the OpenedToken the Session holds.
     /// `None` where there is none to send: no Session, an anonymous one, or a client acting
@@ -133,15 +106,6 @@ module Api =
                 $"SetMaxComponentQuantityProperty cmp={cmp}"
             | OrderContextCmd(SetMedianComponentOrderableQuantityProperty cmp, _) ->
                 $"SetMedianComponentQuantityProperty cmp={cmp}"
-
-            | OrderPlanCmd(UpdateOrderPlan _) -> "UpdatedOrderPlan"
-            | OrderPlanCmd(FilterOrderPlan _) -> "FilterOrderPlan"
-            | NutritionPlanCmd(InitNutritionPlan _) -> "InitNutritionPlan"
-            | NutritionPlanCmd(UpdateNutritionOrderContext _) -> "UpdateNutritionOrderContext"
-            | NutritionPlanCmd(SelectNutritionOrderScenario _) -> "SelectNutritionOrderScenario"
-            | NutritionPlanCmd(NavigateNutritionOrderContext _) -> "NavigateNutritionOrderContext"
-            | NutritionPlanCmd(AddNutritionContext _) -> "AddNutritionContext"
-            | NutritionPlanCmd(RemoveNutritionContext _) -> "RemoveNutritionContext"
 
 
     /// The launch command family. Cut from the session family at the authentication boundary:
@@ -326,7 +290,7 @@ module Api =
             processFormulary: Request<Formulary> -> Async<Result<Reply<Formulary>, string[]>>
             processParenteralia: Request<Parenteralia> -> Async<Result<Reply<Parenteralia>, string[]>>
             processInteraction: Request<InteractionCommand> -> Async<Result<Reply<InteractionResponse>, string[]>>
-            // the one plan, nutrition included; the old plan families stay until the client moved
+            // the one plan, nutrition included
             processOrderPlan: Request<PlanCommand> -> Async<Result<Reply<OrderPlan>, string[]>>
             processLaunch: LaunchCommand -> Async<LaunchOutcome>
             processSession: SessionCommand -> Async<SessionResponse>

--- a/src/Informedica.GenPRES.Shared/Models.fs
+++ b/src/Informedica.GenPRES.Shared/Models.fs
@@ -2363,23 +2363,6 @@ module Models =
             }
 
 
-    module NutritionPlan =
-
-        let empty: NutritionPlan =
-            {
-                Patient = Patient.empty
-                NutritionContexts = [||]
-                Totals = Totals.empty
-            }
-
-        let create patient contexts : NutritionPlan =
-            {
-                Patient = patient
-                NutritionContexts = contexts
-                Totals = Totals.empty
-            }
-
-
     module Formulary =
 
         let empty: Formulary =

--- a/src/Informedica.GenPRES.Shared/Types.fs
+++ b/src/Informedica.GenPRES.Shared/Types.fs
@@ -530,14 +530,6 @@ module Types =
         }
 
 
-    type NutritionPlan =
-        {
-            Patient: Patient
-            NutritionContexts: NutritionContext[]
-            Totals: Totals
-        }
-
-
     type Formulary =
         {
             Generics: string[]

--- a/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/StubAdapterTests.fs
@@ -39,30 +39,12 @@ module StubAdapters =
         { evaluate = fun _ _ -> async { return Error msgs } }
 
 
-    let orderPlanAlwaysOk (returnPlan: OrderPlan) : OrderPlanPort =
-        {
-            updateOrderPlan = fun _ _ -> async { return Ok returnPlan }
-            filterOrderPlan = fun _ -> async { return Ok returnPlan }
-        }
-
-
     let planAlwaysOk (returnPlan: OrderPlan) : PlanPort =
         {
             recalculate = fun _ -> async { return Ok returnPlan }
             navigate = fun _ _ _ _ -> async { return Ok returnPlan }
             addContext = fun _ _ -> async { return Ok returnPlan }
             removeContext = fun _ _ -> async { return Ok returnPlan }
-        }
-
-
-    let nutritionPlanAlwaysOk (returnPlan: NutritionPlan) : NutritionPlanPort =
-        {
-            initNutritionPlan = fun _ -> async { return Ok returnPlan }
-            addNutritionContext = fun _ -> async { return Ok returnPlan }
-            removeNutritionContext = fun _ -> async { return Ok returnPlan }
-            updateNutritionOrderContext = fun _ -> async { return Ok returnPlan }
-            selectNutritionOrderScenario = fun _ -> async { return Ok returnPlan }
-            navigateNutritionOrderContext = fun _ -> async { return Ok returnPlan }
         }
 
 
@@ -96,18 +78,10 @@ module StubAdapters =
         }
 
 
-    let makeEnv
-        (formulary: FormularyPort)
-        (orderContext: OrderContextPort)
-        (orderPlan: OrderPlanPort)
-        (nutritionPlan: NutritionPlanPort)
-        : AppEnv
-        =
+    let makeEnv (formulary: FormularyPort) (orderContext: OrderContextPort) : AppEnv =
         {
             formulary = formulary
             orderContext = orderContext
-            orderPlan = orderPlan
-            nutritionPlan = nutritionPlan
             plan = planAlwaysOk (OrderPlan.create Models.Patient.empty [||])
             interaction =
                 {
@@ -124,20 +98,6 @@ module StubAdapters =
         {
             formulary = formularyAlwaysFails [| "not loaded" |]
             orderContext = orderContextAlwaysFails [| "not loaded" |]
-            orderPlan =
-                {
-                    updateOrderPlan = fun _ _ -> async { return Error [| "not loaded" |] }
-                    filterOrderPlan = fun _ -> async { return Error [| "not loaded" |] }
-                }
-            nutritionPlan =
-                {
-                    initNutritionPlan = fun _ -> async { return Error [| "not loaded" |] }
-                    addNutritionContext = fun _ -> async { return Error [| "not loaded" |] }
-                    removeNutritionContext = fun _ -> async { return Error [| "not loaded" |] }
-                    updateNutritionOrderContext = fun _ -> async { return Error [| "not loaded" |] }
-                    selectNutritionOrderScenario = fun _ -> async { return Error [| "not loaded" |] }
-                    navigateNutritionOrderContext = fun _ -> async { return Error [| "not loaded" |] }
-                }
             plan =
                 {
                     recalculate = fun _ -> async { return Error [| "not loaded" |] }
@@ -162,8 +122,6 @@ let emptyCtx = Models.OrderContext.empty
 
 let emptyPlan = OrderPlan.empty
 
-let emptyNutritionPlan = Models.NutritionPlan.create Models.Patient.empty [||]
-
 
 let commandRoutingTests =
     testList
@@ -173,12 +131,7 @@ let commandRoutingTests =
             testAsync "processFormulary dispatches to formulary.getFormulary, typed" {
                 let returnForm = { Formulary.empty with Markdown = "stubbed" }
 
-                let env =
-                    makeEnv
-                        (formularyAlwaysOk returnForm)
-                        (orderContextAlwaysOk emptyCtx)
-                        (orderPlanAlwaysOk emptyPlan)
-                        (nutritionPlanAlwaysOk emptyNutritionPlan)
+                let env = makeEnv (formularyAlwaysOk returnForm) (orderContextAlwaysOk emptyCtx)
 
                 let! result = FormularyCommand.processCmd env Formulary.empty
 
@@ -189,11 +142,7 @@ let commandRoutingTests =
 
             testAsync "processParenteralia dispatches to formulary.getParenteralia, typed" {
                 let env =
-                    makeEnv
-                        (formularyAlwaysOk Formulary.empty)
-                        (orderContextAlwaysOk emptyCtx)
-                        (orderPlanAlwaysOk emptyPlan)
-                        (nutritionPlanAlwaysOk emptyNutritionPlan)
+                    makeEnv (formularyAlwaysOk Formulary.empty) (orderContextAlwaysOk emptyCtx)
 
                 let! result = ParenteraliaCommand.processCmd env Parenteralia.empty
 
@@ -204,47 +153,13 @@ let commandRoutingTests =
 
             testAsync "OrderContextCmd dispatches to orderContext.evaluate" {
                 let env =
-                    makeEnv
-                        (formularyAlwaysOk Formulary.empty)
-                        (orderContextAlwaysOk emptyCtx)
-                        (orderPlanAlwaysOk emptyPlan)
-                        (nutritionPlanAlwaysOk emptyNutritionPlan)
+                    makeEnv (formularyAlwaysOk Formulary.empty) (orderContextAlwaysOk emptyCtx)
 
                 let! result = Command.processCmd env (Api.OrderContextCmd(Api.UpdateOrderContext, emptyCtx))
 
                 match result with
                 | Ok(Api.OrderContextResp(Api.OrderContextResult _)) -> ()
                 | other -> failtest $"expected Ok OrderContextResp, got {other}"
-            }
-
-            testAsync "NutritionPlanCmd InitNutritionPlan dispatches to nutritionPlan port" {
-                let env =
-                    makeEnv
-                        (formularyAlwaysOk Formulary.empty)
-                        (orderContextAlwaysOk emptyCtx)
-                        (orderPlanAlwaysOk emptyPlan)
-                        (nutritionPlanAlwaysOk emptyNutritionPlan)
-
-                let! result = Command.processCmd env (Api.NutritionPlanCmd(Api.InitNutritionPlan Models.Patient.empty))
-
-                match result with
-                | Ok(Api.NutritionPlanResp(Api.NutritionPlanInitialised _)) -> ()
-                | other -> failtest $"expected Ok NutritionPlanInitialised, got {other}"
-            }
-
-            testAsync "OrderPlanCmd FilterOrderPlan dispatches to orderPlan port" {
-                let env =
-                    makeEnv
-                        (formularyAlwaysOk Formulary.empty)
-                        (orderContextAlwaysOk emptyCtx)
-                        (orderPlanAlwaysOk emptyPlan)
-                        (nutritionPlanAlwaysOk emptyNutritionPlan)
-
-                let! result = Command.processCmd env (Api.OrderPlanCmd(Api.FilterOrderPlan emptyPlan))
-
-                match result with
-                | Ok(Api.OrderPlanResp(Api.OrderPlanFiltered _)) -> ()
-                | other -> failtest $"expected Ok OrderPlanFiltered, got {other}"
             }
         ]
 
@@ -256,11 +171,7 @@ let errorPropagationTests =
 
             testAsync "processFormulary propagates port error" {
                 let env =
-                    makeEnv
-                        (formularyAlwaysFails [| "test error" |])
-                        (orderContextAlwaysOk emptyCtx)
-                        (orderPlanAlwaysOk emptyPlan)
-                        (nutritionPlanAlwaysOk emptyNutritionPlan)
+                    makeEnv (formularyAlwaysFails [| "test error" |]) (orderContextAlwaysOk emptyCtx)
 
                 let! result = FormularyCommand.processCmd env Formulary.empty
 
@@ -271,11 +182,7 @@ let errorPropagationTests =
 
             testAsync "OrderContextCmd propagates port error" {
                 let env =
-                    makeEnv
-                        (formularyAlwaysOk Formulary.empty)
-                        (orderContextAlwaysFails [| "ctx error" |])
-                        (orderPlanAlwaysOk emptyPlan)
-                        (nutritionPlanAlwaysOk emptyNutritionPlan)
+                    makeEnv (formularyAlwaysOk Formulary.empty) (orderContextAlwaysFails [| "ctx error" |])
 
                 let! result = Command.processCmd env (Api.OrderContextCmd(Api.UpdateOrderContext, emptyCtx))
 
@@ -324,11 +231,7 @@ let requireLoadedTests =
 
             testAsync "requireLoaded passes when loaded" {
                 let env =
-                    makeEnv
-                        (formularyAlwaysOk Formulary.empty)
-                        (orderContextAlwaysOk emptyCtx)
-                        (orderPlanAlwaysOk emptyPlan)
-                        (nutritionPlanAlwaysOk emptyNutritionPlan)
+                    makeEnv (formularyAlwaysOk Formulary.empty) (orderContextAlwaysOk emptyCtx)
 
                 let! result = bound env (Api.OrderContextCmd(Api.UpdateOrderContext, emptyCtx))
 
@@ -3472,13 +3375,7 @@ module SessionStubTests =
         directory,
         outbox,
 
-        { makeEnv
-              (formularyAlwaysOk Formulary.empty)
-              (orderContextAlwaysOk OrderContext.empty)
-              (orderPlanAlwaysOk (OrderPlan.create Patient.empty [||]))
-              (nutritionPlanAlwaysOk (NutritionPlan.create Patient.empty [||])) with
-            session = port
-        }
+        { makeEnv (formularyAlwaysOk Formulary.empty) (orderContextAlwaysOk OrderContext.empty) with session = port }
 
 
     let envWithStub () =
@@ -4750,13 +4647,7 @@ module AdminTests =
 
 
     let envWith admin =
-        { makeEnv
-              (formularyAlwaysOk Formulary.empty)
-              (orderContextAlwaysOk emptyCtx)
-              (orderPlanAlwaysOk emptyPlan)
-              (nutritionPlanAlwaysOk emptyNutritionPlan) with
-            admin = admin
-        }
+        { makeEnv (formularyAlwaysOk Formulary.empty) (orderContextAlwaysOk emptyCtx) with admin = admin }
 
 
     let run env cmd =
@@ -4952,11 +4843,7 @@ module BoundTests =
     /// A stub env: the formulary answers, the Session's answer given, loaded or not.
     let envWith (loaded: bool) (told: RecordNotice option) =
         let env =
-            makeEnv
-                (formularyAlwaysOk { Formulary.empty with Markdown = "stubbed" })
-                (orderContextAlwaysOk emptyCtx)
-                (orderPlanAlwaysOk emptyPlan)
-                (nutritionPlanAlwaysOk emptyNutritionPlan)
+            makeEnv (formularyAlwaysOk { Formulary.empty with Markdown = "stubbed" }) (orderContextAlwaysOk emptyCtx)
 
         { env with
             requireLoaded = (fun () -> if loaded then None else Some [| "not loaded" |])
@@ -5010,9 +4897,9 @@ module BoundTests =
                     | Ok reply ->
                         reply.Notice |> Expect.isNone "nothing told without a cookie"
 
+                        // the one case left in Response: the order context
                         match reply.Response with
                         | Api.OrderContextResp _ -> ()
-                        | other -> failtest $"expected OrderContextResp, got {other}"
                     | Error errs -> failtest $"expected Ok, got {errs}"
                 }
 
@@ -5024,9 +4911,9 @@ module BoundTests =
                         reply.Notice
                         |> Expect.equal "the ending" (Some(RecordNotice.Ended SessionEnding.SupersededByLaunch))
 
+                        // the one case left in Response: the order context
                         match reply.Response with
                         | Api.OrderContextResp _ -> ()
-                        | other -> failtest $"expected OrderContextResp, got {other}"
                     | Error errs -> failtest $"expected Ok, got {errs}"
                 }
 
@@ -5347,13 +5234,7 @@ module PlanTests =
                         }
 
                     let env =
-                        { makeEnv
-                              (formularyAlwaysOk Formulary.empty)
-                              (orderContextAlwaysOk emptyCtx)
-                              (orderPlanAlwaysOk emptyPlan)
-                              (nutritionPlanAlwaysOk emptyNutritionPlan) with
-                            plan = port
-                        }
+                        { makeEnv (formularyAlwaysOk Formulary.empty) (orderContextAlwaysOk emptyCtx) with plan = port }
 
                     let p = OrderPlan.empty
                     let! _ = PlanCommand.processCmd env (PlanCommand.Recalculate p)

--- a/tests/Informedica.GenPRES.Server.Tests/TotalsTests.fs
+++ b/tests/Informedica.GenPRES.Server.Tests/TotalsTests.fs
@@ -41,118 +41,52 @@ let tests =
     testList
         "Totals Tests"
         [
-            testAsync "updateOrderPlan doesn't cache totals" {
+            testAsync "recalculate doesn't cache totals" {
                 let spy = TotalsSpy()
                 let sut = ServerApi.Adapters.makeAppEnv spy
                 let countBefore = spy.CallCount
 
-                let! _ = sut.orderPlan.updateOrderPlan emptyPlan None
+                let! _ = sut.plan.recalculate emptyPlan
 
                 let countAfter = spy.CallCount
                 countBefore <! countAfter
             }
 
-            testAsync "filterOrderPlan doesn't cache totals" {
-                let spy = TotalsSpy()
-                let sut = ServerApi.Adapters.makeAppEnv spy
-                let countBefore = spy.CallCount
-
-                let! _ = sut.orderPlan.filterOrderPlan emptyPlan
-
-                let countAfter = spy.CallCount
-                countBefore <! countAfter
-            }
-
-            testAsync "initNutritionPlan doesn't cache totals" {
-                let spy = TotalsSpy()
-                let sut = ServerApi.Adapters.makeAppEnv spy
-                let countBefore = spy.CallCount
-
-                let! _ = sut.nutritionPlan.initNutritionPlan Models.Patient.empty
-
-                let countAfter = spy.CallCount
-                countBefore <! countAfter
-            }
-
-            testAsync "addNutritionContext doesn't cache totals" {
-                let spy = TotalsSpy()
-                let sut = ServerApi.Adapters.makeAppEnv spy
-                let countBefore = spy.CallCount
-
-                let dummyCategory = NutritionCategory.TPN
-                let! _ = sut.nutritionPlan.addNutritionContext (Models.NutritionPlan.empty, dummyCategory)
-
-                let countAfter = spy.CallCount
-                // The + 1 is a terrible hack to account for orderCtxPort unrelatedly also calling
-                // provider.GetTotals():
-                countBefore + 1 <! countAfter
-            }
-
-            testAsync "removeNutritionContext doesn't cache totals" {
-                let spy = TotalsSpy()
-                let sut = ServerApi.Adapters.makeAppEnv spy
-                let countBefore = spy.CallCount
-
-                let! _ = sut.nutritionPlan.removeNutritionContext (Models.NutritionPlan.empty, "dummy ID")
-
-                let countAfter = spy.CallCount
-                countBefore <! countAfter
-            }
-
-            testAsync "updateNutritionOrderContext doesn't cache totals" {
-                let spy = TotalsSpy()
-                let sut = ServerApi.Adapters.makeAppEnv spy
-                let countBefore = spy.CallCount
-
-                let! _ =
-                    sut.nutritionPlan.updateNutritionOrderContext (
-                        Models.NutritionPlan.empty,
-                        "dummy label",
-                        Models.OrderContext.empty
-                    )
-
-                let countAfter = spy.CallCount
-                // The + 1 is a terrible hack to account for orderCtxPort unrelatedly also calling
-                // provider.GetTotals():
-                countBefore + 1 <! countAfter
-            }
-
-            testAsync "selectNutritionOrderScenario doesn't cache totals" {
-                let spy = TotalsSpy()
-                let sut = ServerApi.Adapters.makeAppEnv spy
-                let countBefore = spy.CallCount
-
-                let! _ =
-                    sut.nutritionPlan.selectNutritionOrderScenario (
-                        Models.NutritionPlan.empty,
-                        "dummy label",
-                        Models.OrderContext.empty
-                    )
-
-                let countAfter = spy.CallCount
-                // The + 1 is a terrible hack to account for orderCtxPort unrelatedly also calling
-                // provider.GetTotals():
-                countBefore + 1 <! countAfter
-            }
-
-            testAsync "navigateNutritionOrderContext doesn't cache totals" {
+            testAsync "navigate doesn't cache totals" {
                 let spy = TotalsSpy()
                 let sut = ServerApi.Adapters.makeAppEnv spy
                 let countBefore = spy.CallCount
 
                 let dummyCmd = Shared.Api.OrderContextCommand.UpdateOrderContext
-
-                let! _ =
-                    sut.nutritionPlan.navigateNutritionOrderContext (
-                        Models.NutritionPlan.empty,
-                        "dummy label",
-                        dummyCmd,
-                        Models.OrderContext.empty
-                    )
+                let! _ = sut.plan.navigate emptyPlan None dummyCmd Models.OrderContext.empty
 
                 let countAfter = spy.CallCount
                 // The + 1 is a terrible hack to account for orderCtxPort unrelatedly also calling
                 // provider.GetTotals():
                 countBefore + 1 <! countAfter
+            }
+
+            testAsync "addContext doesn't cache totals" {
+                let spy = TotalsSpy()
+                let sut = ServerApi.Adapters.makeAppEnv spy
+                let countBefore = spy.CallCount
+
+                let! _ = sut.plan.addContext emptyPlan NutritionCategory.TPN
+
+                let countAfter = spy.CallCount
+                // The + 1 is a terrible hack to account for orderCtxPort unrelatedly also calling
+                // provider.GetTotals():
+                countBefore + 1 <! countAfter
+            }
+
+            testAsync "removeContext doesn't cache totals" {
+                let spy = TotalsSpy()
+                let sut = ServerApi.Adapters.makeAppEnv spy
+                let countBefore = spy.CallCount
+
+                let! _ = sut.plan.removeContext emptyPlan "dummy ID"
+
+                let countAfter = spy.CallCount
+                countBefore <! countAfter
             }
         ]


### PR DESCRIPTION
Step 8c of [plan 654](https://github.com/informedica/GenPRES/blob/master/docs/implementation-plans/654-api-per-use-case.md): with the client on the one plan (#663), the old plan families leave the contract and the server.

**In this PR (committed)**

- `Server/Scripts/Compute.fsx` (rewritten): the totals as the plan's own, `PlanService.recalculate` computing them (was `OrderPlanService.calculateTotals`), with the deletions stated. 2 tests.
- `docs/domain/core-domain.md`: the API-wrapper paragraph names the generic envelope and the members instead of the one `Command` DU.

**Migration (for the maintainer, `.claude/docs/654-pr7c-migration.patch`, 10 files, +44/−610)**

`Shared/Api.fs`: `OrderPlanCmd`, `NutritionPlanCmd`, `OrderPlanCommand`, `NutritionPlanCommand`, `OrderPlanResp`, `NutritionPlanResp`, `OrderPlanResponse`, `NutritionPlanResponse` and their `toString` arms gone; `Command` and `Response` hold the order context alone. `Shared/Types.fs` and `Models.fs`: the `NutritionPlan` type and module gone. `Ports.fs`: `OrderPlanPort`, `NutritionPlanPort`, `AppEnv.orderPlan`, `AppEnv.nutritionPlan` gone. `Services.fs`: `OrderPlanService` gone (its totals now `PlanService.recalculate`), the nutrition-plan functions gone; the dose-rule sets, the filter by rule set and the filter discovery stay for the one plan. `Adapters.fs`: the two old ports gone. `Command.fs`: dispatches the order context alone. `Client/App.fs`: the no-op arm for the old responses gone. Tests: the old stubs and the two routing tests gone, every `makeEnv` call two arguments shorter, the totals tests on the plan port. Verified in a worktree: build, 288 server tests, Fantomas, Fable, `CheckDependencyRule.fsx`.

After this, `processCommand` carries only `OrderContextCmd`; PR 8 moves it to `processOrderContext` and deletes `processCommand`, `Command`, `Response` and `ServerApi.Command.fs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q228qLAaCzuK9Bhq2pEBGc